### PR TITLE
feat: add webscraping plugin and rebrand to code-salad

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "vikyw89-looper",
+  "name": "code-salad-looper",
   "description": "Plan-Do-Check loop orchestrator and nested subagent toolkit for Claude Code",
   "owner": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
   "plugins": [
     {
@@ -10,7 +10,7 @@
       "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
       "version": "0.18.0",
       "author": {
-        "name": "vikyw89"
+        "name": "code-salad"
       },
       "source": "./plugins/looper",
       "category": "development"
@@ -20,7 +20,7 @@
       "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
       "version": "0.18.0",
       "author": {
-        "name": "vikyw89"
+        "name": "code-salad"
       },
       "source": "./plugins/fallback-agent",
       "category": "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
   "version": "0.18.0",
   "author": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
-  "repository": "https://github.com/vikyw89/looper",
+  "repository": "https://github.com/code-salad/looper",
   "license": "MIT",
   "keywords": [
     "pdc",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Checker) in a loop until the Checker issues a PASS verdict.
 
 ```bash
 # From GitHub
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 
 # Local install from a checkout
 claude plugin install /path/to/looper/plugins/looper

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No manual intervention required. Just describe what you want, and Looper handles
 ### 1. Install
 
 ```bash
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 ```
 
 ### 2. Run your first loop

--- a/dashboard/public/guide.html
+++ b/dashboard/public/guide.html
@@ -336,7 +336,7 @@ npm install</pre>
 
 <h3>Install the Plugin</h3>
 <pre># Install from GitHub
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 
 # Or install from a local checkout
 claude plugin install /path/to/looper/plugins/looper</pre>
@@ -635,7 +635,7 @@ npm install</pre>
 
 <h3>플러그인 설치</h3>
 <pre># GitHub에서 설치
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 
 # 또는 로컬 체크아웃에서 설치
 claude plugin install /path/to/looper/plugins/looper</pre>

--- a/plugins/fallback-agent/.claude-plugin/plugin.json
+++ b/plugins/fallback-agent/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
   "version": "0.18.0",
   "author": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
   "license": "MIT",
   "keywords": [

--- a/plugins/looper/.claude-plugin/plugin.json
+++ b/plugins/looper/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
   "version": "0.18.0",
   "author": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
-  "repository": "https://github.com/vikyw89/looper",
+  "repository": "https://github.com/code-salad/looper",
   "license": "MIT",
   "keywords": [
     "pdc",

--- a/plugins/webscraping/.claude-plugin/plugin.json
+++ b/plugins/webscraping/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "webscraping",
+  "description": "End-to-end web scraping toolkit — domain recon, method selection, .NET 10 implementation, anti-detection, and proxy management",
+  "version": "0.1.0",
+  "author": {
+    "name": "code-salad"
+  },
+  "repository": "https://github.com/code-salad/looper",
+  "license": "MIT",
+  "keywords": [
+    "webscraping",
+    "scraper",
+    "recon",
+    "dotnet",
+    "playwright"
+  ]
+}

--- a/plugins/webscraping/skills/recon/SKILL.md
+++ b/plugins/webscraping/skills/recon/SKILL.md
@@ -1,0 +1,445 @@
+---
+name: recon
+user-invocable: false
+argument-hint: "[domain]"
+description: Domain reconnaissance skill. Discovers subdomains, API endpoints, tech stack, auth requirements, and anti-bot signals for a target domain. Produces a structured markdown report with recommended scraping approach. Use before building a scraper to find what data sources exist.
+allowed-tools: Bash(curl:*), Bash(uvx:*), Bash(subfinder:*), Bash(httpx:*), Bash(katana:*), Bash(go install:*), Bash(amass:*), Bash(mkdir:*), Bash(sort:*), Bash(jq:*), Bash(pip install:*), WebFetch, WebSearch, Read, Write, Grep, Glob
+---
+
+# Domain Reconnaissance Playbook
+
+Run all phases in order. Maximize parallelism — independent tools MUST run as parallel Bash calls in a single message.
+
+Save all raw data to `recon/<domain>/` and the final report to `recon/<domain>-report.md`.
+
+---
+
+## Tool Installation
+
+Install Go tools if not already present (check with `which` first):
+
+```bash
+# ProjectDiscovery suite
+go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
+go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest
+go install -v github.com/projectdiscovery/katana/cmd/katana@latest
+
+# Python tools (theHarvester, waymore) use uvx — no install needed
+```
+
+---
+
+## Phase 1: Quick Passive Checks
+
+Run ALL of these as **parallel Bash/WebFetch calls in one message**:
+
+```
+┌──────────────────────────────────────────────────────┐
+│              PARALLEL PASSIVE CHECKS                  │
+│                                                       │
+│  curl: robots.txt                                     │
+│  curl: sitemap.xml                                    │
+│  curl: sitemap_index.xml                              │
+│  curl: /api/                                          │
+│  curl: /api/v1/                                       │
+│  curl: /api/v2/                                       │
+│  curl: /graphql (POST introspection query)            │
+│  curl: /rest/                                         │
+│  curl: /_next/data/                                   │
+│  curl: /wp-json/                                      │
+│  curl: /swagger.json                                  │
+│  curl: /openapi.json                                  │
+│  curl: /api-docs                                      │
+│  curl: /docs                                          │
+│  curl: /.well-known/                                  │
+│  curl: /feed/                                         │
+│  WebSearch: "site:<domain> api"                       │
+│  WebSearch: "<domain> api documentation developer"    │
+│  WebSearch: "<domain> scraper github"                 │
+└──────────────────────────────────────────────────────┘
+```
+
+For each curl check, use `-sS -o /dev/null -w "%{http_code}"` first to check status, then fetch the body if 2xx/3xx.
+
+Also probe common API subdomains:
+- `api.<domain>`
+- `data.<domain>`
+- `feeds.<domain>`
+- `public-api.<domain>`
+- `gateway.<domain>`
+- `services.<domain>`
+
+Refer to `${CLAUDE_PLUGIN_ROOT}/skills/recon/references/common-paths.md` for the full list of paths and patterns.
+
+**Save results to:** `recon/<domain>/passive-checks.txt`
+
+---
+
+## Phase 2: Subdomain Discovery
+
+Run these tools **in parallel**:
+
+### 2A. theHarvester (OSINT — subdomains, IPs, emails)
+```bash
+mkdir -p recon/<domain>
+uvx theHarvester -d <domain> -b all -l 500 -f recon/<domain>/harvester
+```
+
+### 2B. subfinder (50+ passive sources)
+```bash
+subfinder -d <domain> -all -o recon/<domain>/subfinder-subs.txt
+```
+
+### 2C. crt.sh (Certificate Transparency — no install needed)
+```bash
+curl -s "https://crt.sh/?q=%25.<domain>&output=json" | jq -r '.[].name_value' | sort -u > recon/<domain>/crtsh-subs.txt
+```
+
+### 2D. amass (OWASP — passive mode first, active if needed)
+```bash
+amass enum -passive -d <domain> -o recon/<domain>/amass-subs.txt
+```
+
+**After all complete** — merge and dedupe:
+```bash
+sort -u recon/<domain>/subfinder-subs.txt \
+       recon/<domain>/crtsh-subs.txt \
+       recon/<domain>/amass-subs.txt \
+       <(grep -oP '[\w.-]+\.<domain>' recon/<domain>/harvester.json 2>/dev/null) \
+       > recon/<domain>/all-subdomains.txt
+echo "[recon] $(wc -l < recon/<domain>/all-subdomains.txt) unique subdomains found"
+```
+
+**Save results to:** `recon/<domain>/all-subdomains.txt`
+
+---
+
+## Phase 3: Historical URL Mining
+
+Run these **in parallel** with Phase 2 (they are independent):
+
+### 3A. waymore (Wayback Machine + Common Crawl + URLScan)
+```bash
+uvx waymore -i <domain> -mode U -oU recon/<domain>/waymore-urls.txt
+```
+
+### 3B. gau (GetAllUrls — Wayback, Common Crawl, OTX, URLScan)
+```bash
+# Install if needed: go install github.com/lc/gau/v2/cmd/gau@latest
+gau <domain> > recon/<domain>/gau-urls.txt 2>/dev/null || true
+```
+
+### 3C. waybackurls
+```bash
+# Install if needed: go install github.com/tomnomnom/waybackurls@latest
+waybackurls <domain> > recon/<domain>/waybackurls.txt 2>/dev/null || true
+```
+
+**After all complete** — merge and filter for API paths:
+```bash
+sort -u recon/<domain>/waymore-urls.txt \
+       recon/<domain>/gau-urls.txt \
+       recon/<domain>/waybackurls.txt \
+       2>/dev/null > recon/<domain>/all-historical-urls.txt
+
+# Filter for likely API/data endpoints
+grep -iE '(/api/|/v[0-9]/|/graphql|/rest/|/data/|\.json|/feed/|/export|/search\?|/query\?|/webhook|/callback)' \
+  recon/<domain>/all-historical-urls.txt > recon/<domain>/api-urls.txt 2>/dev/null || true
+
+echo "[recon] $(wc -l < recon/<domain>/all-historical-urls.txt) historical URLs found"
+echo "[recon] $(wc -l < recon/<domain>/api-urls.txt) likely API URLs found"
+```
+
+**Save results to:** `recon/<domain>/all-historical-urls.txt`, `recon/<domain>/api-urls.txt`
+
+---
+
+## Phase 4: Live Endpoint Probing
+
+Depends on Phases 2 & 3 completing. Run httpx on all discovered subdomains and interesting endpoints.
+
+### 4A. Probe subdomains for live hosts
+```bash
+httpx -l recon/<domain>/all-subdomains.txt -sc -ct -title -tech-detect -o recon/<domain>/live-subdomains.txt
+```
+
+### 4B. Filter for JSON/API-serving endpoints
+```bash
+httpx -l recon/<domain>/all-subdomains.txt -mc 200,301,302 -ct -match-string "application/json" -o recon/<domain>/json-endpoints.txt
+```
+
+### 4C. Probe historical API URLs that are still live
+```bash
+httpx -l recon/<domain>/api-urls.txt -sc -ct -o recon/<domain>/live-api-urls.txt 2>/dev/null || true
+```
+
+Run 4A, 4B, and 4C in parallel.
+
+**Save results to:** `recon/<domain>/live-subdomains.txt`, `recon/<domain>/json-endpoints.txt`, `recon/<domain>/live-api-urls.txt`
+
+---
+
+## Phase 5: JS Bundle Analysis
+
+Find API routes, hardcoded keys, and hidden endpoints embedded in JavaScript bundles.
+
+### 5A. katana JS crawl
+```bash
+katana -u https://<domain> -d 2 -jc -kf all -ef css,png,jpg,gif,svg,woff,woff2,ttf -o recon/<domain>/katana-js.txt
+```
+
+`-jc` enables JavaScript parsing to extract endpoints from JS files. `-kf all` keeps all discovered form/link/script references.
+
+### 5B. Extract API routes from JS bundles
+
+After katana finds JS file URLs, download and search them:
+
+```bash
+# Extract JS file URLs from katana output
+grep -iE '\.js(\?|$)' recon/<domain>/katana-js.txt > recon/<domain>/js-files.txt 2>/dev/null || true
+
+# Download and search each JS file for API patterns
+while IFS= read -r jsurl; do
+  curl -sS "$jsurl" 2>/dev/null | grep -oE '"/(api|v[0-9]|graphql|rest|data|auth|users?|search|query|endpoint)[^"]*"' >> recon/<domain>/js-api-routes.txt 2>/dev/null
+done < recon/<domain>/js-files.txt
+sort -u -o recon/<domain>/js-api-routes.txt recon/<domain>/js-api-routes.txt 2>/dev/null || true
+```
+
+### 5C. Search for hardcoded secrets and config in JS
+
+```bash
+# Search JS bundles for interesting patterns
+while IFS= read -r jsurl; do
+  curl -sS "$jsurl" 2>/dev/null | grep -oiE '(apiKey|api_key|apiSecret|baseUrl|base_url|endpoint|Authorization|Bearer|token)["\s:=]+["\x27][^"\x27]{8,}["\x27]' >> recon/<domain>/js-secrets.txt 2>/dev/null
+done < recon/<domain>/js-files.txt
+sort -u -o recon/<domain>/js-secrets.txt recon/<domain>/js-secrets.txt 2>/dev/null || true
+```
+
+### 5D. LinkFinder (optional — if katana misses endpoints)
+
+```bash
+# Install: pip install linkfinder
+# Run on discovered JS files
+while IFS= read -r jsurl; do
+  python3 -m linkfinder -i "$jsurl" -o cli >> recon/<domain>/linkfinder-results.txt 2>/dev/null
+done < recon/<domain>/js-files.txt
+```
+
+**Save results to:** `recon/<domain>/js-api-routes.txt`, `recon/<domain>/js-secrets.txt`
+
+---
+
+## Phase 6: Deep Crawl (Only If Needed)
+
+Only run this phase if Phases 1-5 haven't found sufficient API endpoints or data sources. A deep crawl is slow and generates a lot of data.
+
+```bash
+katana -u https://<domain> -d 5 -jc -kf all -aff -o recon/<domain>/deep-crawl.txt
+```
+
+Flags:
+- `-d 5` — crawl depth 5
+- `-jc` — parse JavaScript
+- `-kf all` — keep all form/link references
+- `-aff` — automatically follow redirects to other subdomains found
+
+Filter the deep crawl for API endpoints:
+```bash
+grep -iE '(/api/|/v[0-9]/|/graphql|/rest/|/data/|\.json|/feed/)' \
+  recon/<domain>/deep-crawl.txt >> recon/<domain>/api-urls.txt
+sort -u -o recon/<domain>/api-urls.txt recon/<domain>/api-urls.txt
+```
+
+---
+
+## Phase 7: Analysis & Structured Report
+
+After all discovery phases complete, analyze findings and generate a comprehensive markdown report.
+
+### Endpoint Classification
+
+Classify each discovered endpoint:
+
+| Signal | Classification | Scraping Approach |
+|--------|---------------|-------------------|
+| JSON response, no auth headers required | **Unguarded API** | Direct HTTP fetch — easiest |
+| JSON response, requires cookie/session | **Session-gated** | Establish session first, then fetch |
+| JSON response, requires Bearer/API key | **Key-gated** | Check if key is in frontend JS bundles |
+| HTML response, server-rendered | **HTML target** | Parse with AngleSharp/BeautifulSoup |
+| HTML response, client-rendered (SPA) | **SPA target** | Browser automation (Playwright) |
+| GraphQL endpoint | **GraphQL API** | Flexible queries, check complexity limits |
+| 403/429 on first request | **Anti-bot active** | Residential proxies, browser automation |
+| Cloudflare/Akamai challenge page | **WAF protected** | Browser + stealth, residential proxies |
+
+### Tech Stack Detection
+
+Look for these signals in response headers and HTML:
+
+| Header/Pattern | Indicates |
+|---------------|-----------|
+| `x-powered-by: Next.js` | Next.js — check `__NEXT_DATA__` for embedded JSON |
+| `x-powered-by: Nuxt` | Nuxt.js — check `__NUXT_DATA__` |
+| `server: cloudflare` | Cloudflare CDN/WAF |
+| `server: AkamaiGHost` | Akamai CDN/WAF |
+| `x-shopify-stage` | Shopify store |
+| `x-wp-*` headers | WordPress — check `/wp-json/` API |
+| `cf-ray` header | Behind Cloudflare |
+| `set-cookie: __cf_bm` | Cloudflare bot management |
+| `<script id="__NEXT_DATA__">` | Next.js with embedded page data |
+| `window.__INITIAL_STATE__` | Redux/Vuex with embedded state |
+
+### Generate Report
+
+Write the final report to `recon/<domain>-report.md` with this structure:
+
+```markdown
+# Recon Report: <domain>
+
+**Date:** <date>
+**Analyst:** Claude Code (recon skill)
+
+## Summary
+
+- **Subdomains found:** N
+- **Live hosts:** N
+- **API endpoints discovered:** N
+- **Tech stack:** [detected technologies]
+- **Anti-bot signals:** [none | Cloudflare | Akamai | custom WAF | ...]
+- **Recommended approach:** [Direct API | HTML parsing | Browser automation]
+
+## Subdomains
+
+| Subdomain | Status | Content-Type | Title | Technologies |
+|-----------|--------|-------------|-------|-------------|
+| (from httpx output) |
+
+## API Endpoints
+
+### Unguarded APIs (Tier 1 — best targets)
+- `GET https://api.example.com/v1/...` — JSON, no auth
+- ...
+
+### Session-Gated APIs (Tier 2)
+- `GET https://example.com/api/...` — requires session cookie
+- ...
+
+### Key-Gated APIs (Tier 3)
+- `GET https://example.com/api/...` — requires API key (found in JS: yes/no)
+- ...
+
+### GraphQL Endpoints
+- `POST https://example.com/graphql` — introspection enabled: yes/no
+- ...
+
+## Historical URLs of Interest
+
+(Notable URLs from Wayback Machine / Common Crawl that suggest data endpoints)
+
+## JS Bundle Findings
+
+- API routes found in JavaScript: [list]
+- Hardcoded keys/tokens: [list, redacted]
+- Base URLs: [list]
+
+## Tech Stack
+
+| Component | Value |
+|-----------|-------|
+| Framework | Next.js / Nuxt / Rails / Django / ... |
+| CDN/WAF | Cloudflare / Akamai / none |
+| Server | nginx / Apache / ... |
+| Database hints | (from API response patterns) |
+
+## Auth Requirements
+
+| Endpoint | Auth Type | Details |
+|----------|-----------|---------|
+| /api/v1/public | None | Open access |
+| /api/v1/user | Bearer token | JWT, obtained from /auth/login |
+| ... | ... | ... |
+
+## Anti-Bot Signals
+
+| Signal | Severity | Details |
+|--------|----------|---------|
+| Cloudflare | High | cf-ray header present, __cf_bm cookie |
+| Rate limiting | Medium | 429 after N requests |
+| ... | ... | ... |
+
+## Recommended Scraping Approach
+
+Based on the findings above:
+
+1. **Primary target:** [best endpoint found]
+2. **Method:** [Direct API / HTML parsing / Browser automation]
+3. **Auth strategy:** [none / session / key from JS / ...]
+4. **Proxy recommendation:** [datacenter / residential / none]
+5. **Estimated difficulty:** [easy / medium / hard]
+6. **Key risks:** [rate limiting / anti-bot / auth complexity / ...]
+```
+
+### Save Raw Data
+
+Ensure all raw data files are saved in `recon/<domain>/`:
+- `passive-checks.txt` — Phase 1 results
+- `all-subdomains.txt` — merged subdomains
+- `all-historical-urls.txt` — merged historical URLs
+- `api-urls.txt` — filtered API URLs
+- `live-subdomains.txt` — httpx probe results
+- `json-endpoints.txt` — JSON-serving endpoints
+- `live-api-urls.txt` — live historical API URLs
+- `js-files.txt` — discovered JS bundle URLs
+- `js-api-routes.txt` — API routes from JS
+- `js-secrets.txt` — hardcoded config from JS
+- Individual tool outputs (harvester, subfinder, crtsh, amass, waymore, gau, waybackurls, katana)
+
+---
+
+## Parallelism Summary
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Phase 1: Passive Checks          (all parallel)            │
+│  Phase 2: Subdomain Discovery     (all parallel)            │  ← Run Phases 1-3
+│  Phase 3: Historical URL Mining   (all parallel)            │    concurrently
+├─────────────────────────────────────────────────────────────┤
+│  Phase 4: Live Probing            (depends on 2+3)          │  ← Sequential gate
+├─────────────────────────────────────────────────────────────┤
+│  Phase 5: JS Bundle Analysis      (depends on 4)            │  ← Sequential gate
+├─────────────────────────────────────────────────────────────┤
+│  Phase 6: Deep Crawl              (only if needed)          │  ← Conditional
+├─────────────────────────────────────────────────────────────┤
+│  Phase 7: Analysis & Report       (depends on all above)    │  ← Final
+└─────────────────────────────────────────────────────────────┘
+```
+
+Phases 1, 2, and 3 are fully independent — launch ALL their tools as parallel Bash calls in a single message. Phase 4 waits for 2+3 to complete (needs subdomain and URL lists). Phase 5 waits for katana output. Phase 6 is conditional. Phase 7 is always last.
+
+---
+
+## Multi-Domain Recon
+
+When running recon on multiple domains, spawn one Task subagent per domain:
+
+```
+Task(general-purpose): "Run /recon on domain-a.com"
+Task(general-purpose): "Run /recon on domain-b.com"
+Task(general-purpose): "Run /recon on domain-c.com"
+```
+
+Each subagent runs its own parallel recon pipeline independently.
+
+---
+
+## Instructions
+
+After reading this playbook, begin reconnaissance on the target domain.
+1. Create the output directory `recon/<domain>/`.
+2. Run Phases 1-3 with maximum parallelism.
+3. Proceed through Phases 4-7 sequentially as results become available.
+4. Write the final report to `recon/<domain>-report.md`.
+5. Present the key findings (summary + recommended approach) to the user.
+
+## Target
+
+$ARGUMENTS

--- a/plugins/webscraping/skills/recon/references/common-paths.md
+++ b/plugins/webscraping/skills/recon/references/common-paths.md
@@ -1,0 +1,328 @@
+# Common API Paths & Detection Patterns
+
+Reference file for the recon skill. Use these patterns during Phase 1 (passive checks) and Phase 7 (analysis).
+
+---
+
+## Standard Paths to Probe
+
+### Sitemaps & Robots
+```
+/robots.txt
+/sitemap.xml
+/sitemap_index.xml
+/sitemaps/sitemap.xml
+```
+
+### REST API Paths
+```
+/api
+/api/
+/api/v1/
+/api/v2/
+/api/v3/
+/rest/
+/data/
+/public/api/
+/external/api/
+/mobile/api/
+/app/api/
+```
+
+### GraphQL
+```
+/graphql
+/graphql/
+/gql
+/query
+/api/graphql
+/v1/graphql
+```
+
+GraphQL introspection query:
+```json
+{"query": "{ __schema { types { name } } }"}
+```
+
+Full introspection (if simple one works):
+```json
+{"query": "{ __schema { queryType { name } types { name kind fields { name type { name kind ofType { name } } } } } }"}
+```
+
+### OpenAPI / Swagger
+```
+/swagger.json
+/swagger/v1/swagger.json
+/openapi.json
+/openapi.yaml
+/api-docs
+/api-docs/
+/docs
+/docs/
+/swagger-ui/
+/swagger-ui/index.html
+/redoc
+/api/docs
+/api/swagger.json
+/v1/api-docs
+/v2/api-docs
+```
+
+### Framework-Specific
+
+#### Next.js
+```
+/_next/data/                     # Data routes (build ID needed)
+/_next/data/<buildId>/<page>.json
+```
+Look for `<script id="__NEXT_DATA__">` in HTML — contains page props as JSON.
+
+#### Nuxt.js
+```
+/_nuxt/
+/__nuxt/
+```
+Look for `window.__NUXT_DATA__` or `window.__NUXT__` in HTML.
+
+#### WordPress
+```
+/wp-json/
+/wp-json/wp/v2/
+/wp-json/wp/v2/posts
+/wp-json/wp/v2/pages
+/wp-json/wp/v2/categories
+/wp-json/wp/v2/tags
+/wp-json/wp/v2/users
+/wp-json/wp/v2/media
+/wp-json/wp/v2/search?search=<term>
+/wp-json/wc/v3/                  # WooCommerce
+/?rest_route=/wp/v2/posts        # Alternative REST route
+/xmlrpc.php                      # Legacy XML-RPC
+```
+
+#### Django / Django REST Framework
+```
+/api/
+/api/v1/
+/api/v2/
+/api-auth/
+/admin/
+```
+
+#### Rails
+```
+/api/
+/api/v1/
+/rails/info/routes               # Route listing (dev mode)
+```
+
+#### Laravel
+```
+/api/
+/api/v1/
+/sanctum/csrf-cookie             # Laravel Sanctum
+/oauth/token                     # Laravel Passport
+```
+
+#### ASP.NET
+```
+/api/
+/odata/
+/signalr/
+/_blazor
+```
+
+#### Shopify
+```
+/products.json
+/collections.json
+/cart.json
+/search/suggest.json?q=<term>
+/admin/api/2024-01/              # Admin API (auth required)
+```
+
+### Authentication Endpoints
+```
+/auth/
+/auth/login
+/auth/token
+/auth/refresh
+/oauth/token
+/oauth/authorize
+/login
+/signin
+/api/auth/
+/api/login
+/.well-known/openid-configuration
+```
+
+### Common Data Endpoints
+```
+/feed/
+/feed/atom
+/feed/rss
+/rss
+/rss.xml
+/atom.xml
+/export
+/download
+/search?q=<term>
+/autocomplete?q=<term>
+/suggest?q=<term>
+```
+
+### Well-Known Paths
+```
+/.well-known/
+/.well-known/openid-configuration
+/.well-known/security.txt
+/.well-known/change-password
+/.well-known/assetlinks.json      # Android app links
+/.well-known/apple-app-site-association  # iOS app links
+```
+
+### Common API Subdomains
+```
+api.<domain>
+data.<domain>
+feeds.<domain>
+public-api.<domain>
+gateway.<domain>
+services.<domain>
+rest.<domain>
+graphql.<domain>
+search.<domain>
+cdn.<domain>
+static.<domain>
+assets.<domain>
+media.<domain>
+admin.<domain>
+app.<domain>
+mobile.<domain>
+m.<domain>
+```
+
+---
+
+## Tech Stack Detection Signatures
+
+### Response Headers
+
+| Header | Value Pattern | Indicates |
+|--------|--------------|-----------|
+| `x-powered-by` | `Next.js` | Next.js (check `__NEXT_DATA__`) |
+| `x-powered-by` | `Nuxt`, `Nuxt.js` | Nuxt.js (check `__NUXT_DATA__`) |
+| `x-powered-by` | `Express` | Node.js Express |
+| `x-powered-by` | `PHP/*` | PHP backend |
+| `x-powered-by` | `ASP.NET` | .NET backend |
+| `server` | `cloudflare` | Cloudflare CDN/WAF |
+| `server` | `AkamaiGHost` | Akamai CDN/WAF |
+| `server` | `nginx` | Nginx web server |
+| `server` | `Apache` | Apache web server |
+| `server` | `Vercel` | Vercel hosting (likely Next.js) |
+| `server` | `Netlify` | Netlify hosting |
+| `x-shopify-stage` | any | Shopify store |
+| `x-wp-total` | any | WordPress REST API |
+| `x-wp-totalpages` | any | WordPress REST API |
+| `x-drupal-cache` | any | Drupal CMS |
+| `x-generator` | `Drupal *` | Drupal CMS |
+| `x-aspnet-version` | any | ASP.NET |
+| `x-aspnetmvc-version` | any | ASP.NET MVC |
+| `cf-ray` | any | Behind Cloudflare |
+| `cf-cache-status` | any | Cloudflare caching |
+| `x-amz-cf-id` | any | AWS CloudFront |
+| `x-cache` | `Hit from cloudfront` | AWS CloudFront cache hit |
+| `x-vercel-cache` | any | Vercel edge cache |
+
+### HTML Body Patterns
+
+| Pattern | Indicates |
+|---------|-----------|
+| `<script id="__NEXT_DATA__">` | Next.js with embedded page data |
+| `window.__NEXT_DATA__` | Next.js hydration data |
+| `window.__NUXT__` | Nuxt.js state |
+| `window.__NUXT_DATA__` | Nuxt 3 state |
+| `window.__INITIAL_STATE__` | Redux/Vuex embedded state |
+| `window.__APOLLO_STATE__` | Apollo GraphQL cache |
+| `window.__RELAY_STORE__` | Relay GraphQL cache |
+| `window._sharedData` | Instagram-style embedded data |
+| `<div id="__next">` | Next.js app root |
+| `<div id="app">` or `<div id="root">` | React/Vue SPA |
+| `ng-app` or `ng-version` | Angular |
+| `data-reactroot` | React |
+| `<meta name="generator" content="WordPress">` | WordPress |
+| `<meta name="generator" content="Shopify">` | Shopify |
+
+### JS Bundle Patterns (search with grep)
+
+| Pattern | Indicates |
+|---------|-----------|
+| `"baseUrl"` or `"baseURL"` | API base URL configuration |
+| `"apiKey"` or `"api_key"` | Hardcoded API key |
+| `"apiSecret"` or `"api_secret"` | Hardcoded API secret |
+| `"Authorization"` | Auth header construction |
+| `"Bearer "` | JWT token usage |
+| `"/api/v"` | API versioned routes |
+| `"graphql"` | GraphQL endpoint reference |
+| `fetch(` or `axios.` | HTTP client calls |
+| `"x-api-key"` | Custom API key header |
+| `process.env.` or `import.meta.env.` | Environment variable references |
+
+---
+
+## Anti-Bot Detection Signals
+
+### HTTP Response Signals
+
+| Signal | Severity | Indicates |
+|--------|----------|-----------|
+| `server: cloudflare` + `cf-ray` header | High | Cloudflare protection |
+| `set-cookie: __cf_bm` | High | Cloudflare bot management active |
+| `set-cookie: cf_clearance` | Very High | Cloudflare challenge required |
+| `server: AkamaiGHost` | High | Akamai bot detection |
+| `set-cookie: _abck` | Very High | Akamai bot manager active |
+| `set-cookie: bm_sz` | High | Akamai sensor data |
+| `x-datadome` header | High | DataDome anti-bot |
+| `set-cookie: datadome` | Very High | DataDome active |
+| HTTP 403 on first request | High | Blocked by WAF/anti-bot |
+| HTTP 429 on first request | Medium | Aggressive rate limiting |
+| HTTP 503 with challenge page | High | JS challenge required |
+| `<title>Just a moment...</title>` | Very High | Cloudflare challenge page |
+| `<title>Access Denied</title>` | High | WAF block page |
+| `<noscript>` with redirect | Medium | JS requirement (may indicate anti-bot) |
+
+### JavaScript Challenge Indicators
+
+| Pattern | Indicates |
+|---------|-----------|
+| `turnstile` in HTML | Cloudflare Turnstile CAPTCHA |
+| `hcaptcha` in HTML | hCaptcha challenge |
+| `recaptcha` in HTML | Google reCAPTCHA |
+| `challenge-platform` in HTML | Cloudflare challenge |
+| `_cf_chl_opt` in HTML | Cloudflare challenge options |
+| `window._phantom` or `window.__nightmare` checks | Headless browser detection |
+| Canvas fingerprinting scripts | Browser fingerprinting |
+| WebGL fingerprinting | Hardware fingerprinting |
+
+### Request Header Checks (what anti-bot systems look for)
+
+| Check | What They Verify |
+|-------|-----------------|
+| User-Agent consistency | UA string matches TLS fingerprint and JS navigator |
+| sec-ch-ua consistency | Chromium brand/version matches User-Agent |
+| Accept-Language presence | Missing = bot signal |
+| Referer chain | Direct requests without referrer = suspicious |
+| Cookie jar | No cookies after initial visit = suspicious |
+| TLS fingerprint (JA3/JA4) | Matches known browser fingerprint |
+| HTTP/2 settings frame | Matches browser implementation |
+| Header order | Browsers send headers in consistent order |
+
+---
+
+## API URL Pattern Filter
+
+Use this regex to filter URLs for likely API/data endpoints:
+
+```bash
+grep -iE '(/api/|/v[0-9]/|/graphql|/rest/|/data/|\.json(\?|$)|/feed/|/export|/search\?|/query\?|/webhook|/callback|/oauth|/token|/auth/|/rss|/atom|/sitemap|/suggest|/autocomplete)'
+```

--- a/plugins/webscraping/skills/webscraping/SKILL.md
+++ b/plugins/webscraping/skills/webscraping/SKILL.md
@@ -1,0 +1,1262 @@
+---
+name: webscraping
+description: End-to-end web scraping skill. Use when the user wants to scrape a website, build scrapers, or extract structured data. Covers the full pipeline - recon (via the recon sub-skill), method selection, implementation (.NET 10), checkpointing, anti-detection, and proxy management.
+argument-hint: "[url or target description]"
+allowed-tools: Read, Grep, Glob, Write, Edit, Bash(dotnet run:*), Bash(dotnet build:*), Bash(dotnet new:*), Bash(dotnet add:*), Bash(dotnet test:*), Bash(dotnet publish:*), Bash(curl:*), Bash(cp:*), Bash(mkdir:*), WebFetch, WebSearch, Task
+---
+
+# Web Scraping Playbook (.NET 10)
+
+Follow these phases in order. **Phase 0 determines whether you can skip recon entirely.**
+
+---
+
+## Phase 0: Quick Assessment — Do You Already Know the Target?
+
+Before running any recon tools, assess what you already know:
+
+**Skip to Phase 2** (method selection) if:
+- The user gave you a specific API endpoint or URL
+- The user said "scrape this GraphQL/REST API at ..."
+- You already know the data source from a previous conversation
+
+**Skip to Phase 3** (implementation) if:
+- The user gave you a complete API spec (endpoint + params + response shape)
+- You are modifying an existing scraper in the project
+
+**Proceed to Phase 1** (recon sub-skill) if:
+- The user gave you just a domain or site name
+- You need to discover where the data lives
+- The user asked you to "find the API" or "figure out how to scrape"
+
+---
+
+## Phase 1: Recon — Find the Data Source
+
+Delegate reconnaissance to the **recon** sub-skill. Do NOT run recon tools inline — spawn a subagent.
+
+### Single-Domain Recon
+
+Use the Task tool to spawn the recon skill as a subagent:
+
+```
+Task tool call:
+  subagent_type: "general-purpose"
+  prompt: "Run the /webscraping:recon skill on <domain>. Save results to recon/<domain>/"
+```
+
+Wait for the subagent to complete, then read the report:
+- Report location: `recon/<domain>-report.md`
+- Raw data location: `recon/<domain>/`
+
+### Multi-Domain Recon
+
+Spawn one subagent per domain **in parallel**:
+
+```
+Task(general-purpose): "Run /webscraping:recon on site-a.com"
+Task(general-purpose): "Run /webscraping:recon on site-b.com"
+Task(general-purpose): "Run /webscraping:recon on site-c.com"
+```
+
+### After Recon Completes
+
+1. Read the recon report from `recon/<domain>-report.md`
+2. Review the key findings: discovered endpoints, tech stack, auth requirements, anti-bot signals
+3. Present the recommended scraping approach to the user
+
+**CHECKPOINT: Present recon findings to the user and WAIT for confirmation before proceeding to Phase 2.** If the user says the approach looks wrong or wants changes, re-run recon or investigate further.
+
+---
+
+## Phase 2: Choose the Scraping Method
+
+Pick the **lightest method that works**:
+
+| Tier | Method | When to Use | .NET Library |
+|------|--------|-------------|--------------|
+| 1 | **Direct API** | Unguarded JSON API or key available in frontend JS | `HttpClient` + `System.Text.Json` |
+| 2 | **HTML Parsing** | Server-rendered HTML, no JS needed | `AngleSharp` |
+| 3 | **Embedded JSON** | SSR sites (Next.js/Nuxt) with `__NEXT_DATA__` or similar | `AngleSharp` + `System.Text.Json` |
+| 4 | **Browser Automation** | Content requires JS execution or anti-bot needs real browser | Playwright |
+
+Always prefer higher tiers. Tier 4 (browser automation) is 10-100x slower than direct fetch.
+
+**Anti-bot note:** If the target showed signs of anti-bot protection during probing (403/429 responses, Cloudflare challenge pages, CAPTCHA), consult **Phase 5** before selecting a method. Anti-bot defenses may rule out Tier 1-2 entirely or require specific proxy/header configurations.
+
+**CHECKPOINT: Confirm your chosen method with the user before implementing.**
+
+---
+
+## Phase 3: Implementation — .NET 10
+
+### Project Setup
+
+**For HTTP-based scraping (Tier 1-3):**
+
+```bash
+dotnet new console -n Scraper
+cd Scraper
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite --version 10.0.0
+dotnet add package Polly.Core --version 8.6.5
+dotnet add package AngleSharp --version 1.3.0
+dotnet add package CsvHelper --version 33.0.0
+```
+
+**For browser-based scraping (Tier 4 — Playwright):**
+
+```bash
+dotnet new console -n Scraper
+cd Scraper
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite --version 10.0.0
+dotnet add package Microsoft.Playwright --version 1.52.0
+dotnet add package CsvHelper --version 33.0.0
+# Install Chromium binary
+dotnet build
+pwsh bin/Debug/net10.0/playwright.ps1 install chromium
+```
+
+If your method is **Tier 4 (Browser Automation)**, skip to **Phase 3B** below.
+
+### Reusable Services
+
+This skill ships with working service modules at `${CLAUDE_PLUGIN_ROOT}/skills/webscraping/template/`. Copy them into your project:
+
+```bash
+cp -r ${CLAUDE_PLUGIN_ROOT}/skills/webscraping/template/Services/ ./Services/
+cp -r ${CLAUDE_PLUGIN_ROOT}/skills/webscraping/template/Data/ ./Data/
+cp -r ${CLAUDE_PLUGIN_ROOT}/skills/webscraping/template/Helpers/ ./Helpers/
+```
+
+**Template files:**
+
+| File | Description |
+|------|-------------|
+| `Services/ProxyPool.cs` | Proxy rotation with per-proxy rate limiting (SemaphoreSlim), LRU selection, SOCKS5 support, blacklist with exponential expiry |
+| `Data/ScraperDb.cs` | EF Core SQLite context with checkpoint/progress tracking, atomic CompleteWork, LINQ queries, streaming export |
+| `Helpers/Headers.cs` | Browser-like header randomization with consistent sec-ch-ua, updated UAs |
+| `Helpers/CsvExporter.cs` | True streaming CSV export via IAsyncEnumerable (constant memory) |
+
+### Key Architecture: Per-Proxy Rate Limiting
+
+Each proxy gets its own `HttpClient` with its own `SocketsHttpHandler`. The `ProxyPool` enforces one-request-at-a-time per proxy with a minimum interval via `SemaphoreSlim` + delay. This is the correct design for per-IP rate limiting — it cannot have the bug that `p-throttle` had where a shared throttle distributes requests unevenly across proxies.
+
+```
+ProxyPool
+├── ProxyEntry[0] (socks5://proxy1:1080)
+│   ├── SemaphoreSlim(1) — 1 concurrent request
+│   ├── MinInterval delay — 8s between requests
+│   └── HttpClient → SocketsHttpHandler(proxy=socks5://proxy1:1080)
+├── ProxyEntry[1] (http://proxy2:8080)
+│   ├── SemaphoreSlim(1)
+│   ├── MinInterval delay
+│   └── HttpClient → SocketsHttpHandler(proxy=http://proxy2:8080)
+└── ...
+```
+
+The `SemaphoreSlim(1, 1)` gate ensures only one request is in flight per proxy at any time. After the gate is released, the next caller waiting for that proxy sees the elapsed time since the last request. If it is less than `MinRequestInterval`, a jittered delay (80%-120% of the remaining interval) is applied before sending. This guarantees the target sees at most one request per interval per IP address, regardless of how many concurrent workers are queued up.
+
+### Blacklist with Exponential Expiry
+
+When a proxy accumulates too many consecutive failures, it is temporarily removed from the rotation with exponentially increasing cooldown periods:
+
+- After N consecutive failures (default: 10), proxy is blacklisted for `baseDuration * 2^(strikes-1)`
+- Default progression: 5min -> 10min -> 20min -> 40min -> 80min -> capped at 2hr
+- After the expiry window, the proxy automatically becomes available again
+- Sustained success (every 20 consecutive successful requests) reduces the strike count by 1
+- If ALL proxies are blacklisted, `AllProxiesBlacklistedException` is thrown with the earliest unblacklist time
+- Use `pool.WaitForAvailableAsync()` to block until a proxy recovers instead of failing
+
+Only transient errors count as proxy failures: HTTP 429, 5xx status codes, network failures, and timeouts. Client errors (400, 404, etc.) are rethrown without penalizing the proxy, because those indicate application-level issues, not proxy problems.
+
+### Scraper Template
+
+A simplified `Program.cs` showing the core fetch pattern:
+
+```csharp
+using System.Net.Http.Json;
+using Scraper.Data;
+using Scraper.Helpers;
+using Scraper.Services;
+
+var pool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromSeconds(8),
+    BaseBlacklistDuration = TimeSpan.FromMinutes(5),
+});
+
+await using var db = ScraperDb.Create("data.db");
+await db.Database.EnsureCreatedAsync();
+
+// Fetch with automatic proxy rotation + rate limiting
+var result = await pool.ExecuteAsync(async (client, ct) =>
+{
+    var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/data");
+    Headers.Randomize(request);
+    var response = await client.SendAsync(request, ct);
+    response.EnsureSuccessStatusCode();
+    return await response.Content.ReadFromJsonAsync<MyResponse>(ct);
+}, cancellationToken);
+```
+
+`pool.ExecuteAsync` handles: proxy selection (LRU), per-proxy rate gate, success/failure tracking, and blacklist management. You only write the request logic.
+
+### Polly Retry with Retry-After
+
+Set up a Polly retry pipeline that respects `Retry-After` headers from the server:
+
+```csharp
+using System.Net;
+using Polly;
+using Polly.Retry;
+
+var retryPipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+    .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+    {
+        ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+            .HandleResult(r => r.StatusCode is
+                HttpStatusCode.TooManyRequests or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable or
+                HttpStatusCode.GatewayTimeout)
+            .Handle<HttpRequestException>()
+            .Handle<TaskCanceledException>(),
+        MaxRetryAttempts = 5,
+        BackoffType = DelayBackoffType.Exponential,
+        Delay = TimeSpan.FromSeconds(2),
+        UseJitter = true,
+        DelayGenerator = args =>
+        {
+            // Respect Retry-After header from the server
+            if (args.Outcome.Result?.Headers.RetryAfter?.Delta is { } delta)
+                return ValueTask.FromResult<TimeSpan?>(delta);
+            return ValueTask.FromResult<TimeSpan?>(null); // use default backoff
+        },
+        OnRetry = args =>
+        {
+            var status = args.Outcome.Result?.StatusCode;
+            Console.Error.WriteLine(
+                $"[retry] Attempt {args.AttemptNumber + 1}/5, " +
+                $"status={status}, delay={args.RetryDelay.TotalSeconds:F1}s");
+            return ValueTask.CompletedTask;
+        },
+    })
+    .Build();
+```
+
+Use it inside `pool.ExecuteAsync`:
+
+```csharp
+var result = await pool.ExecuteAsync(async (client, ct) =>
+{
+    var request = new HttpRequestMessage(HttpMethod.Get, url);
+    Headers.Randomize(request);
+
+    var response = await retryPipeline.ExecuteAsync(
+        async _ => await client.SendAsync(request, ct), ct);
+    response.EnsureSuccessStatusCode();
+
+    return await response.Content.ReadFromJsonAsync<MyResponse>(ct);
+}, cancellationToken);
+```
+
+### Orchestrator Template — Parallel Page Fetching
+
+The full orchestrator with parallel page fetching, checkpointing, and graceful shutdown:
+
+```csharp
+using System.Net.Http.Json;
+using System.Text.Json;
+using Scraper.Data;
+using Scraper.Helpers;
+using Scraper.Services;
+
+// --- Configuration ---
+var pool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromSeconds(8),
+    MaxConsecutiveFailures = 10,
+    BaseBlacklistDuration = TimeSpan.FromMinutes(5),
+    MaxBlacklistDuration = TimeSpan.FromHours(2),
+    RequestTimeout = TimeSpan.FromSeconds(30),
+});
+
+await using var db = ScraperDb.Create("data.db");
+await db.Database.EnsureCreatedAsync();
+
+// --- Graceful shutdown ---
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    Console.Error.WriteLine("\n[shutdown] Ctrl+C received, finishing current requests...");
+    cts.Cancel();
+};
+
+// --- Fetch function ---
+async Task<JsonDocument> FetchPage(int page, CancellationToken ct)
+{
+    return await pool.ExecuteAsync(async (client, innerCt) =>
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"https://api.example.com/data?page={page}&pageSize=50");
+        Headers.Randomize(request, "example.com");
+
+        var response = await client.SendAsync(request, innerCt);
+        response.EnsureSuccessStatusCode();
+        return await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(innerCt),
+            cancellationToken: innerCt);
+    }, ct);
+}
+
+// --- Orchestrator ---
+try
+{
+    // Discover total pages from first request
+    using var firstPage = await FetchPage(1, cts.Token);
+    var totalPages = firstPage.RootElement.GetProperty("total_pages").GetInt32();
+    Console.Error.WriteLine($"[scraper] Total pages: {totalPages}");
+
+    // Process page 1 data
+    // TODO: Extract and store data from firstPage
+
+    // Fan out remaining pages across proxy pool
+    var concurrency = Math.Max(1, pool.AvailableCount);
+    using var semaphore = new SemaphoreSlim(concurrency);
+    var tasks = new List<Task>();
+    var completedPages = 1;
+    var startTime = DateTime.UtcNow;
+
+    for (var page = 2; page <= totalPages; page++)
+    {
+        cts.Token.ThrowIfCancellationRequested();
+
+        var key = ScraperDb.MakeKey("page", page);
+        if (await db.IsCompletedAsync(key, cts.Token))
+        {
+            Interlocked.Increment(ref completedPages);
+            continue;
+        }
+
+        await semaphore.WaitAsync(cts.Token);
+        var currentPage = page;
+
+        tasks.Add(Task.Run(async () =>
+        {
+            try
+            {
+                using var data = await FetchPage(currentPage, cts.Token);
+
+                // TODO: Parse data.RootElement and store entities
+                // var items = data.RootElement.GetProperty("items").EnumerateArray()
+                //     .Select(e => new YourEntity { ... });
+                // await db.AddBatchAsync(items, cts.Token);
+
+                await db.CompleteWorkAsync(key, cts.Token);
+                var done = Interlocked.Increment(ref completedPages);
+
+                // Progress reporting every 50 pages
+                if (done % 50 == 0)
+                {
+                    var elapsed = DateTime.UtcNow - startTime;
+                    var rate = done / elapsed.TotalMinutes;
+                    var eta = TimeSpan.FromMinutes((totalPages - done) / rate);
+                    var stats = pool.GetStats();
+                    Console.Error.WriteLine(
+                        $"[progress] {done}/{totalPages} ({rate:F1}/min, ETA {eta:hh\\:mm})");
+                    Console.Error.WriteLine(
+                        $"[proxies] {stats.Available}/{stats.Total} available, " +
+                        $"{stats.Blacklisted} blacklisted");
+                }
+            }
+            catch (OperationCanceledException) { /* shutdown */ }
+            catch (AllProxiesBlacklistedException)
+            {
+                Console.Error.WriteLine(
+                    $"[scraper] Page {currentPage} deferred — all proxies blacklisted");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[scraper] Page {currentPage} failed: {ex.Message}");
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }, cts.Token));
+    }
+
+    await Task.WhenAll(tasks);
+
+    // Export
+    // var count = await CsvExporter.ExportAsync(db.Set<YourEntity>(), "output.csv", ct: cts.Token);
+    // Console.Error.WriteLine($"[export] Wrote {count} rows to output.csv");
+
+    var finalStats = pool.GetStats();
+    Console.Error.WriteLine(
+        $"\n[done] Successes: {finalStats.TotalSuccesses}, " +
+        $"Failures: {finalStats.TotalFailures}, " +
+        $"Blacklisted: {finalStats.Blacklisted}");
+}
+catch (OperationCanceledException)
+{
+    Console.Error.WriteLine("[shutdown] Scrape interrupted. Progress saved — rerun to resume.");
+}
+finally
+{
+    await pool.DisposeAsync();
+}
+```
+
+### No Proxies? Simpler Pattern
+
+When the target does not need proxies (unguarded API, no rate limiting):
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Scraper.Data;
+using Scraper.Helpers;
+
+var handler = new SocketsHttpHandler
+{
+    AutomaticDecompression = DecompressionMethods.All,
+    PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+};
+using var client = new HttpClient(handler);
+
+await using var db = ScraperDb.Create("data.db");
+await db.Database.EnsureCreatedAsync();
+
+// Sequential with polite delay (for rate-sensitive APIs)
+for (var page = 1; page <= totalPages; page++)
+{
+    var key = ScraperDb.MakeKey("page", page);
+    if (await db.IsCompletedAsync(key)) continue;
+
+    var request = new HttpRequestMessage(HttpMethod.Get,
+        $"https://api.example.com/data?page={page}");
+    Headers.Randomize(request);
+
+    var response = await client.SendAsync(request);
+    response.EnsureSuccessStatusCode();
+
+    var data = await response.Content.ReadFromJsonAsync<MyResponse>();
+    // Store data...
+
+    await db.CompleteWorkAsync(key);
+    await Task.Delay(500); // polite delay
+}
+```
+
+### Pagination Patterns
+
+**1. Page-Number Pagination (can parallelize)**
+
+When the API uses `?page=N` parameters, you can fan out all pages simultaneously because each page is independently addressable:
+
+```csharp
+// Fetch page 1 to discover totalPages
+using var firstPage = await FetchPage(1, ct);
+var totalPages = firstPage.RootElement.GetProperty("total_pages").GetInt32();
+
+// Fan out pages 2..N in parallel across proxy pool
+var tasks = new List<Task>();
+for (var page = 2; page <= totalPages; page++)
+{
+    await semaphore.WaitAsync(ct);
+    var p = page;
+    tasks.Add(Task.Run(async () =>
+    {
+        try { await FetchAndStorePage(p, ct); }
+        finally { semaphore.Release(); }
+    }));
+}
+await Task.WhenAll(tasks);
+```
+
+**2. Cursor-Based Pagination (must be sequential)**
+
+When the API returns a `nextCursor` token that is needed to fetch the next page, you CANNOT parallelize. Each page depends on the previous page's response:
+
+```csharp
+string? cursor = null;
+var pageNum = 0;
+
+// Check for resumed progress
+var progress = await db.GetProgressAsync("cursor-scrape");
+if (progress is not null)
+{
+    cursor = progress.Extra; // stored cursor
+    pageNum = progress.LastPage;
+    Console.Error.WriteLine($"[resume] Resuming from page {pageNum}, cursor={cursor}");
+}
+
+while (true)
+{
+    pageNum++;
+    var url = cursor is null
+        ? "https://api.example.com/data?limit=100"
+        : $"https://api.example.com/data?limit=100&cursor={cursor}";
+
+    var response = await pool.ExecuteAsync(async (client, ct) =>
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        Headers.Randomize(request);
+        var resp = await client.SendAsync(request, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<CursorResponse>(ct);
+    }, cts.Token);
+
+    if (response is null || response.Items.Count == 0) break;
+
+    // Store data...
+    await db.AddBatchAsync(response.Items.Select(MapToEntity), cts.Token);
+
+    // Save cursor for resume
+    cursor = response.NextCursor;
+    await db.UpdateProgressAsync("cursor-scrape", pageNum, extra: cursor, ct: cts.Token);
+
+    if (response.NextCursor is null) break; // last page
+}
+
+await db.CompleteWorkAsync("cursor-scrape", cts.Token);
+```
+
+For cursor-based APIs, maximize throughput by rotating across proxies for each sequential request (the `pool.ExecuteAsync` call picks a different proxy each time via LRU).
+
+### HTML Parsing with AngleSharp
+
+When the target serves HTML (Tier 2), use AngleSharp to parse and extract:
+
+```csharp
+using AngleSharp;
+using AngleSharp.Html.Parser;
+
+var parser = new HtmlParser();
+
+var result = await pool.ExecuteAsync(async (client, ct) =>
+{
+    var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com/products");
+    Headers.Randomize(request);
+    // Accept HTML instead of JSON
+    request.Headers.TryAddWithoutValidation("Accept",
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+
+    var response = await client.SendAsync(request, ct);
+    response.EnsureSuccessStatusCode();
+
+    var html = await response.Content.ReadAsStringAsync(ct);
+    var document = await parser.ParseDocumentAsync(html);
+
+    // Extract data using CSS selectors
+    var items = document.QuerySelectorAll(".product-card").Select(card => new
+    {
+        Name = card.QuerySelector(".title")?.TextContent.Trim(),
+        Price = card.QuerySelector(".price")?.TextContent.Trim(),
+        Url = card.QuerySelector("a")?.GetAttribute("href"),
+    }).ToList();
+
+    return items;
+}, cancellationToken);
+```
+
+---
+
+## Phase 3B: Browser Automation Implementation (Tier 4)
+
+When the target requires a real browser (WAF, JS rendering, anti-bot), use Playwright with a multi-browser worker pool. This is a fundamentally different architecture from the HTTP-based templates above.
+
+**Template file:** `${CLAUDE_PLUGIN_ROOT}/skills/webscraping/template/BrowserProgram.cs` — a complete working template. Copy it and customize.
+
+**Key differences from HTTP-based scraping:**
+
+| Aspect | HTTP (Tier 1-3) | Browser (Tier 4) |
+|--------|-----------------|-------------------|
+| Client | `HttpClient` via `ProxyPool` | Playwright `IBrowser` per worker |
+| Proxy config | Per-request via `SocketsHttpHandler` | Per-browser at launch time |
+| Proxy rotation | Automatic LRU in `ProxyPool` | Close browser + relaunch with new proxy |
+| Concurrency | `SemaphoreSlim(proxyCount)` | N long-lived browser worker tasks |
+| Work distribution | `Task.Run` per page | `ConcurrentQueue` + worker loop |
+| Rate limiting | Per-proxy `SemaphoreSlim` in pool | `Task.Delay` between requests per worker |
+| Speed | 10-100x faster | Slow but bypasses anti-bot |
+
+### Architecture: Worker-Per-Browser
+
+Each worker owns a Playwright instance and browser, pulling work items from a shared queue:
+
+```
+ConcurrentQueue<WorkItem>
+├── Worker 0: Playwright → Browser (proxy A) → Page → scrape loop
+├── Worker 1: Playwright → Browser (proxy B) → Page → scrape loop
+├── Worker 2: Playwright → Browser (proxy C) → Page → scrape loop
+└── ...N workers
+```
+
+### Multi-Dimensional Work Queues
+
+Real scrapers often iterate over multiple dimensions, not just page numbers. Build your queue from whatever dimensions your target requires:
+
+```csharp
+// Example: country × HS code (739K combinations)
+var workQueue = new ConcurrentQueue<(string Country, string HsCode)>();
+foreach (var country in countries)
+    foreach (var hs in hsCodes)
+        if (!await db.IsCompletedAsync($"{country}:{hs}"))
+            workQueue.Enqueue((country, hs));
+
+// Example: category × subcategory
+var workQueue = new ConcurrentQueue<(string Category, string SubCategory)>();
+foreach (var cat in categories)
+    foreach (var sub in subcategories)
+        workQueue.Enqueue((cat, sub));
+
+// Example: list of URLs from a seed file
+var workQueue = new ConcurrentQueue<string>();
+foreach (var url in await File.ReadAllLinesAsync("urls.txt"))
+    if (!await db.IsCompletedAsync(url))
+        workQueue.Enqueue(url);
+```
+
+### Browser Worker Loop
+
+Each worker runs independently, pulling from the shared queue until it's empty or shutdown is requested:
+
+```csharp
+var workers = Enumerable.Range(0, ConcurrentBrowsers).Select(workerId => Task.Run(async () =>
+{
+    var pw = await Playwright.CreateAsync();
+    var proxyIndex = workerId % proxyList.Count;
+    var (browser, page) = await LaunchBrowser(pw, proxyList[proxyIndex]);
+    var consecutiveFailures = 0;
+    await using var workerDb = new ScraperDb(DbPath);
+
+    while (workQueue.TryDequeue(out var work))
+    {
+        cts.Token.ThrowIfCancellationRequested();
+        try
+        {
+            var results = await ScrapeWorkItem(page, work, cts.Token);
+            if (results.Count > 0)
+                await workerDb.AddBatchAsync(results, cts.Token);
+            await workerDb.CompleteWorkAsync(work.Key, cts.Token);
+            consecutiveFailures = 0;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            consecutiveFailures++;
+            if (consecutiveFailures >= MaxConsecutiveFailures)
+            {
+                // Rotate: close browser, relaunch with new proxy
+                proxyIndex = (proxyIndex + ConcurrentBrowsers) % proxyList.Count;
+                await browser.CloseAsync();
+                (browser, page) = await LaunchBrowser(pw, proxyList[proxyIndex]);
+                consecutiveFailures = 0;
+            }
+            // Re-queue for retry
+            workQueue.Enqueue(work);
+        }
+        await Task.Delay(DelayBetweenRequestsMs, cts.Token);
+    }
+
+    await browser.CloseAsync();
+    pw.Dispose();
+})).ToArray();
+
+await Task.WhenAll(workers);
+```
+
+### WAF / Challenge Detection
+
+Many sites show a challenge page (Cloudflare "Just a moment", custom WAF) before serving content. Detect it by title or content and wait for it to resolve:
+
+```csharp
+async Task WaitForChallenge(IPage page, int timeoutMs = 30000)
+{
+    var title = await page.TitleAsync();
+    if (title.Contains("WAF", StringComparison.OrdinalIgnoreCase) ||
+        title.Contains("Just a moment", StringComparison.OrdinalIgnoreCase) ||
+        title.Contains("Checking your browser", StringComparison.OrdinalIgnoreCase))
+    {
+        await page.WaitForFunctionAsync(
+            "() => !document.title.includes('WAF') && " +
+            "!document.title.includes('Just a moment') && " +
+            "!document.title.includes('Checking')",
+            null,
+            new() { Timeout = timeoutMs });
+    }
+}
+```
+
+Call this after every `GotoAsync`. If the wait times out, the challenge was not solvable — rotate to a new proxy.
+
+### Extracting `__NEXT_DATA__` via Browser
+
+When using Playwright on a Next.js site, extract the embedded JSON via `page.EvaluateAsync` (not AngleSharp):
+
+```csharp
+var json = await page.EvaluateAsync<string?>("""
+    (() => {
+        const el = document.getElementById('__NEXT_DATA__');
+        return el ? el.textContent : null;
+    })()
+""");
+
+if (json != null)
+{
+    using var doc = JsonDocument.Parse(json);
+    var pageProps = doc.RootElement
+        .GetProperty("props")
+        .GetProperty("pageProps");
+    // Extract your data from pageProps
+}
+```
+
+### Re-Queue on Failure
+
+Instead of retrying in-place (blocking the worker) or skipping (losing the work), re-queue failed items back to the shared queue. Another worker (possibly with a different proxy) will pick it up:
+
+```csharp
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"[worker-{id}] {work.Key} failed: {ex.Message}");
+    workQueue.Enqueue(work); // back of the queue — will be retried
+}
+```
+
+This is simpler than Polly retry for browser-based scraping and naturally spreads retries across different proxies. To prevent infinite retry loops, you can add a retry counter to your work item:
+
+```csharp
+record WorkItem(string Category, string Key, int Retries = 0);
+
+// In the catch block:
+if (work.Retries < 3)
+    workQueue.Enqueue(work with { Retries = work.Retries + 1 });
+else
+    Console.Error.WriteLine($"[worker-{id}] {work.Key} permanently failed after 3 retries");
+```
+
+### Browser Anti-Fingerprinting
+
+Minimal stealth setup for Playwright browsers:
+
+```csharp
+var browser = await playwright.Chromium.LaunchAsync(new()
+{
+    Headless = true,
+    Args = ["--disable-blink-features=AutomationControlled", "--no-sandbox"],
+    Proxy = new Proxy { Server = $"http://{proxy.Host}:{proxy.Port}",
+                        Username = proxy.User, Password = proxy.Pass },
+});
+
+var context = await browser.NewContextAsync(new()
+{
+    UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) ...",
+    ViewportSize = new() { Width = 1920, Height = 1080 },
+    Locale = "en-US",
+    TimezoneId = "America/New_York",
+});
+
+// Hide webdriver flag
+await context.AddInitScriptAsync(
+    "Object.defineProperty(navigator, 'webdriver', { get: () => false });");
+```
+
+See `references/headless-browser.md` for more stealth techniques, XHR interception, infinite scroll, and cookie handling.
+
+---
+
+## Phase 4: Checkpointing & Storage
+
+Every scraper MUST be resumable. A crash at row 50,000 should not require re-scraping from row 1.
+
+### Checkpoint Strategy (EF Core)
+
+The `ScraperDb` provides three core operations:
+
+| Method | Purpose |
+|--------|---------|
+| `db.IsCompletedAsync(key)` | Check if a work unit is done — skip on resume |
+| `db.UpdateProgressAsync(key, page, totalPages)` | Track page-level progress for in-flight work |
+| `db.CompleteWorkAsync(key)` | Atomic: deletes progress + marks completed in one transaction |
+| `db.GetProgressAsync(key)` | Read last page/cursor to resume from |
+| `ScraperDb.MakeKey("category", id, "variant")` | Build composite keys from parts |
+
+### Resume Pattern
+
+Every work unit follows this lifecycle:
+
+```csharp
+var key = ScraperDb.MakeKey("category", categoryId);
+
+// 1. Skip if already done
+if (await db.IsCompletedAsync(key)) continue;
+
+// 2. Check for partial progress
+var progress = await db.GetProgressAsync(key);
+var startPage = progress?.LastPage ?? 0;
+
+// 3. Scrape remaining pages
+for (var page = startPage + 1; page <= totalPages; page++)
+{
+    var data = await FetchPage(page, ct);
+
+    // Store data
+    await db.AddBatchAsync(data.Items.Select(MapToEntity), ct);
+
+    // Update progress after each page
+    await db.UpdateProgressAsync(key, page, totalPages, ct: ct);
+}
+
+// 4. Atomically mark complete (deletes progress record too)
+await db.CompleteWorkAsync(key);
+```
+
+### Adding a New Entity
+
+Register your entity in a derived `ScraperDb` or extend the base:
+
+```csharp
+// Define the entity
+public class Product
+{
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public decimal Price { get; set; }
+    public string? Category { get; set; }
+    public DateTime ScrapedAt { get; set; } = DateTime.UtcNow;
+}
+
+// Add to ScraperDb (extend the class)
+public class MyDb : ScraperDb
+{
+    public DbSet<Product> Products => Set<Product>();
+
+    public MyDb(string dbPath) : base(dbPath) { }
+
+    protected override void OnModelCreating(ModelBuilder m)
+    {
+        base.OnModelCreating(m); // keep checkpoint tables
+        m.Entity<Product>(e =>
+        {
+            e.HasKey(p => p.Id);
+            e.HasIndex(p => p.Category);
+        });
+    }
+}
+```
+
+### Storage Rules
+
+- **Primary storage:** SQLite with EF Core. Use unique constraints for built-in dedup.
+- **Batch writes:** Use `db.AddBatchAsync()` — wraps adds + save in a transaction. Do not call `SaveChangesAsync()` after every row.
+- **Export:** `CsvExporter.ExportAsync(db.Set<Product>(), "output.csv")` — streaming, constant memory via `IAsyncEnumerable`.
+- **WAL mode:** `ScraperDb.Create()` configures `PRAGMA journal_mode = WAL` and `PRAGMA synchronous = NORMAL` automatically for safe concurrent reads + fast writes.
+
+---
+
+## Phase 5: Anti-Bot / Rate Limit / CAPTCHA Bypass
+
+### Rate Limiting
+
+- **Per-proxy throttle**: Built into `ProxyPool` — `SemaphoreSlim(1)` + `MinRequestInterval` per proxy entry
+- **Global concurrency**: `SemaphoreSlim(proxyCount)` in the orchestrator — total parallel requests = proxy count
+- **Exponential backoff**: Polly `RetryStrategyOptions` — 2s -> 4s -> 8s -> ... with jitter on failure
+- **Retry-After**: Polly `DelayGenerator` reads the `Retry-After` response header and delays accordingly
+- **Adaptive**: if seeing 429s, increase `MinRequestInterval` dynamically (see Phase 6C)
+
+### Header Fingerprinting
+
+`Headers.Randomize()` in `Helpers/Headers.cs` rotates:
+- User-Agent (Chrome/Firefox/Safari/Edge x Windows/Mac/Linux)
+- Accept-Language (varies locale)
+- sec-ch-ua, sec-ch-ua-platform (matches User-Agent browser and OS)
+- Randomly includes/excludes Cache-Control and Pragma headers
+- Always sets proper Origin and Referer matching target domain
+- sec-fetch-dest, sec-fetch-mode, sec-fetch-site for Chromium and Firefox UAs
+
+**Important:** Update the version numbers in `Headers.cs` periodically to match current browser stable releases. Outdated UA versions are the number one fingerprinting signal for bot detection systems. Check https://chromiumdash.appspot.com/releases for current Chrome versions.
+
+### Proxy Rotation
+
+- Load from `proxies.txt` (multiple formats supported — see Phase 7C)
+- LRU selection — least-recently-used available proxy is picked next
+- Auto-blacklist with exponential expiry after N consecutive failures
+- After expiry window, proxy automatically re-enters rotation
+- Sustained success reduces strike count (rehabilitates proxies over time)
+- **Residential proxies** for anti-bot heavy sites
+- **Datacenter proxies** for unguarded APIs (faster, cheaper)
+
+### SOCKS5 Support
+
+.NET's `SocketsHttpHandler` supports SOCKS5 natively. Just prefix proxy URLs with `socks5://` in your `proxies.txt`:
+
+```
+socks5://user:pass@residential-proxy.example.com:1080
+```
+
+`ProxyPool` automatically detects the protocol and configures the handler accordingly.
+
+### Anti-Bot Escalation
+
+| Problem | Solution |
+|---------|----------|
+| **403 Forbidden** | Check for Cloudflare/Akamai. Try browser cookies. Switch to residential proxies. |
+| **429 Too Many Requests** | Increase MinRequestInterval. Add more proxies. Respect `Retry-After` header. Add jitter. |
+| **CAPTCHA** | Check for API endpoint that doesn't trigger it. Use browser cookies. Last resort: CAPTCHA solving service. |
+| **JS Challenge** | Playwright + stealth plugin. Or FlareSolverr service. |
+| **TLS Fingerprint** | Switch to browser automation or curl-impersonate. |
+| **Consistent blocks** | Rotate User-Agent versions in Headers.cs. Try mobile proxies. Reduce request rate. |
+
+### Request Timing
+
+Add human-like jitter between requests:
+
+```csharp
+// Between logical operations — random 500-2500ms
+var delay = Random.Shared.Next(500, 2500);
+await Task.Delay(delay, ct);
+
+// Vary page size if API allows it (makes traffic less uniform)
+int[] pageSizes = [10, 20, 25, 50];
+var pageSize = pageSizes[Random.Shared.Next(pageSizes.Length)];
+```
+
+---
+
+## Phase 6: Maximizing Performance Without Getting Rate Limited
+
+This phase covers how to extract maximum throughput from a proxy pool while staying under each proxy's rate limit.
+
+### 6A. Concurrency = Proxy Count
+
+Your maximum useful concurrency equals the number of available proxies. More concurrent workers than proxies means workers queue behind the same `SemaphoreSlim` gate, wasting thread pool resources.
+
+```csharp
+var concurrency = Math.Max(1, pool.AvailableCount);
+using var semaphore = new SemaphoreSlim(concurrency);
+```
+
+Do NOT set concurrency to an arbitrary number like 50 when you only have 10 proxies. The extra 40 workers will just block on the per-proxy gates.
+
+### 6B. Tune the Rate Interval, Not Concurrency
+
+The throughput formula is:
+
+```
+throughput = proxyCount / minRequestInterval
+```
+
+With 10 proxies at an 8-second interval, you get 10/8 = **1.25 requests/second**. To go faster:
+
+1. **Reduce the interval** (if the target allows it) — change `MinRequestInterval` in `ProxyPoolOptions`
+2. **Add more proxies** — append to `proxies.txt`
+
+Never increase concurrency beyond the proxy count. It does not help.
+
+| Proxies | Interval | Throughput |
+|---------|----------|------------|
+| 10 | 8s | 1.25 req/s |
+| 10 | 4s | 2.5 req/s |
+| 40 | 8s | 5.0 req/s |
+| 80 | 8s | 10.0 req/s |
+
+### 6C. Adaptive Throttling
+
+Start with a conservative interval (8s). Monitor error rates. Adjust dynamically:
+
+- If zero 429s for 100 consecutive requests, reduce interval by 20% (go faster)
+- If you see a 429, increase interval by 50% (slow down) and note the Retry-After
+
+Implement this as a feedback loop in the orchestrator:
+
+```csharp
+var interval = TimeSpan.FromSeconds(8);
+var consecutiveSuccesses = 0;
+
+void OnSuccess()
+{
+    consecutiveSuccesses++;
+    if (consecutiveSuccesses >= 100)
+    {
+        interval = TimeSpan.FromTicks((long)(interval.Ticks * 0.8)); // 20% faster
+        consecutiveSuccesses = 0;
+        Console.Error.WriteLine($"[adaptive] Reduced interval to {interval.TotalSeconds:F1}s");
+    }
+}
+
+void OnRateLimited()
+{
+    interval = TimeSpan.FromTicks((long)(interval.Ticks * 1.5)); // 50% slower
+    consecutiveSuccesses = 0;
+    Console.Error.WriteLine($"[adaptive] Increased interval to {interval.TotalSeconds:F1}s");
+}
+```
+
+Feed the adapted interval back into the proxy pool (or create a new pool with updated options). In practice, you can expose a mutable interval on `ProxyPoolOptions` or create a wrapper that adjusts the delay dynamically.
+
+### 6D. Connection Pooling
+
+`SocketsHttpHandler` pools TCP and TLS connections per host automatically. Configure it for scraping workloads:
+
+```csharp
+var handler = new SocketsHttpHandler
+{
+    PooledConnectionLifetime = TimeSpan.FromMinutes(5),  // recycle connections periodically
+    MaxConnectionsPerServer = 2,                         // avoid looking like a bot with 50 connections
+    EnableMultipleHttp2Connections = true,                // allow HTTP/2 multiplexing
+};
+```
+
+Each proxy's `HttpClient` in `ProxyPool` already has its own `SocketsHttpHandler` configured with `PooledConnectionLifetime = 5 min` and `AutomaticDecompression = All`.
+
+### 6E. Compression
+
+Always accept compressed responses. `SocketsHttpHandler` with `AutomaticDecompression = DecompressionMethods.All` handles gzip, deflate, and Brotli automatically. This reduces bandwidth by 60-80% and speeds up transfers, especially on slow residential proxies.
+
+The template's `ProxyPool.CreateClient()` already sets this. For direct `HttpClient` usage:
+
+```csharp
+var handler = new SocketsHttpHandler
+{
+    AutomaticDecompression = DecompressionMethods.All,  // gzip + deflate + brotli
+};
+using var client = new HttpClient(handler);
+```
+
+`Headers.Randomize()` also sets `Accept-Encoding: gzip, deflate, br` to signal the server that compressed responses are accepted.
+
+### 6F. Parallel Pagination
+
+For **page-number APIs**, fan out ALL pages across the proxy pool simultaneously:
+
+```csharp
+// Page 1 discovers totalPages, then fan out 2..N
+for (var page = 2; page <= totalPages; page++)
+{
+    await semaphore.WaitAsync(ct);
+    var p = page;
+    tasks.Add(Task.Run(async () =>
+    {
+        try { await FetchAndStorePage(p, ct); }
+        finally { semaphore.Release(); }
+    }));
+}
+await Task.WhenAll(tasks);
+```
+
+For **cursor-based APIs**, you CANNOT parallelize — pages must be fetched sequentially. Maximize throughput by using the proxy pool for each sequential request (LRU rotation means each request likely uses a different proxy, spreading the load across IPs).
+
+### 6G. Write Batching
+
+Do not call `SaveChangesAsync()` after every row. Batch writes to reduce database I/O:
+
+```csharp
+var batch = new List<MyEntity>(500);
+foreach (var item in data.Items)
+{
+    batch.Add(new MyEntity
+    {
+        Id = item.Id,
+        Name = item.Name,
+        // ...
+    });
+    if (batch.Count >= 500)
+    {
+        await db.AddBatchAsync(batch, ct);
+        batch.Clear();
+    }
+}
+if (batch.Count > 0) await db.AddBatchAsync(batch, ct);
+```
+
+`AddBatchAsync` wraps the add + save in a single transaction for atomicity. For very large scrapes (millions of rows), this reduces SQLite write overhead dramatically.
+
+### 6H. Monitor and Log
+
+Log every N pages with: current rate, error rate, proxy stats, and ETA.
+
+```csharp
+if (completedPages % 50 == 0)
+{
+    var stats = pool.GetStats();
+    var elapsed = DateTime.UtcNow - startTime;
+    var rate = completedPages / elapsed.TotalMinutes;
+    var eta = TimeSpan.FromMinutes((totalPages - completedPages) / rate);
+    Console.Error.WriteLine(
+        $"[progress] {completedPages}/{totalPages} ({rate:F1}/min, ETA {eta:hh\\:mm})");
+    Console.Error.WriteLine(
+        $"[proxies] {stats.Available}/{stats.Total} available, {stats.Blacklisted} blacklisted");
+}
+```
+
+This gives you real-time feedback on:
+- **Throughput** — are you hitting your expected rate?
+- **Proxy health** — are proxies getting blacklisted faster than expected?
+- **ETA** — how long until completion?
+
+Write to `Console.Error` (stderr) so logs do not mix with data output if you pipe stdout.
+
+---
+
+## Phase 7: Sourcing Proxies
+
+This phase helps you find and configure proxies for your scraping needs.
+
+### 7A. Proxy Types
+
+| Type | Speed | Cost | Anti-Bot Bypass | Best For |
+|------|-------|------|-----------------|----------|
+| Datacenter | Fast (1-10ms) | Cheap ($1-5/GB) | Low | Unguarded APIs, bulk data |
+| Residential | Medium (50-200ms) | Expensive ($5-15/GB) | High | Anti-bot sites, geo-restricted content |
+| Mobile | Slow (100-500ms) | Very expensive ($15-30/GB) | Very high | Hardest targets, social media |
+| ISP/Static Residential | Fast (5-20ms) | Medium ($3-8/GB) | Medium-High | Consistent sessions, account-based |
+
+**When to use each:**
+- Start with **datacenter** proxies. They are fast and cheap. Only escalate if you get blocked.
+- Switch to **residential** when you see Cloudflare challenges, consistent 403s, or CAPTCHAs.
+- Use **mobile** only for the hardest targets (social media platforms, heavily protected sites).
+- **ISP/static residential** proxies keep the same IP across sessions, useful for login-based scraping.
+
+### 7B. Providers
+
+Popular proxy providers (listed for reference, not endorsement):
+
+- **Rotating residential**: Bright Data, Oxylabs, Smartproxy, IPRoyal, SOAX
+- **Datacenter**: Webshare, Proxy-Cheap, Rayobyte
+- **Free (for testing only)**: free-proxy-list repos on GitHub (unreliable, slow, often dead — do not use for production scraping)
+
+When evaluating a provider, check:
+- Geographic coverage (does the target geo-restrict?)
+- Protocol support (HTTP vs SOCKS5)
+- Bandwidth pricing vs per-IP pricing
+- Concurrent connection limits
+
+### 7C. Proxy File Format
+
+Create a `proxies.txt` file with one proxy per line. All of these formats are supported:
+
+```
+# proxies.txt — one proxy per line
+# HTTP proxies
+host:port
+host:port:username:password
+http://username:password@host:port
+
+# SOCKS5 proxies (for residential/mobile)
+socks5://host:port
+socks5://username:password@host:port
+
+# Lines starting with # are comments
+# Blank lines are ignored
+```
+
+`ProxyPool.LoadAsync("proxies.txt")` parses all formats automatically and creates the appropriate `SocketsHttpHandler` with HTTP or SOCKS5 proxy configuration.
+
+### 7D. How Many Proxies Do You Need?
+
+Formula:
+
+```
+proxies_needed = target_requests_per_second * min_interval_seconds
+```
+
+| Target Rate | Interval per Proxy | Proxies Needed |
+|------------|-------------------|---------------|
+| 1 req/s | 8s | 8 |
+| 5 req/s | 8s | 40 |
+| 10 req/s | 8s | 80 |
+| 1 req/s | 3s | 3 |
+| 20 req/s | 8s | 160 |
+
+For a typical scrape of 100,000 pages:
+- At 1 req/s (8 proxies): ~28 hours
+- At 5 req/s (40 proxies): ~5.5 hours
+- At 10 req/s (80 proxies): ~2.8 hours
+
+Factor in overhead (retries, blacklist recovery, rate limit backoff) — real throughput is typically 60-80% of theoretical maximum.
+
+### 7E. Testing Your Proxies
+
+Before scraping, validate that your proxies work:
+
+```csharp
+// Quick health check after loading
+foreach (var status in pool.GetProxyStatuses())
+    Console.WriteLine($"{status.Proxy}: {(status.Available ? "OK" : "DOWN")}");
+```
+
+Or test individual proxies with curl before adding them:
+
+```bash
+# Test HTTP proxy
+curl -x http://user:pass@host:port https://httpbin.org/ip
+
+# Test SOCKS5 proxy
+curl --socks5-hostname user:pass@host:port https://httpbin.org/ip
+
+# Test with timeout (5 seconds)
+curl -x http://host:port --connect-timeout 5 https://httpbin.org/ip
+```
+
+Discard proxies that fail the basic connectivity test. Dead proxies in your pool waste time on connection timeouts before the blacklist kicks in.
+
+### 7F. Proxy Protocol Selection
+
+- Use **HTTP** proxies for datacenter providers and when the provider supports it — simpler, widely compatible
+- Use **SOCKS5** for residential and mobile proxies — many residential providers only offer SOCKS5
+- .NET's `SocketsHttpHandler` supports both natively — just prefix the URL with `socks5://` in your `proxies.txt`
+- If a provider offers both, prefer HTTP for speed (one fewer protocol layer)
+
+---
+
+## Reference Guides
+
+Detailed scenario-specific guides are in `${CLAUDE_PLUGIN_ROOT}/skills/webscraping/references/`:
+
+| File | Covers |
+|------|--------|
+| `rate-limiting.md` | Fixed limits, sliding windows, adaptive throttling, per-endpoint limits, API key rotation |
+| `headless-browser.md` | Playwright setup, proxy rotation, infinite scroll, XHR interception, cookie extraction, resource blocking |
+| `proxy-strategies.md` | Tiered escalation, geo-targeting, sticky sessions, health monitoring, warm-up, backconnect proxies |
+| `anti-bot-bypass.md` | TLS fingerprinting, Cloudflare/Akamai/PerimeterX bypass, browser fingerprinting, behavioral analysis, honeypots |
+| `authentication.md` | Cookie sessions, JWT/Bearer tokens, OAuth, CSRF handling, browser login → cookie extraction, session rotation |
+| `pagination-patterns.md` | Page number, offset/limit, cursor, keyset, infinite scroll, load-more, GraphQL, multi-level |
+| `data-extraction.md` | JSON APIs, HTML tables, embedded JSON (Next.js/Nuxt), CSS selectors, XHR interception, data cleaning |
+
+Read the relevant reference file before implementing when the scraping scenario involves that topic.
+
+---
+
+## Quick Reference
+
+| Task | Where |
+|------|-------|
+| Add scraper for new target | New `Program.cs`, import from `Services/`/`Data/`/`Helpers/` |
+| Change rate limits | `ProxyPoolOptions` — `MinRequestInterval`, `MaxConsecutiveFailures` |
+| Change retry behavior | Polly `RetryStrategyOptions` in `Program.cs` |
+| Add response fields | Update C# model + `DbSet` + `OnModelCreating` |
+| Add proxies | Append to `proxies.txt` |
+| Export data | `CsvExporter.ExportAsync(db.Set<T>(), path)` |
+| Run scraper | `dotnet run` |
+| Build release | `dotnet publish -c Release` |
+| Copy service modules | `cp -r ${CLAUDE_PLUGIN_ROOT}/skills/webscraping/template/{Services,Data,Helpers}/ ./` |
+| Check proxy health | `pool.GetProxyStatuses()` or `curl -x proxy https://httpbin.org/ip` |
+| Resume after crash | Just `dotnet run` again — checkpoints handle resume automatically |
+
+---
+
+## Instructions
+
+After reading this playbook, analyze the user's request below.
+1. Determine which phase to start from (per Phase 0 rules).
+2. State your plan in 2-3 sentences before beginning execution.
+3. At each CHECKPOINT, present your findings and wait for user confirmation.
+4. Adapt all templates to the actual target — do not use placeholder values.
+
+## User's Request
+
+$ARGUMENTS

