### PR TITLE
fix(create-github-pr): handle default branch and missing local refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "vikyw89-looper",
+  "name": "code-salad-looper",
   "description": "Plan-Do-Check loop orchestrator and nested subagent toolkit for Claude Code",
   "owner": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
   "plugins": [
     {
@@ -10,7 +10,7 @@
       "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
       "version": "0.20.0",
       "author": {
-        "name": "vikyw89"
+        "name": "code-salad"
       },
       "source": "./plugins/looper",
       "category": "development"
@@ -20,7 +20,7 @@
       "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
       "version": "0.20.0",
       "author": {
-        "name": "vikyw89"
+        "name": "code-salad"
       },
       "source": "./plugins/fallback-agent",
       "category": "development",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
   "version": "0.20.0",
   "author": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
-  "repository": "https://github.com/vikyw89/looper",
+  "repository": "https://github.com/code-salad/looper",
   "license": "MIT",
   "keywords": [
     "pdc",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Checker) in a loop until the Checker issues a PASS verdict.
 
 ```bash
 # From GitHub
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 
 # Local install from a checkout
 claude plugin install /path/to/looper/plugins/looper

--- a/README.ko.md
+++ b/README.ko.md
@@ -44,7 +44,7 @@ Looper는 개발 전체 사이클을 자동화하는 Claude Code 플러그인입
 ### 1. 설치
 
 ```bash
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 ```
 
 ### 2. 첫 루프 실행

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ No manual intervention required. Just describe what you want, and Looper handles
 ### 1. Install
 
 ```bash
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 ```
 
 ### 2. Run your first loop

--- a/dashboard/public/guide.html
+++ b/dashboard/public/guide.html
@@ -336,7 +336,7 @@ npm install</pre>
 
 <h3>Install the Plugin</h3>
 <pre># Install from GitHub
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 
 # Or install from a local checkout
 claude plugin install /path/to/looper/plugins/looper</pre>
@@ -635,7 +635,7 @@ npm install</pre>
 
 <h3>플러그인 설치</h3>
 <pre># GitHub에서 설치
-claude plugin install vikyw89/looper
+claude plugin install code-salad/looper
 
 # 또는 로컬 체크아웃에서 설치
 claude plugin install /path/to/looper/plugins/looper</pre>

--- a/loop-plan-1.md
+++ b/loop-plan-1.md
@@ -1,0 +1,144 @@
+# Plan: Fix create-github-pr abort when current branch is GitHub default
+
+## Goal
+
+Fix the `create-github-pr` skill so it does not abort when the current branch
+happens to be the GitHub default branch but the user intends to PR into a
+different base (e.g., on `alpha` wanting to PR into `main`). Also fix diff
+commands that fail when the base branch does not exist locally.
+
+## File to Modify
+
+`plugins/looper/skills/create-github-pr/SKILL.md` (single file change)
+
+## Problem Analysis
+
+Three locations in SKILL.md need changes:
+
+1. **Phase 0 Gate (line ~37-44):** The abort condition
+   `Current branch IS the default branch` is too aggressive. It prevents
+   creating PRs from branches like `alpha` (which may be the GitHub default)
+   into `main`.
+
+2. **Phase 1 Diff Commands (line ~52-68):** All `git diff $BASE_BRANCH...HEAD`
+   and `git log $BASE_BRANCH..HEAD` commands assume `$BASE_BRANCH` exists
+   locally. When it does not (e.g., repo has no local `main`), these fail with
+   `fatal: ambiguous argument`.
+
+3. **Error Handling Table (line ~376):** The row
+   `On default branch | Abort: "Create a feature branch first."` reinforces
+   the broken behavior.
+
+## Implementation Steps
+
+### Step 1: Revise Phase 0 Gate Logic
+
+Replace the current abort rule with smarter logic:
+
+**Current (lines 37-44):**
+```
+**Gate:** Abort with a clear message if:
+- Not in a git repo
+- `gh` is not authenticated
+- Current branch IS the default branch (main/master) — prompt the user to create a feature branch first
+
+Store:
+- `CURRENT_BRANCH` = current branch name
+- `BASE_BRANCH` = default branch (main, master, etc.)
+```
+
+**New:**
+```
+**Gate:** Abort with a clear message if:
+- Not in a git repo
+- `gh` is not authenticated
+
+**Branch resolution:**
+- If `CURRENT_BRANCH` != GitHub default branch → set `BASE_BRANCH` = GitHub default branch (normal case)
+- If `CURRENT_BRANCH` == GitHub default branch → do NOT abort. Instead:
+  1. Look for a plausible base branch: check if `main` or `master` exists
+     (locally or on remote) as an alternative target. If the GitHub default IS
+     `main`/`master`, check for other common bases like `develop`, `release`.
+  2. If a plausible base is found, set `BASE_BRANCH` to that and inform the
+     user: "Current branch is the GitHub default. Using <base> as PR target."
+  3. If no plausible base is found, prompt the user to specify a
+     `--base <branch>` target rather than aborting.
+
+Store:
+- `CURRENT_BRANCH` = current branch name
+- `BASE_BRANCH` = resolved base branch
+```
+
+### Step 2: Fix Phase 1 Diff Commands to Handle Missing Local Refs
+
+Update all diff/log commands in Phase 1a to try `origin/$BASE_BRANCH` as
+fallback when the local ref does not exist.
+
+**Current:**
+```bash
+git diff $BASE_BRANCH...HEAD
+git log --oneline $BASE_BRANCH..HEAD
+git diff --stat $BASE_BRANCH...HEAD
+```
+
+**New:**
+Add a ref-resolution step before the diffs:
+```bash
+# Resolve the base ref: prefer local branch, fall back to remote tracking
+if git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  BASE_REF="$BASE_BRANCH"
+elif git rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  BASE_REF="origin/$BASE_BRANCH"
+else
+  # Fetch and retry
+  git fetch origin "$BASE_BRANCH" 2>/dev/null
+  BASE_REF="origin/$BASE_BRANCH"
+fi
+```
+
+Then replace all `$BASE_BRANCH` in diff/log commands with `$BASE_REF`.
+Also update Phase 1b's `git diff --name-only $BASE_BRANCH...HEAD` reference.
+
+### Step 3: Update Error Handling Table
+
+Change the "On default branch" row from:
+```
+| On default branch | Abort: "Create a feature branch first." |
+```
+To:
+```
+| On default branch | Detect alternate base branch or prompt user for --base target. Do not abort. |
+```
+
+### Step 4: Update Phase 4 (PR Create Command)
+
+Ensure `--base "$BASE_BRANCH"` in the `gh pr create` command uses the
+resolved base branch, not necessarily the GitHub default. This should already
+work if `BASE_BRANCH` is set correctly in Phase 0, but verify the wording
+does not imply it must be the GitHub default.
+
+## What NOT to Change
+
+- Phase 2, 3, 5 logic remains unchanged (they use `$BASE_BRANCH` which will
+  now be correctly resolved).
+- The YAML frontmatter and skill description remain unchanged.
+- The Mermaid diagram style guide remains unchanged.
+
+## Acceptance Criteria
+
+1. When `CURRENT_BRANCH == GitHub default branch`, the skill does NOT abort.
+   Instead it resolves an alternate base branch or prompts the user.
+2. All `git diff` and `git log` commands use a ref-resolution step that falls
+   back to `origin/$BASE_BRANCH` when the local branch does not exist.
+3. The error handling table no longer says "Abort" for the default-branch case.
+4. The skill still aborts correctly when not in a git repo or gh is not
+   authenticated.
+5. No other behavior is changed -- the rest of the skill works as before.
+
+## Risks
+
+- This is a SKILL.md file (agent instructions, not executable code), so the
+  changes are prose/pseudocode that guide an LLM agent. The Doer must preserve
+  the existing markdown structure and formatting conventions.
+- The branch-resolution logic must be clear enough for an LLM to follow at
+  runtime. Keep it concrete with exact bash commands.

--- a/plugins/fallback-agent/.claude-plugin/plugin.json
+++ b/plugins/fallback-agent/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
   "version": "0.20.0",
   "author": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
   "license": "MIT",
   "keywords": [

--- a/plugins/looper/.claude-plugin/plugin.json
+++ b/plugins/looper/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
   "version": "0.20.0",
   "author": {
-    "name": "vikyw89"
+    "name": "code-salad"
   },
-  "repository": "https://github.com/vikyw89/looper",
+  "repository": "https://github.com/code-salad/looper",
   "license": "MIT",
   "keywords": [
     "pdc",

--- a/plugins/looper/skills/create-github-pr/SKILL.md
+++ b/plugins/looper/skills/create-github-pr/SKILL.md
@@ -37,11 +37,32 @@ gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
 **Gate:** Abort with a clear message if:
 - Not in a git repo
 - `gh` is not authenticated
-- Current branch IS the default branch (main/master) — prompt the user to create a feature branch first
+
+**Branch resolution:**
+- If `CURRENT_BRANCH` != GitHub default branch → set `BASE_BRANCH` = GitHub default branch (normal case)
+- If `CURRENT_BRANCH` == GitHub default branch → do NOT abort. Instead:
+  1. Look for a plausible base branch by checking if alternative branches exist (locally or on remote):
+     ```bash
+     # If GitHub default IS main/master, check for develop or release
+     # If GitHub default is something else (e.g., alpha), check for main or master first
+     for candidate in main master develop release; do
+       if [ "$candidate" != "$CURRENT_BRANCH" ]; then
+         if git rev-parse --verify "$candidate" >/dev/null 2>&1 || \
+            git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+           BASE_BRANCH="$candidate"
+           break
+         fi
+       fi
+     done
+     ```
+  2. If a plausible base is found, set `BASE_BRANCH` to that and inform the user:
+     "Current branch is the GitHub default. Using `<base>` as PR target."
+  3. If no plausible base is found, prompt the user to specify a `--base <branch>` target.
+     Do not proceed until the user provides one.
 
 Store:
 - `CURRENT_BRANCH` = current branch name
-- `BASE_BRANCH` = default branch (main, master, etc.)
+- `BASE_BRANCH` = resolved base branch (may differ from the GitHub default branch)
 
 ---
 
@@ -49,22 +70,40 @@ Store:
 
 ### 1a. Collect change information (run in parallel)
 
+First, resolve the base ref to use in diff/log commands. The local branch ref may not exist
+(e.g., when `BASE_BRANCH` is `main` but no local `main` branch has been checked out):
+
+```bash
+# Resolve the base ref: prefer local branch, fall back to remote tracking branch
+if git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+  BASE_REF="$BASE_BRANCH"
+elif git rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  BASE_REF="origin/$BASE_BRANCH"
+else
+  # Fetch the base branch from remote and use the remote tracking ref
+  git fetch origin "$BASE_BRANCH" 2>/dev/null
+  BASE_REF="origin/$BASE_BRANCH"
+fi
+```
+
+Then run these commands in parallel using `$BASE_REF` for all diff/log operations:
+
 ```bash
 # All changes: staged + unstaged + untracked
 git status
 
 # Diff of all changes against the base branch
-git diff $BASE_BRANCH...HEAD
+git diff $BASE_REF...HEAD
 
 # Unstaged/staged working tree changes
 git diff
 git diff --cached
 
 # Commit log since divergence from base
-git log --oneline $BASE_BRANCH..HEAD
+git log --oneline $BASE_REF..HEAD
 
 # Files changed summary
-git diff --stat $BASE_BRANCH...HEAD
+git diff --stat $BASE_REF...HEAD
 ```
 
 ### 1b. Understand the codebase architecture
@@ -73,7 +112,7 @@ Use the Glob and Read tools to understand the project:
 
 1. **Identify the project type** — look for package.json, Cargo.toml, go.mod, pyproject.toml, *.csproj, etc.
 2. **Read key config files** — understand the tech stack, frameworks, dependencies.
-3. **Read the files that were changed** — use `git diff --name-only $BASE_BRANCH...HEAD` to get the list, then Read each file (or the most important ones if there are many).
+3. **Read the files that were changed** — use `git diff --name-only $BASE_REF...HEAD` to get the list, then Read each file (or the most important ones if there are many).
 4. **Read surrounding context** — for each changed file, read related files (imports, callers, tests) to understand the before/after architecture.
 
 ### 1c. Discover and run tests/checks
@@ -374,7 +413,7 @@ Check status manually: gh pr checks $PR_NUMBER
 | Push rejected | Ask user: rebase, merge, or force push? |
 | PR already exists for this branch | Print existing PR URL, ask if user wants to update it |
 | `gh` not installed or not authenticated | Abort with install/auth instructions |
-| On default branch | Abort: "Create a feature branch first." |
+| On default branch | Detect alternate base branch (main/master/develop) or prompt user for `--base` target. Do not abort. |
 | Sensitive files detected in diff | Warn user, exclude from staging, list them |
 | CI checks fail | Report which checks failed, show failed log output, print PR URL |
 | CI checks time out (>20 min) | Report timeout, print PR URL, give manual check command |


### PR DESCRIPTION
## Problem / Task

The `create-github-pr` skill unconditionally aborts when the current branch matches the GitHub default branch. This breaks repos where the default branch is non-standard (e.g., `alpha` for pre-release work) and the developer wants to PR into `main`. Additionally, diff commands fail with `fatal: ambiguous argument` when the local base branch ref doesn't exist.

**Current behavior:** Skill aborts with "Create a feature branch first" even when the user is on the GitHub default branch (`alpha`) but wants to PR into `main`.

**Expected behavior:** Skill detects an alternate base branch (main/master/develop) or prompts the user to specify one — never hard-aborts solely because the current branch is the GitHub default.

Fixes #20

## Existing Architecture

```mermaid
flowchart TD
    A(["/create-github-pr"]) --> B["Phase 0: Preflight"]
    B --> C{"CURRENT == GitHub default?"}
    C -->|yes| D["❌ ABORT: Create a feature branch"]
    C -->|no| E["BASE_BRANCH = GitHub default"]
    E --> F["Phase 1: git diff BASE_BRANCH...HEAD"]
    F --> G{"Local ref exists?"}
    G -->|no| H["❌ fatal: ambiguous argument"]
    G -->|yes| I["Continue to PR creation"]
    style D fill:#f66,stroke:#333
    style H fill:#f66,stroke:#333
```

## Proposed Architecture

```mermaid
flowchart TD
    A(["/create-github-pr"]) --> B["Phase 0: Preflight"]
    B --> C{"CURRENT == GitHub default?"}
    C -->|no| E["BASE_BRANCH = GitHub default"]
    C -->|yes| R["Search main/master/develop/release"]
    R --> S{"Alternate found?"}
    S -->|yes| E2["BASE_BRANCH = alternate branch"]
    S -->|no| P["Prompt user for --base target"]
    E --> F["Resolve BASE_REF"]
    E2 --> F
    F --> G{"Local ref exists?"}
    G -->|yes| I["BASE_REF = BASE_BRANCH"]
    G -->|no| J["BASE_REF = origin/BASE_BRANCH"]
    I --> K["Phase 1: git diff BASE_REF...HEAD"]
    J --> K
    K --> L["Continue to PR creation"]
    style R fill:#69f,stroke:#333
    style E2 fill:#6f6,stroke:#333
    style F fill:#6f6,stroke:#333
    style J fill:#6f6,stroke:#333
```

## Key Changes

### 1. Phase 0 Gate — Remove unconditional abort, add branch resolution

When `CURRENT_BRANCH == GitHub default`, instead of aborting, iterate over `main master develop release` candidates, check both local and `origin/<candidate>` refs, and set `BASE_BRANCH` to the first plausible alternate. If none found, prompt user for `--base`.

### 2. Phase 1a — `BASE_REF` resolution step

Before any `git diff`/`git log` command, resolve `BASE_REF`: try local ref first, fall back to `origin/$BASE_BRANCH`, fetch from remote as last resort. All diff/log commands now use `$BASE_REF`.

### 3. Error Handling Table — Updated "On default branch" row

Changed from `Abort` to `Detect alternate base branch or prompt user. Do not abort.`

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No test suite configured |
| Checker Agent | ✅ | PASS verdict — all requirements verified |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>