### PR TITLE
fix: PID-scoped debug log files

### DIFF
--- a/plugins/fallback-agent/mcp-server-rs/src/main.rs
+++ b/plugins/fallback-agent/mcp-server-rs/src/main.rs
@@ -25,12 +25,14 @@ use crate::types::{
 
 // ── Debug Logging ────────────────────────────────────────────────────────────
 
-const LOG_FILE: &str = "/tmp/fallback-agent-debug.log";
+fn log_file() -> String {
+    format!("/tmp/fallback-agent-debug-{}.log", std::process::id())
+}
 
 pub fn log(message: &str) {
     let timestamp = simple_timestamp();
     let log_line = format!("[{}] {}\n", timestamp, message);
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(LOG_FILE) {
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&log_file()) {
         let _ = file.write_all(log_line.as_bytes());
     }
 }
@@ -46,8 +48,8 @@ fn simple_timestamp() -> String {
 }
 
 fn init_log() {
-    if let Ok(mut file) = fs::File::create(LOG_FILE) {
-        let _ = writeln!(file, "=== Fallback Agent MCP Server Started (Rust) ===");
+    if let Ok(mut file) = fs::File::create(&log_file()) {
+        let _ = writeln!(file, "=== Fallback Agent MCP Server Started (Rust, pid {}) ===", std::process::id());
         let _ = writeln!(
             file,
             "CLAUDE_PLUGIN_ROOT={}",

--- a/plugins/looper/mcp-server/src/main.rs
+++ b/plugins/looper/mcp-server/src/main.rs
@@ -16,7 +16,9 @@ use crate::watcher::WatcherManager;
 
 // ── Debug Logging ────────────────────────────────────────────────────────────
 
-const LOG_FILE: &str = "/tmp/looper-watcher-debug.log";
+fn log_file() -> String {
+    format!("/tmp/looper-watcher-debug-{}.log", std::process::id())
+}
 
 pub fn log(message: &str) {
     use std::fs::OpenOptions;
@@ -29,7 +31,7 @@ pub fn log(message: &str) {
         format!("{}.{:03}", d.as_secs(), d.subsec_millis())
     };
     let log_line = format!("[{}] {}\n", timestamp, message);
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(LOG_FILE) {
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&log_file()) {
         let _ = file.write_all(log_line.as_bytes());
     }
 }
@@ -37,8 +39,8 @@ pub fn log(message: &str) {
 fn init_log() {
     use std::fs;
     use std::io::Write;
-    if let Ok(mut file) = fs::File::create(LOG_FILE) {
-        let _ = writeln!(file, "=== Looper Watcher MCP Server Started ===");
+    if let Ok(mut file) = fs::File::create(&log_file()) {
+        let _ = writeln!(file, "=== Looper Watcher MCP Server Started (pid {}) ===", std::process::id());
     }
 }
 


### PR DESCRIPTION
## Summary
- Debug log files now include the process PID in the filename to prevent interleaving when multiple Claude Code instances run concurrently
- Applies to both `looper-watcher` and `fallback-agent` MCP servers

## Test plan
- [ ] Run two Claude Code instances concurrently and verify separate log files are created
- [ ] Verify log output is clean and not interleaved

🤖 Generated with [Claude Code](https://claude.com/claude-code)