--- a/plugins/webscraping/skills/webscraping/references/anti-bot-bypass.md
+++ b/plugins/webscraping/skills/webscraping/references/anti-bot-bypass.md
@@ -1,0 +1,299 @@
+# Anti-Bot Detection & Bypass Strategies
+
+## Detection Method 1: TLS Fingerprinting (JA3/JA4)
+
+### What it detects
+The server analyzes the TLS Client Hello packet to identify the client. Python's `requests`, Go's `net/http`, and .NET's `HttpClient` all have distinct TLS fingerprints that differ from real browsers.
+
+### How to know you're being fingerprinted
+- Getting 403s even with perfect headers
+- Same request works in browser but fails in code
+- Rotating User-Agent doesn't help
+- Changing proxies doesn't help
+
+### Bypass strategies
+
+```csharp
+// Option 1: Use browser automation (real browser TLS stack)
+// This is the most reliable bypass — Playwright/Puppeteer use Chromium's TLS
+
+// Option 2: Use curl-impersonate via Process
+// curl-impersonate mimics browser TLS fingerprints
+var process = new Process
+{
+    StartInfo = new ProcessStartInfo
+    {
+        FileName = "curl_chrome131", // curl-impersonate binary
+        Arguments = $"-s -o - \"{url}\"",
+        RedirectStandardOutput = true,
+        UseShellExecute = false,
+    }
+};
+process.Start();
+var output = await process.StandardOutput.ReadToEndAsync();
+await process.WaitForExitAsync();
+```
+
+## Detection Method 2: JavaScript Challenges (Cloudflare, Akamai, PerimeterX)
+
+### Cloudflare
+
+**Signals:** `cf-ray` header, `__cf_bm` cookie, challenge page with "Checking your browser..."
+
+```csharp
+// Strategy A: Solve challenge with browser, then use cookies in HttpClient
+using var playwright = await Playwright.CreateAsync();
+await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+{
+    Headless = true,
+    Args = new[] { "--disable-blink-features=AutomationControlled" },
+});
+
+var context = await browser.NewContextAsync();
+var page = await context.NewPageAsync();
+
+// Navigate — Cloudflare challenge will auto-solve
+await page.GotoAsync("https://target.com");
+await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+// Check if challenge was solved
+var title = await page.TitleAsync();
+if (title.Contains("Just a moment"))
+{
+    // Still on challenge page — wait longer
+    await page.WaitForURLAsync(url => !url.Contains("challenge"), new PageWaitForURLOptions
+    {
+        Timeout = 30000,
+    });
+}
+
+// Extract cookies for HttpClient use
+var cookies = await context.CookiesAsync();
+// Transfer to HttpClient handler (see headless-browser.md)
+```
+
+**Strategy B: FlareSolverr** (standalone service that solves Cloudflare challenges)
+
+```csharp
+// FlareSolverr runs as a Docker container
+// docker run -p 8191:8191 flaresolverr/flaresolverr
+
+var solverRequest = new
+{
+    cmd = "request.get",
+    url = "https://target.com/api/data",
+    maxTimeout = 60000,
+};
+
+using var client = new HttpClient();
+var response = await client.PostAsJsonAsync("http://localhost:8191/v1", solverRequest);
+var result = await response.Content.ReadFromJsonAsync<FlareSolverResult>();
+
+// result.Solution.Cookies contains the bypass cookies
+// result.Solution.Response contains the page HTML
+```
+
+### Akamai Bot Manager
+
+**Signals:** `_abck` cookie, `sensor_data` POST to `/-/166/...`
+
+- More aggressive than Cloudflare
+- Generates a device fingerprint via JavaScript
+- Checks mouse movements, keyboard events, touch events
+
+**Bypass:** Browser automation is usually the only option. Direct HTTP bypass is unreliable because the sensor data generation is obfuscated and changes frequently.
+
+### PerimeterX / HUMAN
+
+**Signals:** `_px3` cookie, `/api/v2/collector` requests
+
+- Similar to Akamai — JavaScript device fingerprinting
+- Checks WebGL rendering, canvas fingerprint, audio fingerprint
+
+**Bypass:** Browser automation with stealth plugins.
+
+## Detection Method 3: Browser Fingerprinting
+
+### What they check
+
+| Signal | Bot Indicator | Fix |
+|--------|--------------|-----|
+| `navigator.webdriver` | `true` | Override to `undefined` |
+| `navigator.plugins` | Empty array | Inject fake plugins |
+| `navigator.languages` | Missing or `[""]` | Set via context options |
+| Canvas fingerprint | Missing or uniform | Use real browser (Playwright) |
+| WebGL renderer | `SwiftShader` | Use headed mode or GPU flags |
+| `window.chrome` | Missing | Inject chrome object |
+| `Notification.permission` | `denied` in automation | Override |
+| Screen resolution | `0x0` or unusual | Set viewport in context |
+
+### Stealth overrides for Playwright
+
+```csharp
+await page.AddInitScriptAsync(@"
+    // Hide webdriver flag
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+
+    // Fake plugins
+    Object.defineProperty(navigator, 'plugins', {
+        get: () => [1, 2, 3, 4, 5],
+    });
+
+    // Fake languages
+    Object.defineProperty(navigator, 'languages', {
+        get: () => ['en-US', 'en'],
+    });
+
+    // Add chrome object
+    window.chrome = {
+        runtime: {},
+        loadTimes: function() {},
+        csi: function() {},
+        app: {},
+    };
+
+    // Override permissions
+    const originalQuery = window.navigator.permissions.query;
+    window.navigator.permissions.query = (parameters) =>
+        parameters.name === 'notifications'
+            ? Promise.resolve({ state: Notification.permission })
+            : originalQuery(parameters);
+");
+```
+
+## Detection Method 4: Behavioral Analysis
+
+### What they track
+- Request timing (too uniform = bot)
+- Navigation patterns (jumping directly to deep pages)
+- Mouse movements (none = bot)
+- Session duration (too fast = bot)
+
+### Bypass: Human-like behavior
+
+```csharp
+// Random delays between actions
+async Task HumanDelay(int minMs = 500, int maxMs = 3000)
+{
+    await Task.Delay(Random.Shared.Next(minMs, maxMs));
+}
+
+// Simulate browsing pattern: homepage → category → product
+await page.GotoAsync("https://example.com");
+await HumanDelay(2000, 5000);
+
+await page.ClickAsync("a[href='/products']");
+await HumanDelay(1000, 3000);
+
+await page.ClickAsync(".product-card:first-child a");
+await HumanDelay();
+
+// Random mouse movements
+await page.Mouse.MoveAsync(
+    Random.Shared.Next(100, 800),
+    Random.Shared.Next(100, 600)
+);
+```
+
+### Request timing jitter for direct HTTP
+
+```csharp
+// BAD: uniform timing (easily detected)
+await Task.Delay(1000);
+
+// GOOD: variable timing with natural distribution
+async Task NaturalDelay(double meanMs = 2000, double stdDevMs = 800)
+{
+    // Box-Muller transform for normal distribution
+    var u1 = Random.Shared.NextDouble();
+    var u2 = Random.Shared.NextDouble();
+    var normal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+    var delay = Math.Max(200, meanMs + normal * stdDevMs);
+    await Task.Delay((int)delay);
+}
+```
+
+## Detection Method 5: Honeypot Traps
+
+Hidden links or form fields designed to catch bots.
+
+```csharp
+// When parsing HTML, skip hidden elements
+var visibleLinks = document.QuerySelectorAll("a[href]")
+    .Where(a =>
+    {
+        var style = a.GetAttribute("style") ?? "";
+        var classes = a.ClassName ?? "";
+
+        // Skip elements with display:none, visibility:hidden, or zero dimensions
+        if (style.Contains("display:none") || style.Contains("display: none")) return false;
+        if (style.Contains("visibility:hidden") || style.Contains("visibility: hidden")) return false;
+        if (style.Contains("opacity:0") || style.Contains("opacity: 0")) return false;
+        if (classes.Contains("hidden") || classes.Contains("d-none")) return false;
+
+        // Skip elements positioned off-screen
+        if (style.Contains("position:absolute") && style.Contains("left:-")) return false;
+
+        return true;
+    })
+    .Select(a => a.GetAttribute("href"))
+    .Where(href => href != null)
+    .ToList();
+```
+
+## Detection Method 6: Header Consistency Checks
+
+The server checks if headers are consistent with a real browser.
+
+### Common mistakes that trigger detection
+
+| Mistake | Fix |
+|---------|-----|
+| Missing `sec-ch-ua` with Chrome UA | `Headers.Randomize()` handles this |
+| `sec-fetch-site: cross-site` for same-site requests | Set `sec-fetch-site: same-origin` |
+| `Referer` from a different domain | Set `Referer` to match target domain |
+| Accept-Language mismatch with proxy geo | Match locale to proxy country |
+| Missing Accept-Encoding | Always include `gzip, deflate, br` |
+| Header order different from browsers | Chrome sends in specific order — match it |
+
+### Correct header order for Chrome
+
+```csharp
+// Chrome sends headers in this specific order
+request.Headers.TryAddWithoutValidation("sec-ch-ua", "\"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"");
+request.Headers.TryAddWithoutValidation("sec-ch-ua-mobile", "?0");
+request.Headers.TryAddWithoutValidation("sec-ch-ua-platform", "\"Windows\"");
+request.Headers.TryAddWithoutValidation("Upgrade-Insecure-Requests", "1");
+request.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 ...");
+request.Headers.TryAddWithoutValidation("Accept", "text/html,application/xhtml+xml,...");
+request.Headers.TryAddWithoutValidation("Sec-Fetch-Site", "none");
+request.Headers.TryAddWithoutValidation("Sec-Fetch-Mode", "navigate");
+request.Headers.TryAddWithoutValidation("Sec-Fetch-User", "?1");
+request.Headers.TryAddWithoutValidation("Sec-Fetch-Dest", "document");
+request.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br, zstd");
+request.Headers.TryAddWithoutValidation("Accept-Language", "en-US,en;q=0.9");
+```
+
+## Escalation Decision Tree
+
+```
+Request fails with 403/challenge?
+├── Check: Is it TLS fingerprinting?
+│   ├── Yes → Try curl-impersonate or browser automation
+│   └── No ↓
+├── Check: Is it header-based detection?
+│   ├── Yes → Fix headers with Headers.Randomize(), match header order
+│   └── No ↓
+├── Check: Is it IP-based blocking?
+│   ├── Yes → Switch to residential proxies, reduce rate
+│   └── No ↓
+├── Check: Is it JavaScript challenge?
+│   ├── Cloudflare → FlareSolverr or browser + cookie extraction
+│   ├── Akamai/PerimeterX → Browser automation only
+│   └── No ↓
+├── Check: Is it behavioral?
+│   ├── Yes → Add jitter, simulate browsing patterns, use browser
+│   └── No ↓
+└── Investigate: Check the actual response body for clues
+    └── Look for: CAPTCHA forms, blocked messages, redirect URLs
+```

