### PR TITLE
feat(fallback-agent): discover agents from ~/.claude/agents/ in discover_agents()

### DIFF
--- a/plugins/fallback-agent/mcp-server-rs/src/agent_discovery.rs
+++ b/plugins/fallback-agent/mcp-server-rs/src/agent_discovery.rs
@@ -93,6 +93,7 @@ pub fn is_plugin_dir(dir: &Path) -> bool {
 /// Discover agent definitions by scanning:
 ///   1. CLAUDE_PLUGIN_ROOT/agents/*.md  (own plugin)
 ///   2. Sibling plugins — handles both flat and versioned cache layouts
+///   3. ~/.claude/agents/*.md — user agents, loaded with an empty namespace (no prefix)
 pub fn discover_agents() -> HashMap<String, AgentDefinition> {
     let mut agents: HashMap<String, AgentDefinition> = HashMap::new();
     let plugin_root = match std::env::var("CLAUDE_PLUGIN_ROOT") {
@@ -191,7 +192,19 @@ pub fn discover_agents() -> HashMap<String, AgentDefinition> {
     scan_for_siblings(&parent, &mut scan_targets, &mut visited);
     scan_for_siblings(&grandparent, &mut scan_targets, &mut visited);
 
-    // 3. Parse agent files from all discovered directories
+    // 3. User agents from ~/.claude/agents/
+    if let Ok(home) = std::env::var("HOME") {
+        let user_agents_dir = PathBuf::from(home).join(".claude").join("agents");
+        if user_agents_dir.is_dir() {
+            crate::log(&format!(
+                "Scanning user agents: {}",
+                user_agents_dir.display()
+            ));
+            scan_targets.push((user_agents_dir, String::new()));
+        }
+    }
+
+    // 4. Parse agent files from all discovered directories
     for (dir, namespace) in &scan_targets {
         let entries = match fs::read_dir(dir) {
             Ok(e) => e,
@@ -379,5 +392,58 @@ mod tests {
         // Edit and NotebookEdit should still be disallowed
         assert!(result.contains(&"Edit".to_string()));
         assert!(result.contains(&"NotebookEdit".to_string()));
+    }
+
+    #[test]
+    fn test_discover_user_agents_graceful_skip() {
+        // Set HOME to a nonexistent directory; discover_agents() must not panic or error.
+        // Also point CLAUDE_PLUGIN_ROOT to a nonexistent path to isolate this test.
+        let tmp = std::env::temp_dir().join("looper_test_graceful_skip_no_home");
+        std::env::set_var("HOME", tmp.to_str().unwrap());
+        std::env::set_var("CLAUDE_PLUGIN_ROOT", "/nonexistent_plugin_root_xyz");
+
+        // Should return an empty map without panicking.
+        let agents = discover_agents();
+
+        // No user agents should be loaded (the .claude/agents dir doesn't exist).
+        assert!(
+            agents.is_empty(),
+            "Expected no agents when ~/.claude/agents does not exist"
+        );
+    }
+
+    #[test]
+    fn test_discover_user_agents_loads_md() {
+        use std::fs;
+
+        // Build a temp dir tree: {tmp}/.claude/agents/my-agent.md
+        let tmp = std::env::temp_dir().join("looper_test_user_agents_loads_md");
+        let agents_dir = tmp.join(".claude").join("agents");
+        fs::create_dir_all(&agents_dir).expect("create agents dir");
+
+        let agent_content =
+            "---\nname: my-agent\ndescription: A user agent\nmodel: sonnet\n---\n\nDo the thing.";
+        fs::write(agents_dir.join("my-agent.md"), agent_content).expect("write agent file");
+
+        std::env::set_var("HOME", tmp.to_str().unwrap());
+        std::env::set_var("CLAUDE_PLUGIN_ROOT", "/nonexistent_plugin_root_xyz");
+
+        let agents = discover_agents();
+
+        // Clean up before assertions in case they panic.
+        let _ = fs::remove_dir_all(&tmp);
+
+        assert!(
+            agents.contains_key("my-agent"),
+            "Expected 'my-agent' to be discovered with an empty namespace; got: {:?}",
+            agents.keys().collect::<Vec<_>>()
+        );
+        let agent = &agents["my-agent"];
+        assert_eq!(agent.name, "my-agent");
+        // Empty namespace means qualified_name == name (no colon prefix).
+        assert_eq!(
+            agent.qualified_name, "my-agent",
+            "qualified_name should equal name when namespace is empty"
+        );
     }
 }

--- a/plugins/fallback-agent/mcp-server-rs/src/tool_definitions.rs
+++ b/plugins/fallback-agent/mcp-server-rs/src/tool_definitions.rs
@@ -156,7 +156,10 @@ pub fn build_list_tools_result(agents: &HashMap<String, AgentDefinition>) -> Lis
     ListToolsResult {
         meta: None,
         next_cursor: None,
-        tools: vec![build_agent_fallback_tool(agents), build_agent_fallback_status_tool()],
+        tools: vec![
+            build_agent_fallback_tool(agents),
+            build_agent_fallback_status_tool(),
+        ],
     }
 }
 


### PR DESCRIPTION
## Problem / Task

The `discover_agents()` function in the fallback-agent MCP server only scanned agent `.md` files within plugin directories (own plugin + sibling plugins). It did not pick up agents defined in `~/.claude/agents/`, which is the conventional location for personal/global agents in Claude Code.

**Current behavior:** User agents in `~/.claude/agents/` are silently ignored by the fallback-agent.
**Expected behavior:** `discover_agents()` also scans `~/.claude/agents/*.md` and loads them with an empty namespace (so `qualified_name == name`, no prefix), making them globally available.

Closes #1.

## Existing Architecture

The function scanned two sources: the plugin's own `agents/` directory and sibling plugins discovered via filesystem traversal.

```mermaid
graph TD
    A([discover_agents]) --> B["1. Own plugin: CLAUDE_PLUGIN_ROOT/agents/*.md"]
    A --> C["2. Sibling plugins: ../*/agents/*.md"]
    B --> D[(agents HashMap)]
    C --> D
    style A fill:#69f,stroke:#333
```

## Proposed Architecture

A third source is added: `~/.claude/agents/*.md`, loaded with an empty namespace so agents appear without any prefix.

```mermaid
graph TD
    A([discover_agents]) --> B["1. Own plugin: CLAUDE_PLUGIN_ROOT/agents/*.md"]
    A --> C["2. Sibling plugins: ../*/agents/*.md"]
    A --> E["3. User agents: ~/.claude/agents/*.md (empty namespace)"]
    B --> D[(agents HashMap)]
    C --> D
    E --> D
    style A fill:#69f,stroke:#333
    style E fill:#6f6,stroke:#333
```

## Key Changes

**`plugins/fallback-agent/mcp-server-rs/src/agent_discovery.rs`**
- Updated doc comment on `discover_agents()` to document the new third source
- Added a block after sibling scanning that resolves `HOME` via `std::env::var("HOME")`, checks if `~/.claude/agents/` exists as a directory, and if so pushes it onto `scan_targets` with an empty namespace (`String::new()`). If `HOME` is unset or the directory doesn't exist, the block is silently skipped — no error, no panic.
- Added two new unit tests:
  - `test_discover_user_agents_graceful_skip` — verifies no panic when `~/.claude/agents/` doesn't exist
  - `test_discover_user_agents_loads_md` — creates a real temp agent file and verifies it is discovered with `qualified_name == name`

## Tests & Checks

All tooling checks passed in the Rust workspace.

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 21 passed, 0 failed |
| Build (`cargo build`) | ✅ | success |
| Type check (`cargo check`) | ✅ | no errors |
| Lint (`cargo clippy`) | ✅ | clean |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>