### PR TITLE
feat(looper): assign GitHub issue to current user before starting PDC loop

### DIFF
--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -69,6 +69,27 @@ eval "$SYNC_OUTPUT"   # sets DEFAULT_BRANCH, STATUS
   6. If new conflicts appear, repeat until the rebase completes.
 - **Exit 2 (error):** Warn and continue — the loop can still proceed without sync.
 
+### 4c. Assign GitHub issue (if referenced)
+
+Check if `$ARGUMENTS` contains a GitHub issue reference. Look for:
+- A GitHub issue URL matching `https://github.com/.+/issues/(\d+)`
+- A hash-prefixed issue number like `#123`
+- A plain issue number at the start of the arguments (e.g., "42 fix the bug")
+
+If an issue reference is found, extract the issue number and assign it to
+the current user:
+
+```bash
+gh issue edit <NUMBER> --add-assignee @me
+# If the issue URL included a repo (owner/repo), add: --repo owner/repo
+```
+
+- **Success:** Log "Assigned issue #<NUMBER> to current user." and continue.
+- **Failure:** Warn "Could not assign issue #<NUMBER>. Continuing anyway."
+  Do NOT abort — the loop should proceed regardless.
+
+If no issue reference is found in `$ARGUMENTS`, skip this step silently.
+
 ### 5. Build project context
 
 Read the following files (skip any that don't exist) and assemble them into `PROJECT_CONTEXT`:
@@ -130,6 +151,7 @@ Pay special attention to CONTRIBUTING.md for build/test/lint/commit conventions.
 - **ITERATION:** ${ITERATION}
 - **TASK_PROMPT:** ${TASK_PROMPT}
 - **SCRIPTS_DIR:** ${SCRIPTS_DIR}
+- **WORKTREE_DIR:** ${WORKTREE_DIR}
 
 ## Prior Loop Context
 


### PR DESCRIPTION
## Problem / Task

When multiple contributors run `/looper` on the same GitHub issue, there is no mechanism to claim the ticket, leading to duplicated or conflicting work. This PR adds an explicit issue-assignment step before the loop begins, so the ticket is claimed atomically via the GitHub API.

**Current behavior:** Looper starts working on a task immediately without claiming any related GitHub issue, allowing parallel workers to pick up the same ticket.
**Expected behavior:** If the task prompt contains a GitHub issue reference (URL, `#123`, or plain number), the skill runs `gh issue edit <N> --add-assignee @me` before entering the PDC loop.

## Existing Architecture

The looper skill flows through environment validation → worktree creation → remote sync → context building → PDC iterations. No ticket-assignment guard existed.

```mermaid
flowchart TD
    A(["/looper task description"]) --> B[Step 1: Validate env]
    B --> C[Step 2-3: Validate arg & task name]
    C --> D[Step 4: Create worktree]
    D --> E[Step 4b: Sync with remote]
    E --> F[Step 5: Build project context]
    F --> G[Step 6: Detect resume iteration]
    G --> H[Step 7: PDC Loop]
    H --> I[Step 8: Report & create PR]
    style E fill:#69f,stroke:#333
```

## Proposed Architecture

A new step 4c is inserted between the remote sync and context-building phases. It detects any GitHub issue reference in the original arguments, assigns the issue to `@me`, and continues — never aborting the loop.

```mermaid
flowchart TD
    A(["/looper task description"]) --> B[Step 1: Validate env]
    B --> C[Step 2-3: Validate arg & task name]
    C --> D[Step 4: Create worktree]
    D --> E[Step 4b: Sync with remote]
    E --> F[Step 4c: Assign GitHub issue]
    F --> G[Step 5: Build project context]
    G --> H[Step 6: Detect resume iteration]
    H --> I[Step 7: PDC Loop]
    I --> J[Step 8: Report & create PR]
    style F fill:#6f6,stroke:#333
```

## Key Changes

**`plugins/looper/skills/looper/SKILL.md` — new step 4c**

- Parses three issue reference formats from `$ARGUMENTS`:
  - GitHub issue URL (`https://github.com/owner/repo/issues/123`)
  - Hash-prefixed number (`#123`)
  - Plain number at the start of the arguments
- Calls `gh issue edit <NUMBER> --add-assignee @me` (with optional `--repo owner/repo` when repo is extracted from a URL)
- Logs success or warns on failure — never aborts the loop
- Skips silently when no issue reference is detected

**`plugins/looper/skills/looper/SKILL.md` — step 7b context**

- Added `WORKTREE_DIR` to the Task Variables block forwarded to each subagent.

## Tests & Checks

No automated test suite exists for the looper plugin (it is a skill/prompt file). The implementation was verified via the looper PDC loop itself (1 iteration, Checker issued PASS).

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No test suite for skill/prompt files |
| Lint | ⏭️ | No linter configured |
| Type Check | ⏭️ | Not applicable (Markdown/Bash) |
| Build | ⏭️ | Not applicable |
| PDC Loop | ✅ | PASS on iteration 1 |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>