--- a/plugins/webscraping/skills/webscraping/references/authentication.md
+++ b/plugins/webscraping/skills/webscraping/references/authentication.md
@@ -1,0 +1,257 @@
+# Authenticated Scraping Patterns
+
+## Pattern 1: Cookie-Based Session Authentication
+
+Most common for traditional web applications.
+
+```csharp
+// Login and maintain session cookies automatically
+var handler = new HttpClientHandler
+{
+    CookieContainer = new CookieContainer(),
+    UseCookies = true,
+};
+using var client = new HttpClient(handler);
+
+// Login
+var loginContent = new FormUrlEncodedContent(new Dictionary<string, string>
+{
+    ["email"] = "user@example.com",
+    ["password"] = "password123",
+    ["_csrf"] = csrfToken, // if needed
+});
+
+var loginResponse = await client.PostAsync("https://example.com/login", loginContent);
+loginResponse.EnsureSuccessStatusCode();
+
+// Session cookies are now stored in CookieContainer
+// Subsequent requests include them automatically
+var dataResponse = await client.GetAsync("https://example.com/api/protected-data");
+```
+
+### Extracting CSRF tokens
+
+```csharp
+// Fetch login page to get CSRF token
+var loginPage = await client.GetStringAsync("https://example.com/login");
+var parser = new HtmlParser();
+var document = await parser.ParseDocumentAsync(loginPage);
+var csrfToken = document.QuerySelector("input[name='_csrf']")?.GetAttribute("value")
+    ?? document.QuerySelector("meta[name='csrf-token']")?.GetAttribute("content");
+```
+
+### Saving and restoring cookies
+
+```csharp
+// Save cookies to file for reuse across runs
+void SaveCookies(CookieContainer container, string domain, string path)
+{
+    var cookies = container.GetCookies(new Uri($"https://{domain}"));
+    var data = cookies.Cast<Cookie>().Select(c => new
+    {
+        c.Name, c.Value, c.Domain, c.Path, c.Expires, c.Secure, c.HttpOnly
+    });
+    File.WriteAllText(path, JsonSerializer.Serialize(data));
+}
+
+// Restore cookies
+void LoadCookies(CookieContainer container, string path)
+{
+    if (!File.Exists(path)) return;
+    var cookies = JsonSerializer.Deserialize<List<CookieData>>(File.ReadAllText(path));
+    foreach (var c in cookies!)
+    {
+        container.Add(new Cookie(c.Name, c.Value, c.Path, c.Domain)
+        {
+            Expires = c.Expires,
+            Secure = c.Secure,
+            HttpOnly = c.HttpOnly,
+        });
+    }
+}
+```
+
+## Pattern 2: Bearer Token / JWT Authentication
+
+Common for modern APIs and SPAs.
+
+```csharp
+// Obtain token
+var tokenResponse = await client.PostAsJsonAsync("https://api.example.com/auth/login", new
+{
+    email = "user@example.com",
+    password = "password123",
+});
+
+var tokenResult = await tokenResponse.Content.ReadFromJsonAsync<TokenResponse>();
+var accessToken = tokenResult!.AccessToken;
+var refreshToken = tokenResult.RefreshToken;
+var expiresAt = DateTime.UtcNow.AddSeconds(tokenResult.ExpiresIn);
+
+// Use token for subsequent requests
+async Task<HttpResponseMessage> AuthenticatedRequest(string url, CancellationToken ct)
+{
+    // Auto-refresh if expired
+    if (DateTime.UtcNow >= expiresAt.AddMinutes(-5))
+    {
+        await RefreshAccessToken();
+    }
+
+    var request = new HttpRequestMessage(HttpMethod.Get, url);
+    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+    Headers.Randomize(request);
+    return await client.SendAsync(request, ct);
+}
+
+async Task RefreshAccessToken()
+{
+    var refreshResponse = await client.PostAsJsonAsync("https://api.example.com/auth/refresh", new
+    {
+        refresh_token = refreshToken,
+    });
+    var result = await refreshResponse.Content.ReadFromJsonAsync<TokenResponse>();
+    accessToken = result!.AccessToken;
+    expiresAt = DateTime.UtcNow.AddSeconds(result.ExpiresIn);
+    Console.Error.WriteLine("[auth] Token refreshed");
+}
+
+record TokenResponse(string AccessToken, string RefreshToken, int ExpiresIn);
+```
+
+## Pattern 3: API Key Authentication
+
+```csharp
+// API key in header
+var request = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/data");
+request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
+
+// API key in query string
+var request2 = new HttpRequestMessage(HttpMethod.Get,
+    $"https://api.example.com/data?api_key={apiKey}&page={page}");
+
+// Rotating multiple API keys to distribute rate limits
+var apiKeys = File.ReadAllLines("api-keys.txt")
+    .Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith('#'))
+    .ToArray();
+var keyIndex = 0;
+
+string GetNextApiKey() => apiKeys[Interlocked.Increment(ref keyIndex) % apiKeys.Length];
+```
+
+## Pattern 4: OAuth 2.0 Client Credentials
+
+For APIs that require OAuth authentication.
+
+```csharp
+// Client credentials flow (server-to-server)
+var tokenRequest = new FormUrlEncodedContent(new Dictionary<string, string>
+{
+    ["grant_type"] = "client_credentials",
+    ["client_id"] = clientId,
+    ["client_secret"] = clientSecret,
+    ["scope"] = "read:data",
+});
+
+var tokenResponse = await client.PostAsync("https://auth.example.com/oauth/token", tokenRequest);
+var token = await tokenResponse.Content.ReadFromJsonAsync<OAuthTokenResponse>();
+```
+
+## Pattern 5: Browser Login → Cookie Extraction → HttpClient
+
+When the login flow is complex (CAPTCHA, MFA, OAuth redirect).
+
+```csharp
+using Microsoft.Playwright;
+
+// Use browser for the complex login flow
+using var playwright = await Playwright.CreateAsync();
+await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+{
+    Headless = false, // Show browser so user can solve CAPTCHA/MFA
+});
+
+var context = await browser.NewContextAsync();
+var page = await context.NewPageAsync();
+
+await page.GotoAsync("https://example.com/login");
+Console.Error.WriteLine("[auth] Please login in the browser window...");
+
+// Wait for successful login (detect by URL change or cookie presence)
+await page.WaitForURLAsync("**/dashboard**", new PageWaitForURLOptions
+{
+    Timeout = 120000, // 2 minutes for manual login
+});
+
+Console.Error.WriteLine("[auth] Login detected, extracting cookies...");
+
+// Extract cookies
+var cookies = await context.CookiesAsync();
+
+// Transfer to HttpClient
+var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
+foreach (var cookie in cookies)
+{
+    handler.CookieContainer.Add(new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain)
+    {
+        Secure = cookie.Secure,
+        HttpOnly = cookie.HttpOnly,
+    });
+}
+using var httpClient = new HttpClient(handler);
+
+// Save cookies for next run
+SaveCookies(handler.CookieContainer, "example.com", "session-cookies.json");
+
+// Now scrape with HttpClient (fast) using browser cookies
+await browser.CloseAsync(); // close browser, no longer needed
+```
+
+## Pattern 6: Session Rotation (Multiple Accounts)
+
+When you need multiple sessions to scale.
+
+```csharp
+// Load multiple sessions
+var sessions = new List<(HttpClient Client, string AccountId)>();
+foreach (var creds in accounts)
+{
+    var handler = new HttpClientHandler { CookieContainer = new CookieContainer() };
+    var client = new HttpClient(handler);
+
+    // Login with this account
+    var loginResp = await client.PostAsJsonAsync("https://example.com/api/login", new
+    {
+        email = creds.Email,
+        password = creds.Password,
+    });
+
+    if (loginResp.IsSuccessStatusCode)
+    {
+        sessions.Add((client, creds.Email));
+        Console.Error.WriteLine($"[auth] Logged in as {creds.Email}");
+    }
+}
+
+// Round-robin across sessions
+var sessionIndex = 0;
+var (sessionClient, _) = sessions[Interlocked.Increment(ref sessionIndex) % sessions.Count];
+```
+
+## Security Best Practices
+
+| Practice | Why |
+|----------|-----|
+| Store credentials in environment variables or separate config | Never hardcode in source |
+| Use `.gitignore` for cookie files and API key files | Prevent accidental commits |
+| Encrypt saved sessions at rest | Protect against disk access |
+| Rotate credentials periodically | Limit exposure window |
+| Use read-only API keys when possible | Minimize blast radius |
+| Never log tokens or passwords | Keep them out of stderr/stdout |
+
+```csharp
+// Load credentials from environment
+var email = Environment.GetEnvironmentVariable("SCRAPER_EMAIL")
+    ?? throw new Exception("SCRAPER_EMAIL not set");
+var password = Environment.GetEnvironmentVariable("SCRAPER_PASSWORD")
+    ?? throw new Exception("SCRAPER_PASSWORD not set");
+```

