### PR TITLE
fix(webscraping): remove invalid agents field from plugin manifest

### DIFF
--- a/plugins/webscraping/.claude-plugin/plugin.json
+++ b/plugins/webscraping/.claude-plugin/plugin.json
@@ -13,15 +13,5 @@
     "recon",
     "dotnet",
     "playwright"
-  ],
-  "agents": [
-    {
-      "name": "recon",
-      "path": "agents/recon.md"
-    },
-    {
-      "name": "webscraping",
-      "path": "agents/webscraping.md"
-    }
   ]
 }


### PR DESCRIPTION
## Problem / Task

The webscraping plugin fails to install with: "Plugin has an invalid manifest file. Validation errors: agents: Invalid input."

**Current behavior:** Plugin installation fails because `plugin.json` contains an `agents` array field that is not part of the Claude Code plugin manifest schema.
**Expected behavior:** Plugin installs successfully. Agents are auto-discovered from the `agents/` directory.

## Existing Architecture

The webscraping plugin manifest explicitly declared its agents in `plugin.json`:

```mermaid
graph TD
    M[plugin.json] -->|"agents array"| A1[agents/recon.md]
    M -->|"agents array"| A2[agents/webscraping.md]
    style M fill:#f66,stroke:#333
```

This explicit declaration is not supported by the plugin schema — Claude Code expects agents to be auto-discovered from the `agents/` directory.

## Proposed Architecture

The manifest contains only valid fields. Agents are auto-discovered:

```mermaid
graph TD
    M[plugin.json] -.->|"no agents field"| AD[agents/ directory]
    AD -->|"auto-discovery"| A1[agents/recon.md]
    AD -->|"auto-discovery"| A2[agents/webscraping.md]
    style M fill:#6f6,stroke:#333
    style AD fill:#69f,stroke:#333
```

## Key Changes

- **Removed `agents` array from `plugins/webscraping/.claude-plugin/plugin.json`** — This was the only field causing the validation error. The agent files (`recon.md`, `webscraping.md`) remain in `plugins/webscraping/agents/` and will be auto-discovered by Claude Code, matching the pattern used by official plugins (e.g., `feature-dev`).

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| JSON validity | ✅ | Verified valid JSON |
| Agent files present | ✅ | `agents/recon.md` and `agents/webscraping.md` untouched |
| No other files changed | ✅ | Single-file change |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>