### PR TITLE
fix(looper-issue): use --search no:assignee instead of --assignee empty string

### DIFF
--- a/plugins/looper/skills/looper-issue/SKILL.md
+++ b/plugins/looper/skills/looper-issue/SKILL.md
@@ -40,7 +40,7 @@ gh auth status
 ## Phase 1: Fetch Open Unassigned Issues
 
 ```bash
-gh issue list --state open --assignee "" --limit 20 \
+gh issue list --state open --search "no:assignee" --limit 20 \
   --json number,title,labels,body,createdAt
 ```
 


### PR DESCRIPTION
## Problem / Task

The `looper-issue` skill's Phase 1 command uses `--assignee ""` to filter for unassigned GitHub issues, but this flag is silently ignored by `gh` because an empty string is not a valid assignee filter. This causes the skill to return **all** open issues instead of only unassigned ones, leading to incorrect issue selection.

**Current behavior:** `gh issue list --assignee ""` returns all open issues regardless of assignment status.
**Expected behavior:** Only unassigned issues are returned, using `--search "no:assignee"` which leverages GitHub's search qualifier syntax.

## Existing Architecture

The `looper-issue` skill fetches issues in Phase 1 using `gh issue list` with `--assignee ""`:

```mermaid
graph TD
    A(["/looper-issue"]) --> B["Phase 1: gh issue list --assignee ''"]
    B --> C{"Filter blocked issues"}
    C --> D["Select oldest issue"]
    D --> E["Assign & delegate to /looper"]
    style B fill:#f66,stroke:#333
```

The `--assignee ""` flag is ignored by `gh`, so **all** open issues are returned — including already-assigned ones.

## Proposed Architecture

Replace `--assignee ""` with `--search "no:assignee"` to correctly filter:

```mermaid
graph TD
    A(["/looper-issue"]) --> B["Phase 1: gh issue list --search 'no:assignee'"]
    B --> C{"Filter blocked issues"}
    C --> D["Select oldest issue"]
    D --> E["Assign & delegate to /looper"]
    style B fill:#6f6,stroke:#333
```

## Key Changes

- **`plugins/looper/skills/looper-issue/SKILL.md` line 43:** Replaced `--assignee ""` with `--search "no:assignee"` in the `gh issue list` command. This uses GitHub's search qualifier syntax to correctly filter for issues with no assignee.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No test suite (documentation-only change) |
| Lint | ⏭️ | Markdown file — no linter configured |
| Type Check | ⏭️ | N/A |
| Build | ⏭️ | N/A |

Verified manually: `gh issue list --search "no:assignee"` correctly excludes assigned issues while `--assignee ""` does not.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>