--- a/plugins/webscraping/skills/webscraping/references/data-extraction.md
+++ b/plugins/webscraping/skills/webscraping/references/data-extraction.md
@@ -1,0 +1,313 @@
+# Data Extraction Patterns
+
+## Pattern 1: JSON API Response
+
+The cleanest data source. Deserialize directly to typed models.
+
+```csharp
+// Strongly typed deserialization
+var response = await pool.ExecuteAsync(async (client, ct) =>
+{
+    var req = new HttpRequestMessage(HttpMethod.Get, "https://api.example.com/products?page=1");
+    Headers.Randomize(req);
+    var resp = await client.SendAsync(req, ct);
+    resp.EnsureSuccessStatusCode();
+    return await resp.Content.ReadFromJsonAsync<ApiResponse>(ct);
+}, ct);
+
+record ApiResponse(List<ProductDto> Data, int TotalPages, int TotalItems);
+record ProductDto(string Id, string Name, decimal Price, string? Category, string? ImageUrl);
+```
+
+### Handling inconsistent JSON (missing fields, wrong types)
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true,
+    NumberHandling = JsonNumberHandling.AllowReadingFromString, // "123" → 123
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+};
+
+// Use JsonDocument for dynamic/unpredictable structures
+using var doc = await JsonDocument.ParseAsync(stream);
+var root = doc.RootElement;
+
+// Safe extraction with fallbacks
+var name = root.TryGetProperty("name", out var nameProp) ? nameProp.GetString() : null;
+var price = root.TryGetProperty("price", out var priceProp)
+    ? priceProp.ValueKind == JsonValueKind.Number ? priceProp.GetDecimal()
+    : priceProp.ValueKind == JsonValueKind.String ? decimal.TryParse(priceProp.GetString(), out var p) ? p : 0
+    : 0
+    : 0;
+```
+
+## Pattern 2: HTML Table Extraction
+
+Common for directory sites, government data, legacy sites.
+
+```csharp
+using AngleSharp.Html.Parser;
+
+var parser = new HtmlParser();
+var document = await parser.ParseDocumentAsync(html);
+
+// Extract table rows
+var table = document.QuerySelector("table.data-table");
+var headers = table!.QuerySelectorAll("thead th")
+    .Select(th => th.TextContent.Trim().ToLowerInvariant())
+    .ToList();
+
+var rows = table.QuerySelectorAll("tbody tr").Select(tr =>
+{
+    var cells = tr.QuerySelectorAll("td").Select(td => td.TextContent.Trim()).ToList();
+    var dict = new Dictionary<string, string>();
+    for (var i = 0; i < Math.Min(headers.Count, cells.Count); i++)
+        dict[headers[i]] = cells[i];
+    return dict;
+}).ToList();
+
+// Map to entities
+var entities = rows.Select(row => new Product
+{
+    Name = row.GetValueOrDefault("product name", ""),
+    Price = decimal.TryParse(row.GetValueOrDefault("price", "")
+        .Replace("$", "").Replace(",", ""), out var p) ? p : 0,
+    Category = row.GetValueOrDefault("category", ""),
+}).ToList();
+```
+
+## Pattern 3: Embedded JSON in HTML (SSR Sites)
+
+Next.js, Nuxt.js, and similar SSR frameworks embed structured data in the HTML.
+
+```csharp
+// Next.js __NEXT_DATA__
+var nextDataScript = document.QuerySelector("script#__NEXT_DATA__");
+if (nextDataScript is not null)
+{
+    using var nextData = JsonDocument.Parse(nextDataScript.TextContent);
+    var pageProps = nextData.RootElement
+        .GetProperty("props")
+        .GetProperty("pageProps");
+
+    // Extract data from the SSR payload
+    var products = pageProps.GetProperty("products").Deserialize<List<ProductDto>>();
+}
+
+// Nuxt.js __NUXT__
+var nuxtScript = document.QuerySelectorAll("script")
+    .FirstOrDefault(s => s.TextContent.Contains("__NUXT__"));
+if (nuxtScript is not null)
+{
+    // Nuxt embeds as JS assignment, need to extract the JSON part
+    var match = Regex.Match(nuxtScript.TextContent, @"__NUXT__\s*=\s*(\{.+\})");
+    if (match.Success)
+    {
+        // Note: Nuxt payload may contain JS functions, not pure JSON
+        // May need a JS parser or browser evaluation
+    }
+}
+
+// Generic JSON-LD structured data
+var jsonLdScripts = document.QuerySelectorAll("script[type='application/ld+json']");
+foreach (var script in jsonLdScripts)
+{
+    using var jsonLd = JsonDocument.Parse(script.TextContent);
+    var type = jsonLd.RootElement.GetProperty("@type").GetString();
+    if (type == "Product")
+    {
+        var name = jsonLd.RootElement.GetProperty("name").GetString();
+        var price = jsonLd.RootElement.GetProperty("offers").GetProperty("price").GetString();
+    }
+}
+```
+
+## Pattern 4: CSS Selector Extraction
+
+For server-rendered HTML without embedded JSON.
+
+```csharp
+// Product listing page
+var products = document.QuerySelectorAll(".product-card").Select(card =>
+{
+    return new Product
+    {
+        Name = card.QuerySelector("h2.title, .product-name, [data-testid='name']")
+            ?.TextContent.Trim() ?? "",
+
+        Price = ParsePrice(card.QuerySelector(".price, .product-price, [data-price]")
+            ?.TextContent),
+
+        Url = card.QuerySelector("a[href]")?.GetAttribute("href") ?? "",
+
+        ImageUrl = card.QuerySelector("img")?.GetAttribute("src")
+            ?? card.QuerySelector("img")?.GetAttribute("data-src"), // lazy-loaded
+
+        Rating = ParseRating(card.QuerySelector(".rating, .stars")?.GetAttribute("aria-label")),
+
+        InStock = card.QuerySelector(".out-of-stock, .sold-out") is null,
+    };
+}).ToList();
+
+// Helper: parse "$1,234.56" → 1234.56
+static decimal ParsePrice(string? text)
+{
+    if (string.IsNullOrWhiteSpace(text)) return 0;
+    var cleaned = Regex.Replace(text, @"[^\d.]", "");
+    return decimal.TryParse(cleaned, out var p) ? p : 0;
+}
+
+// Helper: parse "4.5 out of 5 stars" → 4.5
+static double ParseRating(string? text)
+{
+    if (string.IsNullOrWhiteSpace(text)) return 0;
+    var match = Regex.Match(text, @"([\d.]+)");
+    return match.Success && double.TryParse(match.Value, out var r) ? r : 0;
+}
+```
+
+## Pattern 5: XHR/Fetch Interception (Browser)
+
+Capture API calls the frontend makes internally.
+
+```csharp
+var capturedData = new ConcurrentBag<JsonDocument>();
+
+page.Response += async (_, response) =>
+{
+    var url = response.Url;
+
+    // Capture specific API patterns
+    if ((url.Contains("/api/") || url.Contains("/graphql")) &&
+        response.Status == 200 &&
+        response.Headers.ContainsKey("content-type") &&
+        response.Headers["content-type"].Contains("json"))
+    {
+        try
+        {
+            var body = await response.BodyAsync();
+            var doc = JsonDocument.Parse(body);
+            capturedData.Add(doc);
+            Console.Error.WriteLine($"[intercept] Captured: {url} ({body.Length} bytes)");
+        }
+        catch { /* non-JSON response */ }
+    }
+};
+
+// Trigger the page to make API calls
+await page.GotoAsync("https://example.com/products");
+await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+// Process captured data
+foreach (var doc in capturedData)
+{
+    // Extract items from the captured API responses
+}
+```
+
+## Pattern 6: Multi-Format Extraction (Adapting to Unknown Sites)
+
+When you don't know the data format in advance.
+
+```csharp
+async Task<List<Dictionary<string, string>>> ExtractProducts(string html)
+{
+    var document = await new HtmlParser().ParseDocumentAsync(html);
+
+    // Strategy 1: Try JSON-LD
+    var jsonLd = document.QuerySelector("script[type='application/ld+json']");
+    if (jsonLd is not null)
+    {
+        try
+        {
+            var ld = JsonDocument.Parse(jsonLd.TextContent);
+            if (ld.RootElement.TryGetProperty("@type", out var type) &&
+                type.GetString() is "Product" or "ItemList")
+            {
+                return ExtractFromJsonLd(ld);
+            }
+        }
+        catch { }
+    }
+
+    // Strategy 2: Try __NEXT_DATA__
+    var nextData = document.QuerySelector("script#__NEXT_DATA__");
+    if (nextData is not null)
+    {
+        return ExtractFromNextData(nextData.TextContent);
+    }
+
+    // Strategy 3: Try common CSS patterns
+    var selectors = new[]
+    {
+        ".product-card", ".product-item", ".item-card",
+        "[data-product]", "[data-item]", ".listing-item",
+        "article.product", "li.product",
+    };
+
+    foreach (var selector in selectors)
+    {
+        var items = document.QuerySelectorAll(selector);
+        if (items.Length > 0)
+        {
+            return items.Select(ExtractFromElement).ToList();
+        }
+    }
+
+    // Strategy 4: Fall back to table extraction
+    var tables = document.QuerySelectorAll("table");
+    if (tables.Length > 0)
+    {
+        return ExtractFromTable(tables[0]);
+    }
+
+    return new List<Dictionary<string, string>>();
+}
+```
+
+## Data Cleaning Utilities
+
+```csharp
+static class DataCleaner
+{
+    // Remove HTML tags from text
+    public static string StripHtml(string html)
+        => Regex.Replace(html, "<[^>]+>", "").Trim();
+
+    // Normalize whitespace
+    public static string NormalizeWhitespace(string text)
+        => Regex.Replace(text.Trim(), @"\s+", " ");
+
+    // Extract numbers from text
+    public static decimal? ExtractDecimal(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        var match = Regex.Match(text, @"[\d,]+\.?\d*");
+        if (!match.Success) return null;
+        return decimal.TryParse(match.Value.Replace(",", ""), out var d) ? d : null;
+    }
+
+    // Parse dates in various formats
+    public static DateTime? ParseDate(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        string[] formats = { "yyyy-MM-dd", "MM/dd/yyyy", "dd/MM/yyyy",
+            "MMM dd, yyyy", "MMMM dd, yyyy", "yyyy-MM-ddTHH:mm:ss" };
+        return DateTime.TryParseExact(text.Trim(), formats, null,
+            System.Globalization.DateTimeStyles.None, out var d) ? d : null;
+    }
+
+    // Resolve relative URLs
+    public static string ResolveUrl(string? relativeUrl, string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(relativeUrl)) return "";
+        if (Uri.TryCreate(relativeUrl, UriKind.Absolute, out _)) return relativeUrl;
+        return new Uri(new Uri(baseUrl), relativeUrl).ToString();
+    }
+
+    // Deduplicate by key
+    public static List<T> DeduplicateBy<T, TKey>(IEnumerable<T> items, Func<T, TKey> keySelector)
+        => items.GroupBy(keySelector).Select(g => g.First()).ToList();
+}
+```

--- a/plugins/webscraping/skills/webscraping/references/headless-browser.md
+++ b/plugins/webscraping/skills/webscraping/references/headless-browser.md
@@ -1,0 +1,405 @@
+# Headless Browser Scraping with Playwright (.NET)
+
+Use browser automation only when lighter methods fail (Tier 4 — last resort).
+
+## When You Need a Headless Browser
+
+- Content rendered entirely by JavaScript (SPA with no SSR)
+- Anti-bot requiring real browser fingerprint (TLS, canvas, WebGL)
+- Interactions needed: clicks, scrolls, form submissions
+- Cloudflare JS challenge pages
+- Sites checking `navigator.webdriver` or similar bot signals
+
+## Setup
+
+```bash
+dotnet add package Microsoft.Playwright --version 1.52.0
+# Install browser binaries
+dotnet tool install --global Microsoft.Playwright.CLI
+playwright install chromium
+```
+
+## Basic Pattern — Single Page Scrape
+
+```csharp
+using Microsoft.Playwright;
+
+using var playwright = await Playwright.CreateAsync();
+await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+{
+    Headless = true,
+    Args = new[] { "--disable-blink-features=AutomationControlled" },
+});
+
+var context = await browser.NewContextAsync(new BrowserNewContextOptions
+{
+    UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    ViewportSize = new ViewportSize { Width = 1920, Height = 1080 },
+    Locale = "en-US",
+    TimezoneId = "America/New_York",
+});
+
+var page = await context.NewPageAsync();
+
+// Remove webdriver flag
+await page.AddInitScriptAsync(@"
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+    Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+");
+
+await page.GotoAsync("https://example.com/products", new PageGotoOptions
+{
+    WaitUntil = WaitUntilState.NetworkIdle,
+    Timeout = 30000,
+});
+
+// Wait for dynamic content
+await page.WaitForSelectorAsync(".product-card", new PageWaitForSelectorOptions
+{
+    Timeout = 10000,
+});
+
+// Extract data
+var products = await page.EvalOnSelectorAllAsync<List<Dictionary<string, string>>>(
+    ".product-card",
+    @"cards => cards.map(card => ({
+        name: card.querySelector('.title')?.textContent?.trim() ?? '',
+        price: card.querySelector('.price')?.textContent?.trim() ?? '',
+        url: card.querySelector('a')?.href ?? '',
+    }))"
+);
+```
+
+## With Proxy Rotation
+
+```csharp
+// Launch browser with proxy
+await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+{
+    Headless = true,
+    Proxy = new Proxy
+    {
+        Server = "http://proxy-host:8080",
+        Username = "user",
+        Password = "pass",
+    },
+});
+
+// Or SOCKS5
+await using var browser2 = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+{
+    Headless = true,
+    Proxy = new Proxy { Server = "socks5://proxy-host:1080" },
+});
+```
+
+### Rotating proxies per request
+
+```csharp
+// Read proxies from file
+var proxies = File.ReadAllLines("proxies.txt")
+    .Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith('#'))
+    .ToArray();
+var proxyIndex = 0;
+
+async Task<T> WithRotatingProxy<T>(Func<IPage, Task<T>> action)
+{
+    var proxyUrl = proxies[Interlocked.Increment(ref proxyIndex) % proxies.Length];
+
+    // Each request gets a fresh browser context with a different proxy
+    var context = await browser.NewContextAsync(new BrowserNewContextOptions
+    {
+        Proxy = new Proxy { Server = proxyUrl },
+        UserAgent = GetRandomUserAgent(),
+    });
+
+    try
+    {
+        var page = await context.NewPageAsync();
+        return await action(page);
+    }
+    finally
+    {
+        await context.CloseAsync();
+    }
+}
+```
+
+## Infinite Scroll Pattern
+
+```csharp
+var allItems = new List<ProductData>();
+var previousHeight = 0L;
+var maxScrolls = 50;
+
+for (var i = 0; i < maxScrolls; i++)
+{
+    // Scroll to bottom
+    var currentHeight = await page.EvaluateAsync<long>("document.body.scrollHeight");
+    if (currentHeight == previousHeight) break; // no new content loaded
+
+    await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
+
+    // Wait for new content to load
+    await page.WaitForTimeoutAsync(2000); // or WaitForResponse for XHR
+    previousHeight = currentHeight;
+
+    // Extract newly loaded items
+    var newItems = await page.EvalOnSelectorAllAsync<List<ProductData>>(
+        ".product-card:not([data-scraped])",
+        "cards => cards.map(c => ({ /* ... */ }))"
+    );
+    allItems.AddRange(newItems);
+
+    // Mark as scraped to avoid re-extraction
+    await page.EvaluateAsync(@"
+        document.querySelectorAll('.product-card:not([data-scraped])')
+            .forEach(c => c.setAttribute('data-scraped', 'true'));
+    ");
+
+    Console.Error.WriteLine($"[scroll] {i + 1}/{maxScrolls}, total items: {allItems.Count}");
+}
+```
+
+## Intercepting API Calls (Best of Both Worlds)
+
+Often the browser fetches data from an API internally. Intercept those calls to get structured JSON while the browser handles authentication/challenges.
+
+```csharp
+var apiResponses = new List<JsonDocument>();
+
+// Listen for API responses
+page.Response += async (_, response) =>
+{
+    if (response.Url.Contains("/api/products") && response.Status == 200)
+    {
+        var body = await response.BodyAsync();
+        var json = JsonDocument.Parse(body);
+        apiResponses.Add(json);
+        Console.Error.WriteLine($"[intercept] Captured API response: {response.Url}");
+    }
+};
+
+// Navigate — the browser makes the API calls, we capture the responses
+await page.GotoAsync("https://example.com/products");
+await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+// Now apiResponses contains the structured JSON data
+// No need to parse HTML at all
+```
+
+## Handling Login / Cookies
+
+```csharp
+// Login once, save cookies, reuse across sessions
+var context = await browser.NewContextAsync();
+var page = await context.NewPageAsync();
+
+// Login
+await page.GotoAsync("https://example.com/login");
+await page.FillAsync("#email", "user@example.com");
+await page.FillAsync("#password", "password123");
+await page.ClickAsync("button[type=submit]");
+await page.WaitForURLAsync("**/dashboard**");
+
+// Save cookies for reuse
+var cookies = await context.CookiesAsync();
+var cookieJson = JsonSerializer.Serialize(cookies);
+File.WriteAllText("cookies.json", cookieJson);
+
+// Later: restore cookies
+var savedCookies = JsonSerializer.Deserialize<List<Cookie>>(
+    File.ReadAllText("cookies.json"));
+await context.AddCookiesAsync(savedCookies);
+```
+
+## Performance Tips
+
+| Tip | Impact |
+|-----|--------|
+| Block images/fonts/CSS | 2-5x faster page loads |
+| Intercept XHR instead of parsing DOM | Structured data, no parsing |
+| Reuse browser context | Avoid launch overhead per request |
+| Set `WaitUntil = NetworkIdle` | Don't wait for unnecessary resources |
+| Use `page.WaitForSelector` | More reliable than fixed delays |
+
+### Block unnecessary resources
+
+```csharp
+await page.RouteAsync("**/*.{png,jpg,jpeg,gif,svg,woff,woff2,css}", async route =>
+{
+    await route.AbortAsync();
+});
+
+// Or block specific domains (analytics, ads)
+await page.RouteAsync("**/*", async route =>
+{
+    var url = route.Request.Url;
+    if (url.Contains("google-analytics") || url.Contains("facebook") || url.Contains("doubleclick"))
+        await route.AbortAsync();
+    else
+        await route.ContinueAsync();
+});
+```
+
+## Multi-Browser Orchestration
+
+For large-scale browser scraping, run N browser instances in parallel pulling from a shared work queue. Each browser has its own Playwright instance and proxy.
+
+```csharp
+// N workers, each with own Playwright + Browser + proxy
+var workers = Enumerable.Range(0, concurrentBrowsers).Select(id => Task.Run(async () =>
+{
+    var pw = await Playwright.CreateAsync();
+    var proxyIdx = id % proxies.Count;
+    var (browser, page) = await LaunchWithProxy(pw, proxies[proxyIdx]);
+    await using var db = new ScraperDb(dbPath);
+    var failures = 0;
+
+    while (workQueue.TryDequeue(out var work))
+    {
+        cts.Token.ThrowIfCancellationRequested();
+        try
+        {
+            await ScrapeItem(page, work, cts.Token);
+            await db.CompleteWorkAsync(work.Key, cts.Token);
+            failures = 0;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            failures++;
+            if (failures >= maxFailures)
+            {
+                // Kill browser, relaunch with different proxy
+                proxyIdx = (proxyIdx + concurrentBrowsers) % proxies.Count;
+                await browser.CloseAsync();
+                (browser, page) = await LaunchWithProxy(pw, proxies[proxyIdx]);
+                failures = 0;
+            }
+            workQueue.Enqueue(work); // re-queue for retry
+        }
+        await Task.Delay(delayMs, cts.Token);
+    }
+
+    await browser.CloseAsync();
+    pw.Dispose();
+})).ToArray();
+
+await Task.WhenAll(workers);
+```
+
+### Key design points:
+
+- **One Playwright instance per worker** — `Playwright.CreateAsync()` is not thread-safe across browsers. Each worker needs its own.
+- **One DbContext per worker** — EF Core DbContext is not thread-safe. Each worker creates its own.
+- **Proxy rotation = browser restart** — unlike HttpClient where you switch proxies per-request, Playwright proxies are set at launch. To rotate, close and relaunch.
+- **Re-queue on failure** — failed items go back to the queue for another worker (possibly different proxy) to retry.
+- **ConcurrentQueue** — thread-safe, lock-free. Workers call `TryDequeue` in a loop.
+
+### Resource considerations
+
+Each Chromium instance uses ~200-400 MB RAM. Plan accordingly:
+
+| Browsers | Approx RAM | Recommended VPS |
+|----------|-----------|-----------------|
+| 5 | 1-2 GB | 4 GB RAM |
+| 10 | 2-4 GB | 8 GB RAM |
+| 20 | 4-8 GB | 16 GB RAM |
+
+## WAF / Challenge Page Handling
+
+Many sites show a challenge page before serving content. Detect and wait for resolution:
+
+```csharp
+async Task<bool> WaitForChallenge(IPage page, int timeoutMs = 30000)
+{
+    var title = await page.TitleAsync();
+    var challengePatterns = new[] { "WAF", "Just a moment", "Checking your browser",
+                                    "Access denied", "Please wait" };
+
+    if (!challengePatterns.Any(p => title.Contains(p, StringComparison.OrdinalIgnoreCase)))
+        return true; // no challenge
+
+    try
+    {
+        // Build JS condition: title must not contain any challenge pattern
+        var condition = string.Join(" && ",
+            challengePatterns.Select(p => $"!document.title.includes('{p}')"));
+        await page.WaitForFunctionAsync($"() => {condition}", null,
+            new() { Timeout = timeoutMs });
+        return true; // challenge resolved
+    }
+    catch (TimeoutException)
+    {
+        return false; // challenge NOT resolved — rotate proxy
+    }
+}
+
+// Usage:
+await page.GotoAsync(url, new() { WaitUntil = WaitUntilState.DOMContentLoaded });
+if (!await WaitForChallenge(page))
+{
+    Console.Error.WriteLine($"[warn] Challenge not resolved for {url}");
+    // Trigger proxy rotation or skip this item
+}
+```
+
+## Extracting Embedded JSON via Browser
+
+When using Playwright on SSR sites (Next.js, Nuxt), extract embedded JSON via `EvaluateAsync` instead of HTML parsing:
+
+```csharp
+// Next.js __NEXT_DATA__
+var json = await page.EvaluateAsync<string?>("""
+    (() => {
+        const el = document.getElementById('__NEXT_DATA__');
+        return el ? el.textContent : null;
+    })()
+""");
+
+// Nuxt __NUXT_DATA__
+var nuxtJson = await page.EvaluateAsync<string?>("""
+    (() => {
+        const el = document.getElementById('__NUXT_DATA__');
+        return el ? el.textContent : null;
+    })()
+""");
+
+// Generic: extract any window variable
+var initialState = await page.EvaluateAsync<string?>("""
+    (() => {
+        const state = window.__INITIAL_STATE__ || window.__PRELOADED_STATE__;
+        return state ? JSON.stringify(state) : null;
+    })()
+""");
+```
+
+This is preferred over AngleSharp when you're already running a browser, because:
+1. The browser has already parsed and executed the page
+2. No need for a second parsing step
+3. Works even when anti-bot blocks direct HTTP requests
+
+## When to Switch Back to Direct HTTP
+
+After using the browser to solve an initial challenge, often you can:
+1. Extract cookies/tokens from the browser session
+2. Use those cookies with direct `HttpClient` requests (much faster)
+3. Only re-launch the browser when cookies expire
+
+```csharp
+// Solve challenge with browser
+await page.GotoAsync("https://example.com");
+var cookies = await context.CookiesAsync();
+
+// Transfer cookies to HttpClient
+var handler = new HttpClientHandler();
+foreach (var cookie in cookies)
+{
+    handler.CookieContainer.Add(new System.Net.Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain));
+}
+using var client = new HttpClient(handler);
+
+// Now scrape directly — 10-100x faster
+var response = await client.GetAsync("https://example.com/api/data");
+```

--- a/plugins/webscraping/skills/webscraping/references/pagination-patterns.md
+++ b/plugins/webscraping/skills/webscraping/references/pagination-patterns.md
@@ -1,0 +1,342 @@
+# Pagination Patterns Reference
+
+## Pattern 1: Page Number Pagination (Parallelizable)
+
+The most common pattern. Each page is independently addressable via `?page=N`.
+
+```csharp
+// Discover total pages from first request
+using var firstPage = await FetchPage(1, ct);
+var totalPages = firstPage.RootElement.GetProperty("total_pages").GetInt32();
+// OR: calculate from total count
+var totalItems = firstPage.RootElement.GetProperty("total").GetInt32();
+var pageSize = 50;
+var totalPages2 = (int)Math.Ceiling((double)totalItems / pageSize);
+
+// Fan out all pages in parallel
+var concurrency = Math.Max(1, pool.AvailableCount);
+using var semaphore = new SemaphoreSlim(concurrency);
+var tasks = new List<Task>();
+
+for (var page = 2; page <= totalPages; page++)
+{
+    var key = ScraperDb.MakeKey("page", page);
+    if (await db.IsCompletedAsync(key, ct)) continue;
+
+    await semaphore.WaitAsync(ct);
+    var p = page;
+    tasks.Add(Task.Run(async () =>
+    {
+        try
+        {
+            using var data = await FetchPage(p, ct);
+            await ProcessAndStore(data, ct);
+            await db.CompleteWorkAsync(key, ct);
+        }
+        finally { semaphore.Release(); }
+    }, ct));
+}
+await Task.WhenAll(tasks);
+```
+
+## Pattern 2: Offset/Limit Pagination (Parallelizable)
+
+Uses `?offset=N&limit=M` instead of page numbers. Same parallel strategy.
+
+```csharp
+var limit = 100;
+var totalItems = 5000; // from first response
+
+for (var offset = 0; offset < totalItems; offset += limit)
+{
+    var key = ScraperDb.MakeKey("offset", offset);
+    if (await db.IsCompletedAsync(key, ct)) continue;
+
+    await semaphore.WaitAsync(ct);
+    var currentOffset = offset;
+    tasks.Add(Task.Run(async () =>
+    {
+        try
+        {
+            var url = $"https://api.example.com/items?offset={currentOffset}&limit={limit}";
+            var data = await Fetch(url, ct);
+            await ProcessAndStore(data, ct);
+            await db.CompleteWorkAsync(key, ct);
+        }
+        finally { semaphore.Release(); }
+    }, ct));
+}
+```
+
+## Pattern 3: Cursor-Based Pagination (Sequential Only)
+
+Each response includes a cursor/token needed for the next request. Cannot parallelize.
+
+```csharp
+string? cursor = null;
+var pageNum = 0;
+
+// Resume from saved progress
+var progress = await db.GetProgressAsync("cursor-scrape");
+if (progress is not null)
+{
+    cursor = progress.Extra;
+    pageNum = progress.LastPage;
+    Console.Error.WriteLine($"[resume] From page {pageNum}, cursor={cursor}");
+}
+
+while (true)
+{
+    ct.ThrowIfCancellationRequested();
+    pageNum++;
+
+    var url = cursor is null
+        ? "https://api.example.com/items?limit=100"
+        : $"https://api.example.com/items?limit=100&after={cursor}";
+
+    var response = await pool.ExecuteAsync(async (client, innerCt) =>
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, url);
+        Headers.Randomize(req);
+        var resp = await client.SendAsync(req, innerCt);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<CursorResponse>(innerCt);
+    }, ct);
+
+    if (response?.Items is null or { Count: 0 }) break;
+
+    await db.AddBatchAsync(response.Items.Select(MapToEntity), ct);
+
+    cursor = response.NextCursor;
+    await db.UpdateProgressAsync("cursor-scrape", pageNum, extra: cursor, ct: ct);
+
+    if (cursor is null) break; // last page
+}
+
+await db.CompleteWorkAsync("cursor-scrape", ct);
+
+record CursorResponse(List<ItemDto> Items, string? NextCursor);
+```
+
+## Pattern 4: Keyset Pagination (Sequential, but Stable)
+
+Uses the last item's sort key (e.g., `?after_id=123&limit=100`). More stable than offset pagination for large datasets.
+
+```csharp
+string? lastId = null;
+var totalFetched = 0;
+
+// Resume from saved progress
+var progress = await db.GetProgressAsync("keyset-scrape");
+if (progress is not null)
+{
+    lastId = progress.Extra;
+    totalFetched = progress.LastPage;
+}
+
+while (true)
+{
+    var url = lastId is null
+        ? "https://api.example.com/items?limit=100&sort=id"
+        : $"https://api.example.com/items?limit=100&sort=id&after_id={lastId}";
+
+    var items = await Fetch<List<Item>>(url, ct);
+    if (items is null or { Count: 0 }) break;
+
+    await db.AddBatchAsync(items.Select(MapToEntity), ct);
+
+    lastId = items[^1].Id; // last item's ID
+    totalFetched += items.Count;
+    await db.UpdateProgressAsync("keyset-scrape", totalFetched, extra: lastId, ct: ct);
+
+    if (items.Count < 100) break; // partial page = last page
+}
+```
+
+## Pattern 5: Infinite Scroll (Browser Required)
+
+Content loads dynamically as user scrolls. Requires browser automation.
+
+```csharp
+var allItems = new List<ItemData>();
+var seenIds = new HashSet<string>();
+var maxScrollAttempts = 100;
+var noNewDataCount = 0;
+
+for (var i = 0; i < maxScrollAttempts; i++)
+{
+    // Extract current items
+    var items = await page.EvalOnSelectorAllAsync<List<ItemData>>(
+        ".item-card",
+        "cards => cards.map(c => ({ id: c.dataset.id, name: c.querySelector('.name')?.textContent }))"
+    );
+
+    var newItems = items.Where(item => seenIds.Add(item.Id)).ToList();
+    allItems.AddRange(newItems);
+
+    if (newItems.Count == 0)
+    {
+        noNewDataCount++;
+        if (noNewDataCount >= 3) break; // 3 scrolls with no new data = done
+    }
+    else
+    {
+        noNewDataCount = 0;
+    }
+
+    // Scroll down
+    await page.EvaluateAsync("window.scrollTo(0, document.body.scrollHeight)");
+    await page.WaitForTimeoutAsync(Random.Shared.Next(1500, 3000));
+
+    // Check for "Load more" button
+    var loadMore = await page.QuerySelectorAsync("button.load-more");
+    if (loadMore is not null)
+    {
+        await loadMore.ClickAsync();
+        await page.WaitForTimeoutAsync(2000);
+    }
+
+    Console.Error.WriteLine($"[scroll] {i + 1}, total unique items: {allItems.Count}");
+}
+```
+
+## Pattern 6: "Load More" Button
+
+Similar to infinite scroll but requires clicking a button.
+
+```csharp
+var allItems = new List<ItemData>();
+
+while (true)
+{
+    // Extract current items
+    var items = await page.EvalOnSelectorAllAsync<List<ItemData>>(".item", "...");
+    allItems.AddRange(items);
+
+    // Look for load more button
+    var loadMoreBtn = await page.QuerySelectorAsync("[data-testid='load-more'], .load-more, button:has-text('Load More')");
+    if (loadMoreBtn is null) break; // no more pages
+
+    // Check if button is disabled
+    var isDisabled = await loadMoreBtn.GetAttributeAsync("disabled");
+    if (isDisabled is not null) break;
+
+    await loadMoreBtn.ClickAsync();
+
+    // Wait for new content to load
+    var previousCount = items.Count;
+    await page.WaitForFunctionAsync(
+        $"document.querySelectorAll('.item').length > {allItems.Count}",
+        null,
+        new PageWaitForFunctionOptions { Timeout = 10000 }
+    );
+}
+```
+
+## Pattern 7: GraphQL Pagination
+
+GraphQL APIs often use cursor-based or connection-based pagination.
+
+```csharp
+// Relay-style cursor pagination
+string? endCursor = null;
+var hasNextPage = true;
+
+while (hasNextPage)
+{
+    var query = new
+    {
+        query = @"
+            query GetItems($after: String) {
+                items(first: 100, after: $after) {
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
+                    edges {
+                        node {
+                            id
+                            name
+                            price
+                        }
+                    }
+                }
+            }
+        ",
+        variables = new { after = endCursor },
+    };
+
+    var response = await pool.ExecuteAsync(async (client, ct) =>
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "https://api.example.com/graphql");
+        req.Content = JsonContent.Create(query);
+        Headers.Randomize(req);
+        var resp = await client.SendAsync(req, ct);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<GraphQLResponse>(ct);
+    }, ct);
+
+    var connection = response!.Data.Items;
+    hasNextPage = connection.PageInfo.HasNextPage;
+    endCursor = connection.PageInfo.EndCursor;
+
+    var items = connection.Edges.Select(e => e.Node);
+    await db.AddBatchAsync(items.Select(MapToEntity), ct);
+
+    await db.UpdateProgressAsync("graphql-scrape", pageNum++, extra: endCursor, ct: ct);
+}
+```
+
+## Pattern 8: Multi-Level Pagination (Category → Items)
+
+First paginate through categories, then paginate items within each.
+
+```csharp
+// Level 1: Get all categories
+var categories = await FetchAllCategories(ct);
+
+foreach (var category in categories)
+{
+    var categoryKey = ScraperDb.MakeKey("category", category.Id);
+    if (await db.IsCompletedAsync(categoryKey, ct)) continue;
+
+    // Level 2: Paginate items within this category
+    var progress = await db.GetProgressAsync(categoryKey);
+    var startPage = progress?.LastPage ?? 0;
+
+    for (var page = startPage + 1; ; page++)
+    {
+        var url = $"https://api.example.com/categories/{category.Id}/items?page={page}";
+        var items = await Fetch<PagedResponse>(url, ct);
+
+        if (items?.Data is null or { Count: 0 }) break;
+
+        await db.AddBatchAsync(items.Data.Select(MapToEntity), ct);
+        await db.UpdateProgressAsync(categoryKey, page, items.TotalPages, ct: ct);
+
+        if (page >= items.TotalPages) break;
+    }
+
+    await db.CompleteWorkAsync(categoryKey, ct);
+    Console.Error.WriteLine($"[progress] Category {category.Name} complete");
+}
+```
+
+## Choosing the Right Pattern
+
+| API Signals | Pattern | Parallelizable |
+|-------------|---------|----------------|
+| `?page=1&page=2` | Page number | Yes |
+| `?offset=0&limit=100` | Offset/limit | Yes |
+| Response has `nextCursor` or `next_token` | Cursor | No |
+| Response has `after_id` or `since_id` | Keyset | No |
+| No API, content loads on scroll | Infinite scroll | No |
+| GraphQL with `pageInfo.endCursor` | GraphQL cursor | No |
+| Multiple nested levels | Multi-level | Outer: depends, Inner: depends |
+
+### Maximizing throughput for sequential pagination
+
+When stuck with cursor-based pagination, maximize per-request throughput:
+1. Request the maximum `limit` the API allows
+2. Use the proxy pool so each sequential request uses a different IP (LRU rotation)
+3. Minimize delay between requests — the cursor dependency is the bottleneck, not rate limits

--- a/plugins/webscraping/skills/webscraping/references/proxy-strategies.md
+++ b/plugins/webscraping/skills/webscraping/references/proxy-strategies.md
@@ -1,0 +1,244 @@
+# Proxy Strategies & Patterns
+
+## Strategy 1: Tiered Proxy Escalation
+
+Start cheap, escalate only when blocked.
+
+```
+Attempt 1: No proxy (direct connection)
+    ↓ blocked?
+Attempt 2: Datacenter proxy ($1-5/GB)
+    ↓ blocked?
+Attempt 3: Residential proxy ($5-15/GB)
+    ↓ blocked?
+Attempt 4: Mobile proxy ($15-30/GB)
+```
+
+```csharp
+// Implement tiered escalation
+var tiers = new[]
+{
+    await ProxyPool.LoadAsync("proxies-datacenter.txt", new ProxyPoolOptions
+    {
+        MinRequestInterval = TimeSpan.FromSeconds(3),
+    }),
+    await ProxyPool.LoadAsync("proxies-residential.txt", new ProxyPoolOptions
+    {
+        MinRequestInterval = TimeSpan.FromSeconds(5),
+    }),
+};
+
+async Task<HttpResponseMessage> FetchWithEscalation(string url, CancellationToken ct)
+{
+    foreach (var pool in tiers)
+    {
+        try
+        {
+            return await pool.ExecuteAsync(async (client, innerCt) =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                Headers.Randomize(request);
+                var resp = await client.SendAsync(request, innerCt);
+                if (resp.StatusCode == HttpStatusCode.Forbidden)
+                    throw new HttpRequestException("Blocked, escalate");
+                return resp;
+            }, ct);
+        }
+        catch (HttpRequestException) { continue; }
+        catch (AllProxiesBlacklistedException) { continue; }
+    }
+    throw new Exception("All proxy tiers exhausted");
+}
+```
+
+## Strategy 2: Geo-Targeted Proxies
+
+When the target serves different content or blocks based on geography.
+
+```
+# proxies-us.txt — US residential proxies
+socks5://user:pass@us-proxy-1.example.com:1080
+socks5://user:pass@us-proxy-2.example.com:1080
+
+# proxies-eu.txt — EU residential proxies
+socks5://user:pass@eu-proxy-1.example.com:1080
+socks5://user:pass@eu-proxy-2.example.com:1080
+```
+
+```csharp
+// Load geo-specific pools
+var usPool = await ProxyPool.LoadAsync("proxies-us.txt", opts);
+var euPool = await ProxyPool.LoadAsync("proxies-eu.txt", opts);
+
+// Use the right pool for the right target
+var pool = targetDomain.EndsWith(".de") || targetDomain.EndsWith(".fr")
+    ? euPool
+    : usPool;
+```
+
+## Strategy 3: Sticky Sessions (Same IP for a Workflow)
+
+When you need the same IP across multiple requests (login → browse → scrape).
+
+```csharp
+// Get a specific proxy and reuse it for a session
+var (proxyClient, proxyId) = pool.AcquireSpecific(); // hypothetical API
+
+try
+{
+    // Login
+    var loginReq = new HttpRequestMessage(HttpMethod.Post, "https://example.com/login");
+    loginReq.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+    {
+        ["email"] = "user@example.com",
+        ["password"] = "pass",
+    });
+    Headers.Randomize(loginReq);
+    var loginResp = await proxyClient.SendAsync(loginReq);
+
+    // Scrape with same IP (cookies maintained by HttpClient's handler)
+    for (var page = 1; page <= totalPages; page++)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"https://example.com/api/data?page={page}");
+        Headers.Randomize(req);
+        var resp = await proxyClient.SendAsync(req);
+        // process...
+        await Task.Delay(2000); // polite delay on single IP
+    }
+}
+finally
+{
+    pool.Release(proxyId);
+}
+```
+
+## Strategy 4: Proxy Health Monitoring
+
+Continuously monitor and remove dead proxies.
+
+```csharp
+// Periodic health check running in background
+async Task MonitorProxyHealth(ProxyPool pool, CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested)
+    {
+        var stats = pool.GetStats();
+        Console.Error.WriteLine(
+            $"[proxy-health] Available: {stats.Available}/{stats.Total}, " +
+            $"Blacklisted: {stats.Blacklisted}, " +
+            $"Success rate: {stats.SuccessRate:P0}");
+
+        if (stats.Available == 0)
+        {
+            Console.Error.WriteLine(
+                $"[proxy-health] WARNING: All proxies down! " +
+                $"Next recovery at {stats.NextRecoveryTime:HH:mm:ss}");
+        }
+
+        await Task.Delay(TimeSpan.FromMinutes(1), ct);
+    }
+}
+
+// Run in background
+_ = Task.Run(() => MonitorProxyHealth(pool, cts.Token));
+```
+
+## Strategy 5: Proxy Pool Warm-Up
+
+Test all proxies before starting a long scrape.
+
+```csharp
+async Task<int> WarmUpProxies(ProxyPool pool, string testUrl, CancellationToken ct)
+{
+    var working = 0;
+    var failed = 0;
+
+    // Test each proxy with a lightweight request
+    var testTasks = Enumerable.Range(0, pool.TotalCount).Select(async _ =>
+    {
+        try
+        {
+            await pool.ExecuteAsync(async (client, innerCt) =>
+            {
+                var req = new HttpRequestMessage(HttpMethod.Head, testUrl);
+                var resp = await client.SendAsync(req, innerCt);
+                resp.EnsureSuccessStatusCode();
+                return true;
+            }, ct);
+            Interlocked.Increment(ref working);
+        }
+        catch
+        {
+            Interlocked.Increment(ref failed);
+        }
+    });
+
+    await Task.WhenAll(testTasks);
+    Console.Error.WriteLine($"[warm-up] {working} working, {failed} failed out of {pool.TotalCount}");
+    return working;
+}
+
+var workingCount = await WarmUpProxies(pool, "https://httpbin.org/ip", cts.Token);
+if (workingCount < 3)
+{
+    Console.Error.WriteLine("[warm-up] Too few working proxies, aborting");
+    return;
+}
+```
+
+## Strategy 6: Rotating Proxy Services (Backconnect)
+
+Some providers give you a single gateway URL that rotates IPs automatically.
+
+```
+# Backconnect proxy — each request gets a different IP
+# No need for multiple proxy entries
+gate.smartproxy.com:7777:user:pass
+```
+
+```csharp
+// With a backconnect proxy, you only need ONE entry but may want
+// multiple connections to parallelize
+var pool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    // Lower interval since the provider handles rotation
+    MinRequestInterval = TimeSpan.FromSeconds(1),
+});
+
+// The provider rotates IPs server-side, so each request
+// through the same gateway gets a different exit IP
+```
+
+## Proxy File Format Reference
+
+All supported formats in `proxies.txt`:
+
+```
+# === HTTP Proxies ===
+host:port
+host:port:username:password
+http://host:port
+http://username:password@host:port
+
+# === SOCKS5 Proxies ===
+socks5://host:port
+socks5://username:password@host:port
+
+# === With authentication ===
+http://user:pass@192.168.1.1:8080
+socks5://user:pass@10.0.0.1:1080
+
+# Comments and blank lines are ignored
+```
+
+## Cost Optimization
+
+| Strategy | Savings |
+|----------|---------|
+| Start with datacenter, escalate to residential only when blocked | 60-80% cost reduction |
+| Cache responses in SQLite — never re-fetch completed work | Eliminates duplicate bandwidth |
+| Block images/fonts when using browser automation | 50-70% bandwidth savings |
+| Use compression (gzip/brotli) | 60-80% bandwidth savings |
+| Run during off-peak hours (target's timezone) | Lower block rates, fewer retries |
+| Use backconnect proxies for high-volume | Simpler management, often cheaper at scale |

--- a/plugins/webscraping/skills/webscraping/references/rate-limiting.md
+++ b/plugins/webscraping/skills/webscraping/references/rate-limiting.md
@@ -1,0 +1,173 @@
+# Rate Limiting Scenarios & Solutions
+
+## Scenario 1: Fixed Rate Limit (e.g., 60 req/min per IP)
+
+The target returns `429 Too Many Requests` after exceeding a known threshold.
+
+```csharp
+// Configure proxy pool to stay under 1 req/sec per IP
+var pool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromSeconds(1.2), // 50 req/min, safely under 60
+});
+```
+
+### Detecting the limit
+
+```csharp
+// Log 429s to discover the actual threshold
+int requestCount = 0;
+var windowStart = DateTime.UtcNow;
+
+var result = await pool.ExecuteAsync(async (client, ct) =>
+{
+    var resp = await client.SendAsync(request, ct);
+    Interlocked.Increment(ref requestCount);
+
+    if (resp.StatusCode == HttpStatusCode.TooManyRequests)
+    {
+        var elapsed = DateTime.UtcNow - windowStart;
+        Console.Error.WriteLine(
+            $"[rate-limit] Hit 429 after {requestCount} requests in {elapsed.TotalSeconds:F0}s");
+
+        // Check Retry-After header
+        if (resp.Headers.RetryAfter?.Delta is { } delta)
+            Console.Error.WriteLine($"[rate-limit] Server says wait {delta.TotalSeconds}s");
+    }
+    return resp;
+}, ct);
+```
+
+## Scenario 2: Sliding Window Rate Limit
+
+The target tracks requests over a rolling window (e.g., 100 requests in any 60-second window).
+
+```csharp
+// Use a token bucket approach — track request timestamps per proxy
+// The ProxyPool's MinRequestInterval handles this naturally:
+// With 100 req/60s limit → interval = 60/100 = 0.6s per proxy
+var pool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromMilliseconds(700), // 0.7s, safely under 0.6s
+});
+```
+
+## Scenario 3: Adaptive Rate Limiting (Target Adjusts Dynamically)
+
+Some APIs slow you down progressively before hard-blocking.
+
+### Signals to watch for:
+- Response times increasing (server is throttling)
+- Partial data in responses (some fields omitted)
+- Degraded results quality
+- `X-RateLimit-Remaining` headers decreasing
+
+```csharp
+var interval = TimeSpan.FromSeconds(8);
+int consecutiveSuccesses = 0;
+int consecutive429s = 0;
+
+async Task<HttpResponseMessage> FetchWithAdaptiveRate(string url, CancellationToken ct)
+{
+    return await pool.ExecuteAsync(async (client, innerCt) =>
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        Headers.Randomize(request);
+        var response = await client.SendAsync(request, innerCt);
+
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            consecutive429s++;
+            consecutiveSuccesses = 0;
+
+            // Exponential backoff on repeated 429s
+            var backoff = Math.Min(consecutive429s * consecutive429s * 2, 120);
+            Console.Error.WriteLine($"[adaptive] 429 #{consecutive429s}, backing off {backoff}s");
+            await Task.Delay(TimeSpan.FromSeconds(backoff), innerCt);
+        }
+        else if (response.IsSuccessStatusCode)
+        {
+            consecutive429s = 0;
+            consecutiveSuccesses++;
+
+            // Speed up after sustained success
+            if (consecutiveSuccesses >= 100 && interval > TimeSpan.FromSeconds(2))
+            {
+                interval = TimeSpan.FromTicks((long)(interval.Ticks * 0.8));
+                consecutiveSuccesses = 0;
+                Console.Error.WriteLine($"[adaptive] Reduced interval to {interval.TotalSeconds:F1}s");
+            }
+        }
+
+        return response;
+    }, ct);
+}
+```
+
+## Scenario 4: Per-Endpoint Rate Limits
+
+Different endpoints have different limits (e.g., search: 10/min, detail: 60/min).
+
+```csharp
+// Use separate proxy pools or separate interval tracking per endpoint
+var searchPool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromSeconds(7), // ~8.5 req/min, under 10
+});
+
+var detailPool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromSeconds(1.2), // ~50 req/min, under 60
+});
+
+// Or use a single pool with manual delays between endpoint types
+```
+
+## Scenario 5: Rate Limit with API Keys / Tokens
+
+When the rate limit is tied to an API key, not an IP.
+
+```csharp
+// Rotate API keys alongside proxies
+var apiKeys = File.ReadAllLines("api-keys.txt")
+    .Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith('#'))
+    .ToArray();
+var keyIndex = 0;
+
+var result = await pool.ExecuteAsync(async (client, ct) =>
+{
+    var key = apiKeys[Interlocked.Increment(ref keyIndex) % apiKeys.Length];
+    var request = new HttpRequestMessage(HttpMethod.Get,
+        $"https://api.example.com/data?api_key={key}&page={page}");
+    Headers.Randomize(request);
+    return await client.SendAsync(request, ct);
+}, ct);
+```
+
+## Scenario 6: Retry-After with Absolute Timestamps
+
+Some servers return `Retry-After` as an HTTP date instead of seconds.
+
+```csharp
+// Polly handles both formats via the RetryAfter header parsing
+DelayGenerator = args =>
+{
+    var retryAfter = args.Outcome.Result?.Headers.RetryAfter;
+    if (retryAfter?.Delta is { } delta)
+        return ValueTask.FromResult<TimeSpan?>(delta);
+    if (retryAfter?.Date is { } date)
+    {
+        var wait = date - DateTimeOffset.UtcNow;
+        return ValueTask.FromResult<TimeSpan?>(wait > TimeSpan.Zero ? wait : TimeSpan.FromSeconds(1));
+    }
+    return ValueTask.FromResult<TimeSpan?>(null);
+},
+```
+
+## Key Principles
+
+1. **Measure before tuning** — discover the actual limit with a small burst, don't guess
+2. **Stay 10-20% under the limit** — jitter and clock skew can push you over
+3. **Respect Retry-After** — ignoring it often leads to escalating blocks
+4. **Per-IP vs per-account** — proxy rotation only helps with per-IP limits
+5. **Monitor continuously** — rate limits can change without notice

--- a/plugins/webscraping/skills/webscraping/template/BrowserProgram.cs
+++ b/plugins/webscraping/skills/webscraping/template/BrowserProgram.cs
@@ -1,0 +1,354 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Playwright;
+using Scraper.Data;
+
+// ============================================================================
+// BROWSER SCRAPER TEMPLATE — For targets requiring Playwright (Tier 4).
+//
+// Use this instead of Program.cs when the target has:
+//   - WAF / Cloudflare challenge pages
+//   - JS-rendered content (SPA or Next.js behind anti-bot)
+//   - Anti-bot checking navigator.webdriver or TLS fingerprint
+//
+// Steps:
+//   1. Define your work item type and DB entity below
+//   2. Register the entity in ScraperDb (add DbSet + OnModelCreating)
+//   3. Adjust concurrency and proxy settings
+//   4. Update ScrapeWorkItem() with your target's URL and extraction logic
+//   5. Run: dotnet run
+//
+// Key differences from the HTTP-based template:
+//   - N long-lived browser instances instead of HttpClient pool
+//   - Proxies configured at browser launch (not per-request)
+//   - Proxy rotation = close browser + relaunch with new proxy
+//   - WAF challenge detection + wait loop
+//   - Failed work items re-queued for retry
+// ============================================================================
+
+// --- 1. Configuration ---
+
+const int ConcurrentBrowsers = 10;
+const int DelayBetweenRequestsMs = 500;
+const int MaxConsecutiveFailures = 3;
+const string DbPath = "data.db";
+const string BaseUrl = "https://example.com";
+
+// --- 2. Load proxies ---
+
+var proxyList = new List<ProxyInfo>();
+foreach (var line in await File.ReadAllLinesAsync("proxies.txt"))
+{
+    var trimmed = line.Trim();
+    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith('#')) continue;
+    var parts = trimmed.Split(':');
+    if (parts.Length == 4)
+        proxyList.Add(new ProxyInfo(parts[0], int.Parse(parts[1]), parts[2], parts[3]));
+    else if (parts.Length == 2)
+        proxyList.Add(new ProxyInfo(parts[0], int.Parse(parts[1]), null, null));
+    else
+        Console.Error.WriteLine($"[proxy] Skipping malformed line: {trimmed}");
+}
+if (proxyList.Count == 0)
+    throw new InvalidOperationException("No proxies loaded from proxies.txt");
+Console.Error.WriteLine(
+    $"[proxy] Loaded {proxyList.Count} proxies " +
+    $"({proxyList.Count(p => p.User != null)} auth, " +
+    $"{proxyList.Count(p => p.User == null)} no-auth)");
+
+// --- 3. Database ---
+
+{
+    await using var initDb = new ScraperDb(DbPath);
+    await initDb.Database.EnsureCreatedAsync();
+    await initDb.Database.ExecuteSqlRawAsync("PRAGMA journal_mode = WAL;");
+    await initDb.Database.ExecuteSqlRawAsync("PRAGMA synchronous = NORMAL;");
+}
+
+// --- 4. Graceful shutdown ---
+
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    Console.Error.WriteLine("\n[shutdown] Ctrl+C received, finishing current requests...");
+    cts.Cancel();
+};
+
+// --- 5. Build work queue ---
+// Replace this with your own work item generation logic.
+// Multi-dimensional example: iterate over (category, page) or (country, hsCode).
+
+var workQueue = new ConcurrentQueue<WorkItem>();
+var totalWork = 0;
+{
+    await using var queueDb = new ScraperDb(DbPath);
+
+    // Example: load categories from a file, generate work items
+    var categories = await File.ReadAllLinesAsync("categories.txt");
+    foreach (var category in categories.Where(l => !string.IsNullOrWhiteSpace(l)))
+    {
+        var key = $"category:{category}";
+        if (!await queueDb.IsCompletedAsync(key))
+        {
+            workQueue.Enqueue(new WorkItem(category, key));
+            totalWork++;
+        }
+    }
+}
+
+var totalItems = totalWork; // adjust if you know total beforehand
+Console.Error.WriteLine($"[resume] {totalItems - totalWork} already done, {totalWork} remaining");
+
+if (totalWork == 0)
+{
+    Console.Error.WriteLine("[done] All work completed.");
+    return;
+}
+
+// --- 6. Launch browser workers ---
+
+var startTime = DateTime.UtcNow;
+var processed = 0;
+var totalResults = 0;
+
+var workers = Enumerable.Range(0, ConcurrentBrowsers).Select(workerId => Task.Run(async () =>
+{
+    IBrowser? browser = null;
+    IPlaywright? pw = null;
+    await using var workerDb = new ScraperDb(DbPath);
+    var proxyIndex = workerId % proxyList.Count;
+    var consecutiveFailures = 0;
+
+    // --- Browser launcher with proxy ---
+    async Task<(IBrowser Browser, IPage Page)> LaunchBrowser(IPlaywright playwright, int pIndex)
+    {
+        var proxy = proxyList[pIndex];
+        var launchOptions = new BrowserTypeLaunchOptions
+        {
+            Headless = true,
+            // Update this path to match your Playwright install location
+            // Find it: ls ~/.cache/ms-playwright/chromium-*/chrome-linux64/chrome
+            // ExecutablePath = "/home/user/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome",
+            Args = ["--disable-blink-features=AutomationControlled", "--no-sandbox"],
+            Proxy = new Proxy
+            {
+                Server = $"http://{proxy.Host}:{proxy.Port}",
+                Username = proxy.User,
+                Password = proxy.Pass,
+            },
+        };
+
+        var b = await playwright.Chromium.LaunchAsync(launchOptions);
+        var ctx = await b.NewContextAsync(new()
+        {
+            UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                        "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+            ViewportSize = new() { Width = 1920, Height = 1080 },
+            Locale = "en-US",
+        });
+
+        // Anti-fingerprinting: hide webdriver flag
+        await ctx.AddInitScriptAsync(
+            "Object.defineProperty(navigator, 'webdriver', { get: () => false });");
+
+        var p = await ctx.NewPageAsync();
+
+        // Optional: block unnecessary resources for speed
+        // await p.RouteAsync("**/*.{png,jpg,jpeg,gif,svg,woff,woff2,css}", r => r.AbortAsync());
+
+        Console.Error.WriteLine(
+            $"[worker-{workerId}] Browser launched via proxy " +
+            $"{proxy.Host}:{proxy.Port}{(proxy.User != null ? " (auth)" : "")}");
+        return (b, p);
+    }
+
+    try
+    {
+        pw = await Playwright.CreateAsync();
+        (browser, var page) = await LaunchBrowser(pw, proxyIndex);
+
+        while (workQueue.TryDequeue(out var work))
+        {
+            cts.Token.ThrowIfCancellationRequested();
+
+            try
+            {
+                var results = await ScrapeWorkItem(page, work, cts.Token);
+
+                if (results.Count > 0)
+                {
+                    await workerDb.AddBatchAsync(results, cts.Token);
+                    Interlocked.Add(ref totalResults, results.Count);
+                }
+
+                await workerDb.CompleteWorkAsync(work.Key, cts.Token);
+                consecutiveFailures = 0;
+                var done = Interlocked.Increment(ref processed);
+
+                // Progress reporting every 10 items
+                if (done % 10 == 0)
+                {
+                    var elapsed = DateTime.UtcNow - startTime;
+                    var rate = processed / elapsed.TotalMinutes;
+                    var remaining = totalWork - processed;
+                    var eta = rate > 0 ? TimeSpan.FromMinutes(remaining / rate) : TimeSpan.Zero;
+                    Console.Error.WriteLine(
+                        $"[progress] {done}/{totalWork} " +
+                        $"({rate:F1}/min, ETA {eta:hh\\:mm}) " +
+                        $"results: {totalResults}");
+                }
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[worker-{workerId}] {work.Key} failed: {ex.Message}");
+                consecutiveFailures++;
+
+                if (consecutiveFailures >= MaxConsecutiveFailures)
+                {
+                    // Rotate proxy: close browser, relaunch with different proxy
+                    var oldProxy = proxyList[proxyIndex];
+                    proxyIndex = (proxyIndex + ConcurrentBrowsers) % proxyList.Count;
+                    Console.Error.WriteLine(
+                        $"[worker-{workerId}] {consecutiveFailures} consecutive failures — " +
+                        $"swapping proxy {oldProxy.Host}:{oldProxy.Port} → " +
+                        $"{proxyList[proxyIndex].Host}:{proxyList[proxyIndex].Port}");
+
+                    try { if (browser != null) await browser.CloseAsync(); } catch { }
+                    (browser, page) = await LaunchBrowser(pw, proxyIndex);
+                    consecutiveFailures = 0;
+                }
+
+                // Re-queue failed work so it gets retried
+                workQueue.Enqueue(work);
+            }
+
+            await Task.Delay(DelayBetweenRequestsMs, cts.Token);
+        }
+    }
+    catch (OperationCanceledException) { /* shutdown */ }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"[worker-{workerId}] Fatal: {ex.Message}");
+    }
+    finally
+    {
+        if (browser != null) await browser.CloseAsync();
+        pw?.Dispose();
+    }
+}, cts.Token)).ToArray();
+
+try
+{
+    await Task.WhenAll(workers);
+    Console.Error.WriteLine($"\n[done] Scraped {totalResults} results total");
+
+    // TODO: Export results
+    // await using var finalDb = new ScraperDb(DbPath);
+    // var count = await CsvExporter.ExportAsync(finalDb.Set<YourEntity>(), "output.csv");
+}
+catch (OperationCanceledException)
+{
+    Console.Error.WriteLine("[shutdown] Interrupted. Progress saved — rerun to resume.");
+}
+
+// --- 7. Scrape function (customize for your target) ---
+
+async Task<List<YourEntity>> ScrapeWorkItem(IPage page, WorkItem work, CancellationToken ct)
+{
+    var allResults = new List<YourEntity>();
+
+    // Navigate to the target URL
+    var url = $"{BaseUrl}/{work.Category}";
+    await page.GotoAsync(url, new() { WaitUntil = WaitUntilState.DOMContentLoaded, Timeout = 30000 });
+
+    // --- WAF / challenge detection ---
+    var title = await page.TitleAsync();
+    if (title.Contains("WAF", StringComparison.OrdinalIgnoreCase) ||
+        title.Contains("Just a moment", StringComparison.OrdinalIgnoreCase) ||
+        title.Contains("Checking your browser", StringComparison.OrdinalIgnoreCase))
+    {
+        try
+        {
+            // Wait for the challenge to resolve (title changes when done)
+            await page.WaitForFunctionAsync(
+                "() => !document.title.includes('WAF') && " +
+                "!document.title.includes('Just a moment') && " +
+                "!document.title.includes('Checking')",
+                null,
+                new() { Timeout = 30000 });
+        }
+        catch
+        {
+            Console.Error.WriteLine($"  [warn] Challenge not resolved for {url}");
+            return allResults;
+        }
+    }
+
+    // Small delay for dynamic content to settle
+    await page.WaitForTimeoutAsync(1500);
+
+    // --- Extract data ---
+
+    // Option A: Extract __NEXT_DATA__ (Next.js sites)
+    var json = await page.EvaluateAsync<string?>("""
+        (() => {
+            const el = document.getElementById('__NEXT_DATA__');
+            return el ? el.textContent : null;
+        })()
+    """);
+
+    if (json != null)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("props", out var props) &&
+            props.TryGetProperty("pageProps", out var pageProps) &&
+            pageProps.TryGetProperty("data", out var data) &&
+            data.TryGetProperty("items", out var items))
+        {
+            foreach (var item in items.EnumerateArray())
+            {
+                allResults.Add(new YourEntity
+                {
+                    // Map JSON fields to your entity
+                    // Id = item.GetProp("id"),
+                    // Name = item.GetProp("name"),
+                });
+            }
+        }
+    }
+
+    // Option B: Extract via DOM evaluation (non-Next.js sites)
+    // var results = await page.EvalOnSelectorAllAsync<List<Dictionary<string, string>>>(
+    //     ".item-card",
+    //     "cards => cards.map(c => ({ name: c.querySelector('.title')?.textContent }))");
+
+    // Option C: Intercept XHR responses (see headless-browser.md reference)
+
+    return allResults;
+}
+
+// --- Models ---
+
+record ProxyInfo(string Host, int Port, string? User, string? Pass);
+
+record WorkItem(string Category, string Key);
+
+// Replace with your actual entity
+public class YourEntity
+{
+    public int Id { get; set; }
+    // Add your fields here
+}
+
+// --- JSON helper ---
+
+static class JsonExt
+{
+    public static string GetProp(this JsonElement el, string name)
+        => el.TryGetProperty(name, out var v) ? v.GetString() ?? "" : "";
+}

--- a/plugins/webscraping/skills/webscraping/template/Data/ScraperDb.cs
+++ b/plugins/webscraping/skills/webscraping/template/Data/ScraperDb.cs
@@ -1,0 +1,175 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Scraper.Data;
+
+// --- Entities ---
+
+public class Checkpoint
+{
+    public string Key { get; set; } = "";
+    public DateTime CompletedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class Progress
+{
+    public string Key { get; set; } = "";
+    public int LastPage { get; set; }
+    public int? TotalPages { get; set; }
+    public string? Extra { get; set; }
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// EF Core DbContext for scraper data with built-in checkpoint/progress tracking.
+///
+/// <para>Usage:</para>
+/// <code>
+/// await using var db = ScraperDb.Create("data.db");
+/// await db.Database.EnsureCreatedAsync();
+///
+/// // Add your own entity:
+/// // public DbSet&lt;Product&gt; Products =&gt; Set&lt;Product&gt;();
+///
+/// if (!await db.IsCompletedAsync("product::123"))
+/// {
+///     db.Products.Add(new Product { ... });
+///     await db.SaveChangesAsync();
+///     await db.CompleteWorkAsync("product::123");
+/// }
+/// </code>
+/// </summary>
+public class ScraperDb : DbContext
+{
+    public DbSet<Checkpoint> Checkpoints => Set<Checkpoint>();
+    public DbSet<Progress> Progress => Set<Progress>();
+
+    private readonly string _dbPath;
+
+    public ScraperDb(string dbPath)
+    {
+        _dbPath = dbPath;
+    }
+
+    // DbContextOptions constructor for DI scenarios
+    public ScraperDb(DbContextOptions<ScraperDb> options) : base(options) { }
+
+    /// <summary>Quick factory: create a context for a given database file.</summary>
+    public static ScraperDb Create(string dbPath = "data.db")
+    {
+        var db = new ScraperDb(dbPath);
+        db.Database.ExecuteSqlRaw("PRAGMA journal_mode = WAL");
+        db.Database.ExecuteSqlRaw("PRAGMA synchronous = NORMAL");
+        return db;
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+    {
+        if (!options.IsConfigured)
+            options.UseSqlite($"Data Source={_dbPath}");
+    }
+
+    protected override void OnModelCreating(ModelBuilder m)
+    {
+        m.Entity<Checkpoint>(e =>
+        {
+            e.ToTable("_checkpoints");
+            e.HasKey(c => c.Key);
+        });
+
+        m.Entity<Progress>(e =>
+        {
+            e.ToTable("_progress");
+            e.HasKey(p => p.Key);
+        });
+    }
+
+    // --- Checkpoint API ---
+
+    /// <summary>Check if a work unit has been completed.</summary>
+    public Task<bool> IsCompletedAsync(string key, CancellationToken ct = default) =>
+        Checkpoints.AnyAsync(c => c.Key == key, ct);
+
+    /// <summary>Check if a work unit has been completed (sync).</summary>
+    public bool IsCompleted(string key) =>
+        Checkpoints.Any(c => c.Key == key);
+
+    /// <summary>
+    /// Atomically delete progress and mark a work unit as completed.
+    /// Safe against crash: both operations are in a single transaction.
+    /// </summary>
+    public async Task CompleteWorkAsync(string key, CancellationToken ct = default)
+    {
+        await using var tx = await Database.BeginTransactionAsync(ct);
+        await Progress.Where(p => p.Key == key).ExecuteDeleteAsync(ct);
+        if (!await Checkpoints.AnyAsync(c => c.Key == key, ct))
+            Checkpoints.Add(new Checkpoint { Key = key });
+        await SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+    }
+
+    /// <summary>Build a composite checkpoint key from parts.</summary>
+    public static string MakeKey(params object[] parts) =>
+        string.Join("::", parts);
+
+    // --- Progress API ---
+
+    /// <summary>Update page progress for an in-flight work unit.</summary>
+    public async Task UpdateProgressAsync(
+        string key, int lastPage, int? totalPages = null,
+        string? extra = null, CancellationToken ct = default)
+    {
+        var existing = await Progress.FindAsync([key], ct);
+        if (existing is not null)
+        {
+            existing.LastPage = lastPage;
+            existing.TotalPages = totalPages;
+            existing.Extra = extra;
+            existing.UpdatedAt = DateTime.UtcNow;
+        }
+        else
+        {
+            Progress.Add(new Progress
+            {
+                Key = key,
+                LastPage = lastPage,
+                TotalPages = totalPages,
+                Extra = extra,
+            });
+        }
+        await SaveChangesAsync(ct);
+    }
+
+    /// <summary>Get progress for a work unit, or null if none.</summary>
+    public Task<Progress?> GetProgressAsync(string key, CancellationToken ct = default) =>
+        Progress.FindAsync([key], ct).AsTask();
+
+    /// <summary>List all in-flight work units (useful for resume reporting).</summary>
+    public async Task<List<Progress>> ListInFlightAsync(CancellationToken ct = default) =>
+        await Progress.OrderBy(p => p.Key).ToListAsync(ct);
+
+    /// <summary>List all completed keys (useful for stats).</summary>
+    public async Task<List<string>> ListCompletedKeysAsync(CancellationToken ct = default) =>
+        await Checkpoints.Select(c => c.Key).OrderBy(k => k).ToListAsync(ct);
+
+    // --- Bulk operations ---
+
+    /// <summary>
+    /// Add a batch of entities and save. Uses a transaction for atomicity.
+    /// Call with your own entity type: <c>await db.AddBatchAsync(products);</c>
+    /// </summary>
+    public async Task AddBatchAsync<T>(
+        IEnumerable<T> entities, CancellationToken ct = default) where T : class
+    {
+        await using var tx = await Database.BeginTransactionAsync(ct);
+        AddRange(entities);
+        await SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+    }
+
+    /// <summary>
+    /// Stream all rows of a given entity type as an async enumerable.
+    /// Use for memory-efficient export of large tables.
+    /// </summary>
+    public IAsyncEnumerable<T> StreamAllAsync<T>(CancellationToken ct = default) where T : class =>
+        Set<T>().AsNoTracking().AsAsyncEnumerable();
+}

--- a/plugins/webscraping/skills/webscraping/template/Helpers/CsvExporter.cs
+++ b/plugins/webscraping/skills/webscraping/template/Helpers/CsvExporter.cs
@@ -1,0 +1,74 @@
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Microsoft.EntityFrameworkCore;
+
+namespace Scraper.Helpers;
+
+/// <summary>
+/// Streaming CSV export using <c>IAsyncEnumerable</c> — true constant memory.
+/// </summary>
+public static class CsvExporter
+{
+    /// <summary>
+    /// Export all rows of a DbSet to CSV using streaming (constant memory).
+    /// </summary>
+    /// <returns>Number of rows written.</returns>
+    public static async Task<int> ExportAsync<T>(
+        IQueryable<T> query,
+        string outputPath,
+        CsvConfiguration? config = null,
+        CancellationToken ct = default) where T : class
+    {
+        config ??= new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+        };
+
+        await using var writer = new StreamWriter(outputPath);
+        await using var csv = new CsvWriter(writer, config);
+
+        csv.WriteHeader<T>();
+        await csv.NextRecordAsync();
+
+        var count = 0;
+        await foreach (var row in query.AsNoTracking().AsAsyncEnumerable().WithCancellation(ct))
+        {
+            csv.WriteRecord(row);
+            await csv.NextRecordAsync();
+            count++;
+
+            // Flush periodically to avoid buffering too much
+            if (count % 10_000 == 0)
+                await writer.FlushAsync(ct);
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Export any async enumerable to CSV (not tied to EF Core).
+    /// </summary>
+    public static async Task<int> ExportAsync<T>(
+        IAsyncEnumerable<T> source,
+        string outputPath,
+        CancellationToken ct = default)
+    {
+        var config = new CsvConfiguration(CultureInfo.InvariantCulture);
+        await using var writer = new StreamWriter(outputPath);
+        await using var csv = new CsvWriter(writer, config);
+
+        csv.WriteHeader<T>();
+        await csv.NextRecordAsync();
+
+        var count = 0;
+        await foreach (var row in source.WithCancellation(ct))
+        {
+            csv.WriteRecord(row);
+            await csv.NextRecordAsync();
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/plugins/webscraping/skills/webscraping/template/Helpers/Headers.cs
+++ b/plugins/webscraping/skills/webscraping/template/Helpers/Headers.cs
@@ -1,0 +1,129 @@
+using System.Text.RegularExpressions;
+
+namespace Scraper.Helpers;
+
+/// <summary>
+/// Generates randomized browser-like HTTP headers to avoid fingerprint detection.
+/// Headers are internally consistent (sec-ch-ua version matches User-Agent).
+///
+/// <para><b>Important:</b> Update the version numbers in <see cref="UserAgents"/>
+/// periodically to match current browser releases. Outdated versions are the #1
+/// fingerprinting signal for bot detection systems.</para>
+/// </summary>
+public static partial class Headers
+{
+    // --- UPDATE THESE periodically to match current stable releases ---
+    // Check: https://chromiumdash.appspot.com/releases
+    //        https://www.mozilla.org/en-US/firefox/releases/
+    //        https://developer.apple.com/documentation/safari-release-notes
+
+    private static readonly string[] UserAgents =
+    [
+        // Chrome (Windows)
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+        // Chrome (macOS)
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+        // Chrome (Linux)
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+        // Firefox (Windows)
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0",
+        // Firefox (macOS)
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:135.0) Gecko/20100101 Firefox/135.0",
+        // Safari (macOS)
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3 Safari/605.1.15",
+        // Edge (Windows)
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0",
+    ];
+
+    private static readonly string[] AcceptLanguages =
+    [
+        "en-US,en;q=0.9",
+        "en-GB,en;q=0.9",
+        "de-DE,de;q=0.9,en;q=0.8",
+        "fr-FR,fr;q=0.9,en;q=0.8",
+        "es-ES,es;q=0.9,en;q=0.8",
+        "en-US,en;q=0.9,de;q=0.7",
+    ];
+
+    /// <summary>
+    /// Apply randomized browser-like headers to an <see cref="HttpRequestMessage"/>.
+    /// Call this before sending each request.
+    /// </summary>
+    /// <param name="request">The request to modify.</param>
+    /// <param name="domain">
+    /// Origin domain for Origin/Referer headers.
+    /// If null, derived from the request URI.
+    /// </param>
+    public static void Randomize(HttpRequestMessage request, string? domain = null)
+    {
+        domain ??= request.RequestUri?.Host ?? "example.com";
+        var ua = Pick(UserAgents);
+
+        // --- Core headers every browser sends ---
+        request.Headers.TryAddWithoutValidation("User-Agent", ua);
+        request.Headers.TryAddWithoutValidation("Accept", "application/json, text/plain, */*");
+        request.Headers.TryAddWithoutValidation("Accept-Language", Pick(AcceptLanguages));
+        request.Headers.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br");
+        request.Headers.TryAddWithoutValidation("Connection", "keep-alive");
+        request.Headers.TryAddWithoutValidation("DNT", "1");
+        request.Headers.TryAddWithoutValidation("Origin", $"https://{domain}");
+        request.Headers.TryAddWithoutValidation("Referer", $"https://{domain}/");
+
+        // --- Chromium sec-ch-ua headers (Chrome and Edge) ---
+        if (ua.Contains("Chrome"))
+        {
+            var chromeVer = ChromeVersionRegex().Match(ua).Groups[1].Value;
+
+            if (ua.Contains("Edg"))
+            {
+                var edgeVer = EdgeVersionRegex().Match(ua).Groups[1].Value;
+                request.Headers.TryAddWithoutValidation("sec-ch-ua",
+                    $"\"Not A(Brand\";v=\"99\", \"Microsoft Edge\";v=\"{edgeVer}\", \"Chromium\";v=\"{chromeVer}\"");
+            }
+            else
+            {
+                request.Headers.TryAddWithoutValidation("sec-ch-ua",
+                    $"\"Not A(Brand\";v=\"99\", \"Google Chrome\";v=\"{chromeVer}\", \"Chromium\";v=\"{chromeVer}\"");
+            }
+
+            request.Headers.TryAddWithoutValidation("sec-ch-ua-mobile", "?0");
+            request.Headers.TryAddWithoutValidation("sec-ch-ua-platform",
+                ua.Contains("Windows") ? "\"Windows\"" :
+                ua.Contains("Mac") ? "\"macOS\"" : "\"Linux\"");
+        }
+
+        // --- sec-fetch-* headers (all modern browsers) ---
+        if (ua.Contains("Chrome") || ua.Contains("Firefox"))
+        {
+            request.Headers.TryAddWithoutValidation("sec-fetch-dest", "empty");
+            request.Headers.TryAddWithoutValidation("sec-fetch-mode", "cors");
+            request.Headers.TryAddWithoutValidation("sec-fetch-site", "same-origin");
+        }
+
+        // --- Random cache-control (some browsers send it, some don't) ---
+        if (Random.Shared.Next(2) == 0)
+        {
+            request.Headers.TryAddWithoutValidation("Cache-Control", "no-cache");
+            request.Headers.TryAddWithoutValidation("Pragma", "no-cache");
+        }
+    }
+
+    /// <summary>
+    /// Set Content-Type to application/json if the request has a body
+    /// and no Content-Type is already set.
+    /// </summary>
+    public static void EnsureJsonContentType(HttpRequestMessage request)
+    {
+        if (request.Content is not null && request.Content.Headers.ContentType is null)
+            request.Content.Headers.ContentType =
+                new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+    }
+
+    private static T Pick<T>(T[] arr) => arr[Random.Shared.Next(arr.Length)];
+
+    [GeneratedRegex(@"Chrome/(\d+)")]
+    private static partial Regex ChromeVersionRegex();
+
+    [GeneratedRegex(@"Edg/(\d+)")]
+    private static partial Regex EdgeVersionRegex();
+}

--- a/plugins/webscraping/skills/webscraping/template/Program.cs
+++ b/plugins/webscraping/skills/webscraping/template/Program.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Polly;
+using Polly.Retry;
+using Scraper.Data;
+using Scraper.Helpers;
+using Scraper.Services;
+
+// ============================================================================
+// SCRAPER TEMPLATE — Customize this file for your target.
+//
+// Steps:
+//   1. Define your response model and DB entity below
+//   2. Register the entity in ScraperDb (add DbSet + OnModelCreating)
+//   3. Adjust ProxyPoolOptions for your target's rate limits
+//   4. Update FetchPage() with your target's URL, method, and body
+//   5. Run: dotnet run
+// ============================================================================
+
+// --- 1. Configuration ---
+
+var proxyPool = await ProxyPool.LoadAsync("proxies.txt", new ProxyPoolOptions
+{
+    MinRequestInterval = TimeSpan.FromSeconds(8),   // 1 req per 8s per proxy
+    MaxConsecutiveFailures = 10,                     // blacklist after 10 failures
+    BaseBlacklistDuration = TimeSpan.FromMinutes(5), // 5min → 10min → 20min → ...
+    MaxBlacklistDuration = TimeSpan.FromHours(2),    // cap at 2 hours
+    RequestTimeout = TimeSpan.FromSeconds(30),
+});
+
+await using var db = ScraperDb.Create("data.db");
+await db.Database.EnsureCreatedAsync();
+
+// --- 2. Polly retry pipeline (respects Retry-After headers) ---
+
+var retryPipeline = new ResiliencePipelineBuilder<HttpResponseMessage>()
+    .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
+    {
+        ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
+            .HandleResult(r => r.StatusCode is
+                HttpStatusCode.TooManyRequests or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable or
+                HttpStatusCode.GatewayTimeout)
+            .Handle<HttpRequestException>()
+            .Handle<TaskCanceledException>(),
+        MaxRetryAttempts = 5,
+        BackoffType = DelayBackoffType.Exponential,
+        Delay = TimeSpan.FromSeconds(2),
+        UseJitter = true,
+        DelayGenerator = args =>
+        {
+            // Respect Retry-After header from the server
+            if (args.Outcome.Result?.Headers.RetryAfter?.Delta is { } delta)
+                return ValueTask.FromResult<TimeSpan?>(delta);
+            return ValueTask.FromResult<TimeSpan?>(null); // use default backoff
+        },
+        OnRetry = args =>
+        {
+            var status = args.Outcome.Result?.StatusCode;
+            Console.Error.WriteLine(
+                $"[retry] Attempt {args.AttemptNumber + 1}/5, " +
+                $"status={status}, delay={args.RetryDelay.TotalSeconds:F1}s");
+            return ValueTask.CompletedTask;
+        },
+    })
+    .Build();
+
+// --- 3. Graceful shutdown ---
+
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    Console.Error.WriteLine("\n[shutdown] Ctrl+C received, finishing current requests...");
+    cts.Cancel();
+};
+
+// --- 4. Fetch function (customize for your target) ---
+
+async Task<JsonDocument> FetchPage(int page, CancellationToken ct)
+{
+    return await proxyPool.ExecuteAsync(async (client, innerCt) =>
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://api.example.com/data")
+        {
+            Content = JsonContent.Create(new { page, pageSize = 50 }),
+        };
+        Headers.Randomize(request, "example.com");
+        Headers.EnsureJsonContentType(request);
+
+        var response = await retryPipeline.ExecuteAsync(
+            async _ => await client.SendAsync(request, innerCt),
+            innerCt);
+
+        response.EnsureSuccessStatusCode();
+
+        // Validate content type
+        var contentType = response.Content.Headers.ContentType?.MediaType ?? "";
+        if (!contentType.Contains("json"))
+        {
+            var preview = (await response.Content.ReadAsStringAsync(innerCt))[..200];
+            throw new InvalidOperationException(
+                $"Expected JSON but got {contentType}: {preview}");
+        }
+
+        return await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(innerCt), cancellationToken: innerCt);
+    }, ct);
+}
+
+// --- 5. Orchestrator (customize for your scraping pattern) ---
+
+try
+{
+    // Discover total pages from first request
+    using var firstPage = await FetchPage(1, cts.Token);
+    var totalPages = firstPage.RootElement.GetProperty("total_pages").GetInt32();
+    Console.Error.WriteLine($"[scraper] Total pages: {totalPages}");
+
+    // Process page 1
+    // TODO: Extract and store data from firstPage
+
+    // Fan out remaining pages across proxies
+    var concurrency = Math.Max(1, proxyPool.AvailableCount);
+    using var semaphore = new SemaphoreSlim(concurrency);
+    var tasks = new List<Task>();
+
+    for (var page = 2; page <= totalPages; page++)
+    {
+        cts.Token.ThrowIfCancellationRequested();
+
+        var key = ScraperDb.MakeKey("page", page);
+        if (await db.IsCompletedAsync(key, cts.Token))
+            continue;
+
+        await semaphore.WaitAsync(cts.Token);
+        var currentPage = page;
+
+        tasks.Add(Task.Run(async () =>
+        {
+            try
+            {
+                using var data = await FetchPage(currentPage, cts.Token);
+
+                // TODO: Parse data.RootElement and extract your entities
+                // var items = data.RootElement.GetProperty("items").EnumerateArray()
+                //     .Select(e => new YourEntity { ... });
+                // await db.AddBatchAsync(items, cts.Token);
+
+                await db.CompleteWorkAsync(key, cts.Token);
+
+                // Progress reporting
+                var stats = proxyPool.GetStats();
+                Console.Error.WriteLine(
+                    $"[scraper] Page {currentPage}/{totalPages} done | " +
+                    $"Proxies: {stats.Available}/{stats.Total} available");
+            }
+            catch (OperationCanceledException) { /* shutdown */ }
+            catch (AllProxiesBlacklistedException)
+            {
+                Console.Error.WriteLine(
+                    $"[scraper] Page {currentPage} deferred — all proxies blacklisted");
+                // The proxy pool has expiry; the orchestrator could retry later
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[scraper] Page {currentPage} failed: {ex.Message}");
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }, cts.Token));
+    }
+
+    await Task.WhenAll(tasks);
+
+    // --- 6. Export ---
+    // var count = await CsvExporter.ExportAsync(db.Set<YourEntity>(), "output.csv", ct: cts.Token);
+    // Console.Error.WriteLine($"[export] Wrote {count} rows to output.csv");
+
+    var finalStats = proxyPool.GetStats();
+    Console.Error.WriteLine(
+        $"\n[done] Successes: {finalStats.TotalSuccesses}, " +
+        $"Failures: {finalStats.TotalFailures}, " +
+        $"Blacklisted: {finalStats.Blacklisted}");
+}
+catch (OperationCanceledException)
+{
+    Console.Error.WriteLine("[shutdown] Scrape interrupted. Progress saved — rerun to resume.");
+}
+finally
+{
+    await proxyPool.DisposeAsync();
+}

--- a/plugins/webscraping/skills/webscraping/template/Scraper.csproj
+++ b/plugins/webscraping/skills/webscraping/template/Scraper.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Polly.Core" Version="8.6.5" />
+    <PackageReference Include="AngleSharp" Version="1.3.0" />
+    <PackageReference Include="CsvHelper" Version="33.0.0" />
+  </ItemGroup>
+</Project>

--- a/plugins/webscraping/skills/webscraping/template/Services/ProxyPool.cs
+++ b/plugins/webscraping/skills/webscraping/template/Services/ProxyPool.cs
@@ -1,0 +1,455 @@
+using System.Net;
+
+namespace Scraper.Services;
+
+/// <summary>Supported proxy protocols.</summary>
+public enum ProxyProtocol { Http, Socks5 }
+
+/// <summary>Immutable proxy connection info.</summary>
+public sealed record ProxyConfig(
+    string Host,
+    int Port,
+    string? Username = null,
+    string? Password = null,
+    ProxyProtocol Protocol = ProxyProtocol.Http)
+{
+    /// <summary>Safe display string (no credentials).</summary>
+    public override string ToString() =>
+        $"{Protocol.ToString().ToLowerInvariant()}://{Host}:{Port}";
+}
+
+/// <summary>Configuration for proxy pool behavior.</summary>
+public sealed class ProxyPoolOptions
+{
+    /// <summary>Max consecutive failures before blacklisting a proxy.</summary>
+    public int MaxConsecutiveFailures { get; init; } = 10;
+
+    /// <summary>Minimum interval between requests on the same proxy.</summary>
+    public TimeSpan MinRequestInterval { get; init; } = TimeSpan.FromSeconds(8);
+
+    /// <summary>
+    /// Base blacklist duration. Each successive blacklisting doubles it
+    /// (5 min -> 10 min -> 20 min -> 40 min -> 80 min -> capped).
+    /// </summary>
+    public TimeSpan BaseBlacklistDuration { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Maximum blacklist duration cap.</summary>
+    public TimeSpan MaxBlacklistDuration { get; init; } = TimeSpan.FromHours(2);
+
+    /// <summary>Per-request timeout.</summary>
+    public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
+}
+
+/// <summary>
+/// Runtime state for a single proxy: rate gate, failure tracking, blacklist with expiry.
+/// Each proxy owns its own <see cref="HttpClient"/> configured with that proxy's address.
+/// </summary>
+public sealed class ProxyEntry
+{
+    public ProxyConfig Config { get; }
+    public HttpClient Client { get; }
+
+    // --- Counters ---
+    public int ConsecutiveFailures { get; private set; }
+    public int TotalSuccesses { get; private set; }
+    public int TotalFailures { get; private set; }
+    public DateTime LastUsedAt { get; private set; }
+
+    // --- Blacklist with expiry ---
+    public int BlacklistCount { get; private set; }
+    public DateTime? BlacklistedUntil { get; private set; }
+
+    public bool IsBlacklisted =>
+        BlacklistedUntil.HasValue && DateTime.UtcNow < BlacklistedUntil.Value;
+
+    public bool IsAvailable => !IsBlacklisted;
+
+    // --- Per-proxy rate gate: 1 concurrent request, min interval between requests ---
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private DateTime _lastRequestTime;
+    private readonly TimeSpan _minInterval;
+
+    public ProxyEntry(ProxyConfig config, HttpClient client, TimeSpan minInterval)
+    {
+        Config = config;
+        Client = client;
+        _minInterval = minInterval;
+    }
+
+    /// <summary>
+    /// Execute an action through this proxy, respecting the per-proxy rate limit.
+    /// Only one request at a time; waits for the minimum interval between requests.
+    /// </summary>
+    public async Task<T> ExecuteAsync<T>(
+        Func<HttpClient, Task<T>> action, CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var elapsed = DateTime.UtcNow - _lastRequestTime;
+            if (elapsed < _minInterval)
+            {
+                // Add jitter: 80%-120% of the remaining delay
+                var remaining = _minInterval - elapsed;
+                var jitter = remaining * (0.8 + Random.Shared.NextDouble() * 0.4);
+                await Task.Delay(jitter, ct);
+            }
+
+            _lastRequestTime = DateTime.UtcNow;
+            LastUsedAt = DateTime.UtcNow;
+            return await action(Client);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>Record a successful request. Resets consecutive failure counter.</summary>
+    public void MarkSuccess()
+    {
+        ConsecutiveFailures = 0;
+        TotalSuccesses++;
+        // Gradually rehabilitate after sustained success
+        if (BlacklistCount > 0 && TotalSuccesses % 20 == 0)
+            BlacklistCount = Math.Max(0, BlacklistCount - 1);
+    }
+
+    /// <summary>
+    /// Record a failed request. If consecutive failures reach the threshold,
+    /// blacklists the proxy with exponentially increasing duration.
+    /// </summary>
+    public void MarkFailed(int maxFailures, TimeSpan baseDuration, TimeSpan maxDuration)
+    {
+        ConsecutiveFailures++;
+        TotalFailures++;
+        if (ConsecutiveFailures >= maxFailures)
+        {
+            BlacklistCount++;
+            var multiplier = 1L << Math.Min(BlacklistCount - 1, 5);
+            var ticks = Math.Min(baseDuration.Ticks * multiplier, maxDuration.Ticks);
+            BlacklistedUntil = DateTime.UtcNow + TimeSpan.FromTicks(ticks);
+            ConsecutiveFailures = 0;
+            Console.Error.WriteLine(
+                $"[proxy-pool] Blacklisted {Config} for " +
+                $"{TimeSpan.FromTicks(ticks).TotalMinutes:F1}min (strike #{BlacklistCount})");
+        }
+    }
+}
+
+/// <summary>
+/// Manages a pool of proxies with per-proxy rate limiting, LRU rotation,
+/// and automatic blacklisting with exponential expiry.
+///
+/// <para>
+/// Blacklist expiry: when a proxy accumulates too many consecutive failures
+/// it is blacklisted for <c>BaseBlacklistDuration * 2^(strikeCount-1)</c>,
+/// capped at <c>MaxBlacklistDuration</c>. After the expiry window passes
+/// the proxy automatically becomes available again. Sustained success
+/// gradually reduces the strike count.
+/// </para>
+/// </summary>
+public sealed class ProxyPool : IAsyncDisposable
+{
+    private readonly List<ProxyEntry> _entries = [];
+    private readonly ProxyPoolOptions _options;
+    private readonly Lock _lock = new();
+
+    public ProxyPool(ProxyPoolOptions? options = null)
+    {
+        _options = options ?? new();
+    }
+
+    /// <summary>Load proxies from a file.</summary>
+    public static async Task<ProxyPool> LoadAsync(
+        string path, ProxyPoolOptions? options = null)
+    {
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Proxy file not found: {path}", path);
+
+        var pool = new ProxyPool(options);
+        var text = await File.ReadAllTextAsync(path);
+        pool.LoadFromString(text);
+        return pool;
+    }
+
+    /// <summary>
+    /// Parse proxy definitions and create per-proxy HttpClients.
+    /// <para>Supported formats:</para>
+    /// <list type="bullet">
+    ///   <item><c>host:port</c></item>
+    ///   <item><c>host:port:user:pass</c></item>
+    ///   <item><c>socks5://host:port</c></item>
+    ///   <item><c>socks5://user:pass@host:port</c></item>
+    ///   <item><c>http://user:pass@host:port</c></item>
+    /// </list>
+    /// Lines starting with <c>#</c> are comments.
+    /// </summary>
+    public void LoadFromString(string text)
+    {
+        // Dispose previous clients if reloading
+        foreach (var entry in _entries) entry.Client.Dispose();
+        _entries.Clear();
+
+        var lines = text.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0 && !l.StartsWith('#'));
+
+        foreach (var line in lines)
+        {
+            var config = ParseProxy(line);
+            if (config is null)
+            {
+                Console.Error.WriteLine($"[proxy-pool] Skipping malformed line: {line}");
+                continue;
+            }
+            var client = CreateClient(config);
+            _entries.Add(new ProxyEntry(config, client, _options.MinRequestInterval));
+        }
+
+        Console.Error.WriteLine($"[proxy-pool] Loaded {_entries.Count} proxies");
+    }
+
+    /// <summary>Select the least-recently-used available proxy.</summary>
+    /// <exception cref="InvalidOperationException">No proxies loaded.</exception>
+    /// <exception cref="AllProxiesBlacklistedException">All proxies are blacklisted.</exception>
+    public ProxyEntry GetNext()
+    {
+        lock (_lock)
+        {
+            if (_entries.Count == 0)
+                throw new InvalidOperationException(
+                    "No proxies loaded. Call LoadAsync() or LoadFromString() first.");
+
+            var best = _entries
+                .Where(e => e.IsAvailable)
+                .MinBy(e => e.LastUsedAt);
+
+            if (best is null)
+            {
+                var soonest = _entries.MinBy(e => e.BlacklistedUntil)!;
+                throw new AllProxiesBlacklistedException(
+                    _entries.Count, soonest.BlacklistedUntil);
+            }
+
+            return best;
+        }
+    }
+
+    /// <summary>
+    /// High-level execution: pick a proxy via LRU, enforce the per-proxy rate limit,
+    /// execute the action, and automatically track success or failure.
+    /// <para>
+    /// Only transient errors (5xx, 429, network/timeout) count as proxy failures.
+    /// Client errors (4xx except 429) are rethrown without penalizing the proxy.
+    /// </para>
+    /// </summary>
+    public async Task<T> ExecuteAsync<T>(
+        Func<HttpClient, CancellationToken, Task<T>> action,
+        CancellationToken ct = default)
+    {
+        var proxy = GetNext();
+        try
+        {
+            var result = await proxy.ExecuteAsync(
+                client => action(client, ct), ct);
+            proxy.MarkSuccess();
+            return result;
+        }
+        catch (Exception ex) when (IsProxyFault(ex))
+        {
+            proxy.MarkFailed(
+                _options.MaxConsecutiveFailures,
+                _options.BaseBlacklistDuration,
+                _options.MaxBlacklistDuration);
+            throw;
+        }
+        // Non-proxy errors (400, 404, validation, etc.) rethrow without marking
+    }
+
+    /// <summary>
+    /// Wait until at least one proxy becomes available (blacklist expires),
+    /// then return it. Useful for callers that want to block instead of fail.
+    /// </summary>
+    public async Task<ProxyEntry> WaitForAvailableAsync(CancellationToken ct = default)
+    {
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                return GetNext();
+            }
+            catch (AllProxiesBlacklistedException ex)
+            {
+                if (ex.EarliestAvailableAt is { } earliest)
+                {
+                    var wait = earliest - DateTime.UtcNow;
+                    if (wait > TimeSpan.Zero)
+                    {
+                        Console.Error.WriteLine(
+                            $"[proxy-pool] All blacklisted. Waiting {wait.TotalSeconds:F0}s...");
+                        await Task.Delay(wait + TimeSpan.FromMilliseconds(100), ct);
+                    }
+                }
+                else
+                {
+                    await Task.Delay(1000, ct);
+                }
+            }
+        }
+    }
+
+    /// <summary>Is this error the proxy's fault (vs. application/target error)?</summary>
+    private static bool IsProxyFault(Exception ex) => ex switch
+    {
+        HttpRequestException { StatusCode: HttpStatusCode.TooManyRequests } => true,
+        HttpRequestException { StatusCode: >= HttpStatusCode.InternalServerError } => true,
+        HttpRequestException { StatusCode: null } => true, // network-level failure
+        TaskCanceledException => true, // timeout
+        _ => false,
+    };
+
+    // --- Stats ---
+
+    public int TotalCount => _entries.Count;
+
+    public int AvailableCount
+    {
+        get { lock (_lock) return _entries.Count(e => e.IsAvailable); }
+    }
+
+    public ProxyPoolStats GetStats()
+    {
+        lock (_lock)
+        {
+            return new(
+                Total: _entries.Count,
+                Available: _entries.Count(e => e.IsAvailable),
+                Blacklisted: _entries.Count(e => e.IsBlacklisted),
+                TotalSuccesses: _entries.Sum(e => e.TotalSuccesses),
+                TotalFailures: _entries.Sum(e => e.TotalFailures),
+                NextUnblacklistAt: _entries
+                    .Where(e => e.IsBlacklisted)
+                    .MinBy(e => e.BlacklistedUntil)?.BlacklistedUntil
+            );
+        }
+    }
+
+    /// <summary>Get per-proxy details for monitoring dashboards.</summary>
+    public IReadOnlyList<ProxyStatus> GetProxyStatuses()
+    {
+        lock (_lock)
+        {
+            return _entries.Select(e => new ProxyStatus(
+                Proxy: e.Config.ToString(),
+                Available: e.IsAvailable,
+                Successes: e.TotalSuccesses,
+                Failures: e.TotalFailures,
+                BlacklistedUntil: e.BlacklistedUntil,
+                BlacklistStrikes: e.BlacklistCount
+            )).ToList();
+        }
+    }
+
+    // --- Proxy parsing ---
+
+    internal static ProxyConfig? ParseProxy(string line)
+    {
+        var protocol = ProxyProtocol.Http;
+
+        if (line.StartsWith("socks5://", StringComparison.OrdinalIgnoreCase))
+        {
+            protocol = ProxyProtocol.Socks5;
+            line = line[9..];
+        }
+        else if (line.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            line = line[7..];
+        }
+
+        // user:pass@host:port format
+        string? username = null, password = null;
+        var atIdx = line.LastIndexOf('@');
+        if (atIdx >= 0)
+        {
+            var auth = line[..atIdx].Split(':', 2);
+            username = auth[0];
+            password = auth.Length > 1 ? auth[1] : null;
+            line = line[(atIdx + 1)..];
+        }
+
+        // host:port or host:port:user:pass
+        var parts = line.Split(':');
+        if (parts.Length < 2)
+            return null;
+        if (!int.TryParse(parts[1], out var port) || port is < 1 or > 65535)
+            return null;
+
+        // Legacy host:port:user:pass format
+        if (username is null && parts.Length >= 4)
+        {
+            username = parts[2];
+            password = parts[3];
+        }
+
+        return new ProxyConfig(parts[0], port, username, password, protocol);
+    }
+
+    private HttpClient CreateClient(ProxyConfig config)
+    {
+        var proxyUri = config.Protocol switch
+        {
+            ProxyProtocol.Socks5 => $"socks5://{config.Host}:{config.Port}",
+            _ => $"http://{config.Host}:{config.Port}",
+        };
+
+        var webProxy = new WebProxy(proxyUri);
+        if (config.Username is not null && config.Password is not null)
+            webProxy.Credentials = new NetworkCredential(config.Username, config.Password);
+
+        var handler = new SocketsHttpHandler
+        {
+            Proxy = webProxy,
+            UseProxy = true,
+            CookieContainer = new CookieContainer(),
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            AutomaticDecompression = DecompressionMethods.All,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+        };
+
+        return new HttpClient(handler) { Timeout = _options.RequestTimeout };
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var entry in _entries)
+            entry.Client.Dispose();
+        _entries.Clear();
+    }
+}
+
+// --- Supporting types ---
+
+public sealed record ProxyPoolStats(
+    int Total,
+    int Available,
+    int Blacklisted,
+    int TotalSuccesses,
+    int TotalFailures,
+    DateTime? NextUnblacklistAt);
+
+public sealed record ProxyStatus(
+    string Proxy,
+    bool Available,
+    int Successes,
+    int Failures,
+    DateTime? BlacklistedUntil,
+    int BlacklistStrikes);
+
+public sealed class AllProxiesBlacklistedException(int total, DateTime? earliest)
+    : Exception($"All {total} proxies blacklisted. Next available: {earliest:HH:mm:ss}")
+{
+    public int TotalProxies => total;
+    public DateTime? EarliestAvailableAt => earliest;
+}


### PR DESCRIPTION
## Problem / Task

This PR introduces a standalone `webscraping` plugin extracted from local `~/.claude/skills` into the plugin architecture, and rebrands all author/repository references from `vikyw89`/`FINGU-GRINDA` to `code-salad`.

**Current behavior:** Webscraping and recon skills existed only as local user-level skills, not installable as a plugin. All repo references pointed to the old org/user.

**Expected behavior:** Users can install the webscraping plugin via `claude plugin install code-salad/looper`. Recon and webscraping skills are self-contained under `plugins/webscraping/`.

## Existing Architecture

Skills lived in the user's local `~/.claude/skills/` directory — not part of any installable plugin.

```mermaid
graph TD
    A[User installs looper plugin] --> B[looper skills only]
    C[~/.claude/skills/webscraping] -->|manual copy| D[User machine]
    E[~/.claude/skills/recon] -->|manual copy| D
    style C fill:#f66,stroke:#333
    style E fill:#f66,stroke:#333
