### PR TITLE
feat(looper-issue): add skill to auto-pick unassigned GitHub issues

### DIFF
--- a/plugins/looper/skills/looper-issue/SKILL.md
+++ b/plugins/looper/skills/looper-issue/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: looper-issue
+description: >-
+  Use this skill when the user wants to automatically pick up an open GitHub
+  issue and work on it. Finds an unassigned, non-blocked issue, assigns it
+  to the current user, and invokes the looper skill. Triggered by "/looper-issue".
+tools: Bash, Read, Grep, Glob
+---
+
+# Looper Issue Skill
+
+Automatically selects an open, unassigned, non-blocked GitHub issue, assigns it
+to the current user, and delegates to the existing `looper` skill.
+
+## Prerequisites
+
+- Must be in a git repository hosted on GitHub
+- `gh` CLI must be installed and authenticated
+
+---
+
+## Phase 0: Preflight Checks
+
+Run these checks:
+
+```bash
+# Check 1: Confirm inside a git repo
+git rev-parse --is-inside-work-tree
+
+# Check 2: Confirm gh CLI is authenticated
+gh auth status
+```
+
+**Gate:** Abort with a clear message if:
+- Not in a git repo → "This is not a git repository."
+- `gh` is not authenticated → "Please run `gh auth login` first."
+
+---
+
+## Phase 1: Fetch Open Unassigned Issues
+
+```bash
+gh issue list --state open --assignee "" --limit 20 \
+  --json number,title,labels,body,createdAt
+```
+
+- If the result is an empty array, inform the user:
+  > "No open unassigned issues found."
+  and exit.
+
+Store the result as `ISSUES`.
+
+---
+
+## Phase 2: Filter Out Blocked Issues
+
+For each issue in `ISSUES`, apply the three blocking checks below. Remove any
+issue that fails at least one check.
+
+### 2a. Label-based blocking
+
+Skip (block) the issue if any of its labels contain "blocked" or "dependencies"
+(case-insensitive match).
+
+```
+labels[].name | ascii_downcase | contains("blocked") or contains("dependencies")
+```
+
+### 2b. Task-list dependency references
+
+Parse the issue body for lines matching either of these patterns:
+- `- [ ] Depends on #N`
+- `- [ ] #N`
+
+(where `N` is one or more digits)
+
+For each referenced issue number `N` found, check whether it is still open:
+
+```bash
+gh issue view N --json state --jq '.state'
+```
+
+If the result is `"OPEN"`, the issue is blocked. Skip it.
+
+### 2c. "Blocked by" references
+
+Parse the issue body for lines matching the pattern:
+- `Blocked by #N` (case-insensitive)
+
+For each referenced issue number `N`, check whether it is still open:
+
+```bash
+gh issue view N --json state --jq '.state'
+```
+
+If the result is `"OPEN"`, the issue is blocked. Skip it.
+
+---
+
+## Phase 3: Select Issue
+
+- If no eligible issues remain after Phase 2, inform the user:
+  > "All open unassigned issues are currently blocked."
+  and exit.
+
+- Otherwise, sort the remaining issues by `createdAt` ascending and select the
+  first (oldest) issue.
+
+Store the selected issue's number as `NUMBER` and its title as `TITLE`.
+
+---
+
+## Phase 4: Assign Issue
+
+```bash
+gh issue edit $NUMBER --add-assignee @me
+```
+
+- **Success:** Log:
+  > "Assigned issue #`$NUMBER` to current user."
+- **Failure:** Warn:
+  > "Could not assign issue #`$NUMBER`. Continuing anyway."
+  Do NOT abort — proceed to Phase 5 regardless.
+
+---
+
+## Phase 5: Delegate to Looper
+
+Invoke the `looper` skill with the selected issue reference:
+
+```
+/looper #$NUMBER $TITLE
+```
+
+This hands off entirely to the existing looper skill, which will:
+- Sanitize the task name from the argument
+- Create or resume an isolated worktree
+- Run the Plan-Do-Check loop
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Not a git repo | Abort: "This is not a git repository." |
+| `gh` not authenticated | Abort: "Please run `gh auth login` first." |
+| `gh issue list` fails | Abort: report the error message from `gh` to the user |
+| No open unassigned issues | Inform: "No open unassigned issues found." and exit |
+| All issues blocked | Inform: "All open unassigned issues are currently blocked." and exit |
+| Assignment failure | Warn: "Could not assign issue #N. Continuing anyway." and continue |


### PR DESCRIPTION
## Problem / Task

Closes #10

Currently, `/looper` requires the user to manually specify a GitHub issue number or task description. When a backlog of open issues exists, users must manually browse, select, and assign issues before starting the loop.

**Current behavior:** Users must run `/looper #N` with a specific issue number, requiring manual issue triage.
**Expected behavior:** `/looper-issue` automatically finds the oldest open, unassigned, non-blocked issue, assigns it to the current user, and delegates to `/looper`.

## Existing Architecture

The looper plugin has several skills, but none that auto-select issues from the backlog.

```mermaid
graph TD
    User["User"] -->|"/looper #N task"| Looper["looper skill"]
    User -->|"/looper:create-github-pr"| PR["create-github-pr skill"]
    User -->|"/looper:git-commit"| Commit["git-commit skill"]
    User -->|"/looper:github-bug-report"| Bug["github-bug-report skill"]
    Looper --> Planner["Planner Agent"]
    Looper --> Doer["Doer Agent"]
    Looper --> Checker["Checker Agent"]
    style User fill:#ff6,stroke:#333
```

## Proposed Architecture

A new `looper-issue` skill sits in front of the existing `looper` skill, handling issue discovery, filtering, and assignment before delegation.

```mermaid
graph TD
    User["User"] -->|"/looper-issue"| LI["looper-issue skill"]
    User -->|"/looper #N task"| Looper["looper skill"]
    LI -->|"1. gh issue list"| GH["GitHub API"]
    LI -->|"2. filter blocked"| GH
    LI -->|"3. assign @me"| GH
    LI -->|"4. /looper #N title"| Looper
    Looper --> Planner["Planner Agent"]
    Looper --> Doer["Doer Agent"]
    Looper --> Checker["Checker Agent"]
    style LI fill:#6f6,stroke:#333
    style GH fill:#69f,stroke:#333
```

## Key Changes

### New skill: `plugins/looper/skills/looper-issue/SKILL.md`

- **Phase 0:** Preflight checks (git repo + gh auth)
- **Phase 1:** Fetches open unassigned issues via `gh issue list --assignee ""`
- **Phase 2:** Filters blocked issues using three detection methods:
  - Label-based ("blocked" / "dependencies" labels)
  - Task-list dependency references (`- [ ] Depends on #N`)
  - Inline "Blocked by #N" references
  - Each referenced issue is checked live via `gh issue view`
- **Phase 3:** Selects oldest eligible issue (sorted by `createdAt`)
- **Phase 4:** Assigns issue to `@me` with graceful failure handling
- **Phase 5:** Delegates to `/looper #N <title>`

### Design decisions
- **Oldest-first selection** keeps the backlog moving FIFO
- **No modifications to plugin.json** — skills are auto-discovered from the directory structure
- **Warn-and-continue pattern** for assignment failures matches existing looper conventions

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No test framework configured for SKILL.md files |
| Lint | ⏭️ | Markdown skill file — no linter configured |
| Type Check | ⏭️ | N/A |
| Build | ⏭️ | N/A — declarative skill file |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>