```

## Proposed Architecture

Webscraping and recon are now a proper plugin, installable alongside looper.

```mermaid
graph TD
    A[code-salad/looper repo] --> B[plugins/looper]
    A --> C[plugins/webscraping]
    C --> D[skills/webscraping\nSKILL.md + template/ + references/]
    C --> E[skills/recon\nSKILL.md + references/]
    D -->|spawns sub-skill| E
    style C fill:#6f6,stroke:#333
    style D fill:#69f,stroke:#333
    style E fill:#69f,stroke:#333
```

## Key Changes

- **New plugin** `plugins/webscraping/` with `.claude-plugin/plugin.json` (name: `webscraping`, v0.1.0)
- **Two skills** under the plugin:
  - `webscraping` — full .NET 10 scraping pipeline (method selection, checkpointing, anti-detection, proxy management, browser automation via Playwright)
  - `recon` — domain reconnaissance (subdomains, API endpoints, JS bundle analysis, structured report)
- **Path references** updated from `~/.claude/skills/...` → `${CLAUDE_PLUGIN_ROOT}/skills/...` so they resolve correctly regardless of install location
- **Sub-skill invocation** updated from `/recon` → `/webscraping:recon` to use plugin namespace
- **Rebrand** — all occurrences of `vikyw89` and `FINGU-GRINDA` replaced with `code-salad` across plugin manifests, READMEs, and dashboard

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No test suite in this repo |
| Lint | ⏭️ | No linter configured |
| Build | ⏭️ | No build step |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>