### PR TITLE
docs: update README and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,235 @@
+# Contributing to Looper
+
+Thank you for your interest in contributing to Looper. This document covers development setup, project structure, code style, commit conventions, and the PR process.
+
+---
+
+## Overview
+
+Looper is a Claude Code plugin that orchestrates a Plan-Do-Check (PDC) loop using three AI agents. Contributions can be to agent prompts, shell scripts, MCP servers, documentation, or CI tooling.
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+- [`claude` CLI](https://docs.anthropic.com/en/docs/claude-code) (Claude Code)
+- `git`
+- `jq`
+- `gh` (GitHub CLI — required for PR creation and issue automation)
+- `shellcheck` (for linting shell scripts)
+- Rust toolchain (only if modifying the `fallback-agent` MCP server)
+
+### Cloning the Repo
+
+```bash
+git clone https://github.com/code-salad/looper.git
+cd looper
+```
+
+No additional build step is required. The plugin is plain shell scripts and Markdown files (plus a Rust binary for the fallback-agent MCP server).
+
+### Installing the Plugin Locally
+
+To test your changes in Claude Code, install from a local path:
+
+```bash
+claude plugin install ./
+```
+
+---
+
+## Project Structure
+
+```
+looper/
+├── .claude-plugin/
+│   ├── plugin.json          # Root plugin manifest
+│   └── marketplace.json     # Multi-plugin marketplace definition
+├── plugins/
+│   ├── looper/              # Core PDC loop plugin
+│   │   ├── agents/          # Agent prompt files (Markdown)
+│   │   │   ├── planner.md
+│   │   │   ├── doer.md
+│   │   │   ├── checker.md
+│   │   │   └── issue-creator.md
+│   │   ├── mcp-server/      # looper-watcher MCP server
+│   │   └── skills/          # Skill definitions
+│   │       ├── looper/      # Main loop skill
+│   │       │   ├── SKILL.md
+│   │       │   └── scripts/ # Utility scripts (shell)
+│   │       ├── claude-wrap/
+│   │       ├── create-github-pr/
+│   │       ├── git-commit/
+│   │       ├── initiate-worktree/
+│   │       ├── looper-ee/
+│   │       ├── looper-issue/
+│   │       └── looper-watch/
+│   ├── fallback-agent/      # Nested subagent MCP server plugin
+│   │   ├── agents/
+│   │   └── mcp-server-rs/   # Rust MCP server source
+│   └── webscraping/         # Web scraping plugin
+│       ├── agents/
+│       └── skills/
+├── docs/                    # Additional documentation
+└── .github/
+    └── workflows/
+        └── ci.yml           # CI pipeline
+```
+
+---
+
+## Code Style and Conventions
+
+### Shell Scripts
+
+- All scripts in `plugins/looper/skills/looper/scripts/` must be executable (`chmod +x`).
+- Scripts must pass [ShellCheck](https://www.shellcheck.net/) — this is enforced by CI.
+- Use `#!/usr/bin/env bash` as the shebang line.
+- Prefer `local` for function-scoped variables.
+- Use `set -euo pipefail` at the top of scripts.
+- Common helpers are in `scripts/_helpers.sh` — source it where needed.
+
+### Agent Prompts
+
+- Agent prompts are Markdown files in `plugins/<plugin>/agents/`.
+- Use clear section headers and keep instructions unambiguous.
+- Avoid hard-coding file paths — use environment variables or relative paths.
+
+### Skills
+
+- Each skill lives in its own directory under `plugins/<plugin>/skills/<skill-name>/`.
+- Every skill directory must contain a `SKILL.md` file with YAML frontmatter:
+
+```yaml
+---
+name: skill-name
+description: >-
+  One-sentence description used in the Claude Code skill picker.
+tools: Bash, Read, Glob, Grep
+---
+```
+
+- The `tools` field lists all Claude tools the skill may invoke.
+
+### Plugin Manifests
+
+- `plugin.json` and `marketplace.json` must be valid JSON — CI validates this.
+- Bump the `version` field in `plugin.json` for every release using semantic versioning.
+
+---
+
+## Commit Conventions
+
+Looper uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): short description
+
+Optional longer body explaining the why.
+```
+
+**Types:**
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code restructuring without behavior change |
+| `test` | Test additions or fixes |
+| `chore` | Build, CI, dependency, or tooling changes |
+
+**Scope** is optional but recommended — use the plugin name, skill name, or area (e.g., `looper`, `checker`, `scripts`).
+
+### Loop Commits
+
+Commits created by the PDC loop agents include structured trailers:
+
+```
+feat(my-task): implement feature X
+
+Added feature X with tests.
+
+Loop-Phase: do
+Loop-Iteration: 2
+Loop-Verdict: PASS
+```
+
+These trailers allow querying loop state with `git log --grep`.
+
+---
+
+## PR Process
+
+1. **Branch from `main`:**
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+
+2. **Make your changes** following the conventions above.
+
+3. **Run CI checks locally** before pushing:
+   ```bash
+   shellcheck plugins/looper/skills/looper/scripts/*
+   jq . .claude-plugin/plugin.json > /dev/null
+   jq . .claude-plugin/marketplace.json > /dev/null
+   ```
+
+4. **Push and open a PR** targeting `main`:
+   ```bash
+   git push -u origin feat/my-feature
+   gh pr create --base main
+   ```
+
+   Or use the Looper skill for an auto-generated PR with architecture diagrams:
+   ```
+   /looper:create-github-pr
+   ```
+
+5. **CI must pass** — ShellCheck, JSON validation, executable permission checks, and required file existence checks.
+
+6. PRs are reviewed and merged by maintainers. Keep PRs focused — one concern per PR.
+
+---
+
+## Testing and CI
+
+The CI pipeline (`.github/workflows/ci.yml`) validates:
+
+- **ShellCheck** — All shell scripts in `plugins/looper/skills/looper/scripts/` must pass without errors.
+- **JSON validation** — `plugin.json` and `marketplace.json` must be parseable by `jq`.
+- **Executable permissions** — All scripts in the `scripts/` directory must be executable.
+- **Required files** — Key files like `SKILL.md` and `plugin.json` must exist.
+
+There is no automated test suite for the agent prompts — correctness is validated by running the PDC loop against real tasks.
+
+---
+
+## Adding a New Skill
+
+1. Create a directory: `plugins/looper/skills/<skill-name>/`
+2. Add a `SKILL.md` with YAML frontmatter (see [Skills](#skills) above).
+3. Add any supporting scripts in a `scripts/` subdirectory. Make them executable.
+4. Register the skill in `marketplace.json` if needed.
+5. Update the Skills table in `README.md`.
+
+---
+
+## Adding a New Agent
+
+1. Create a Markdown file in `plugins/<plugin>/agents/<agent-name>.md`.
+2. Write the agent prompt following the conventions of existing agents.
+3. Reference the agent from the relevant skill or orchestrator.
+4. Update the Agents table in `README.md`.
+
+---
+
+## Questions and Issues
+
+Open a [GitHub issue](https://github.com/code-salad/looper/issues) for bugs, feature requests, or questions. When reporting a bug, include:
+
+- The task description you passed to Looper
+- The git log output (`git log --grep="Loop-Phase:" --oneline`)
+- The full error message or unexpected behavior

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Three AI agents — Planner, Doer, Checker — iterate in a loop until your code passes all checks, then automatically create a PR.
 
-[![Version](https://img.shields.io/badge/version-0.24.2-blue)](.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-0.26.2-blue)](.claude-plugin/plugin.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![CI](https://img.shields.io/badge/CI-passing-brightgreen)](.github/workflows/ci.yml)
 
@@ -33,6 +33,8 @@ No manual intervention required. Just describe what you want, and Looper handles
 - **Auto PR Creation** — PRs with Mermaid architecture diagrams and test results
 - **Isolated Worktrees** — Each task runs in its own git worktree
 - **Resume Support** — Pick up interrupted loops from the last iteration
+- **Issue Automation** — Auto-pick GitHub issues and work on them end-to-end
+- **Multi-Plugin Marketplace** — Modular plugin architecture with MCP server integration
 
 ---
 
@@ -47,7 +49,7 @@ claude plugin install code-salad/looper
 ### 2. Run your first loop
 
 ```
-/looper "add input validation to the login endpoint"
+/looper:loop "add input validation to the login endpoint"
 ```
 
 ### 3. Watch it work
@@ -117,6 +119,20 @@ Every iteration, the Checker agent spawns 5 parallel review subagents:
 - **Code Quality** — Lint, format, security scan, conventions
 - **Integration Tester** — Starts dev server and tests endpoints
 
+### Automated Issue Processing
+
+> "Point Looper at your GitHub repo and let it work issues automatically."
+
+```
+/looper:looper-issue
+```
+
+Looper finds an open, unassigned issue, assigns it to you, runs the full PDC loop, and opens a PR — all without manual intervention. Use `looper-watch` to poll continuously:
+
+```
+/looper:looper-watch owner/repo 30
+```
+
 ### Multi-Language Project Support
 
 Looper auto-detects your tech stack and uses the right tools:
@@ -135,7 +151,7 @@ Looper auto-detects your tech stack and uses the right tools:
 
 ```mermaid
 flowchart TD
-    A["User: /loop 'task description'"] --> B["SKILL.md Orchestrator"]
+    A["User: /looper:loop 'task description'"] --> B["SKILL.md Orchestrator"]
     B --> C["Create Git Worktree"]
     C --> D["Sync with Remote"]
     D --> E["Build Project Context"]
@@ -184,6 +200,25 @@ git log --grep="Loop-Verdict: PASS" --format="%B" -1
 
 ## Architecture
 
+### Plugins
+
+Looper uses a multi-plugin marketplace architecture. Three plugins ship together:
+
+| Plugin | Description |
+|--------|-------------|
+| **looper** | Core PDC loop — agents, skills, scripts, and MCP watcher server |
+| **fallback-agent** | MCP server (Rust) enabling nested subagent spawning from within Claude Code |
+| **webscraping** | Web scraping agents and skills for gathering context from URLs |
+
+Each plugin lives under `plugins/<name>/` and can be installed independently.
+
+### MCP Servers
+
+| Server | Plugin | Purpose |
+|--------|--------|---------|
+| **looper-watcher** | looper | Watches GitHub repos for open issues and triggers looper-ee |
+| **fallback-agent** | fallback-agent | Provides the `AgentFallback` tool for spawning nested Claude subagents |
+
 ### Agents
 
 | Agent | Model | Role | Tools |
@@ -191,6 +226,7 @@ git log --grep="Loop-Verdict: PASS" --format="%B" -1
 | **Planner** | Opus | Explores codebase, produces actionable plan | Read, Glob, Grep, Bash (read-only) |
 | **Doer** | Sonnet | Implements plan, writes tests, runs checks | Read, Write, Edit, Bash, Glob, Grep |
 | **Checker** | Opus | Reviews work, issues PASS/FAIL verdict | Read, Bash, Glob, Grep |
+| **Issue Creator** | Sonnet | Creates GitHub issues for discovered bugs or improvements | Bash, Read |
 
 ### Skills
 
@@ -200,14 +236,21 @@ git log --grep="Loop-Verdict: PASS" --format="%B" -1
 | Git Commit | `/looper:git-commit` | Conventional commit helper |
 | Create PR | `/looper:create-github-pr` | PR with architecture diagrams |
 | Worktree | `/looper:initiate-worktree "name"` | Git worktree helper |
+| Claude Wrap | `/looper:claude-wrap` | Spawn a nested Claude CLI instance from within Claude Code |
+| Looper EE | `/looper:looper-ee <issue_url>` | Work on a GitHub issue from an external repo |
+| Looper Issue | `/looper:looper-issue` | Auto-pick an open GitHub issue and work on it |
+| Looper Watch | `/looper:looper-watch <owner/repo> [interval]` | Poll a GitHub repo and work issues automatically |
 
 ### Utility Scripts
 
-All scripts auto-detect your tech stack and dispatch to the right tool:
+All scripts live in `plugins/looper/skills/looper/scripts/` and auto-detect your tech stack:
 
 | Script | Purpose |
 |--------|---------|
 | `detect-stack` | Auto-detect project tech stack (JSON) |
+| `detect-resume` | Detect and resume interrupted loops |
+| `git-commit-loop` | Create commits with loop trailers |
+| `git-loop-context` | Read prior loop iterations from git log |
 | `run-tests` | Run test suite |
 | `run-lint` | Run linter (with `--fix`) |
 | `run-typecheck` | Run type checker |
@@ -215,6 +258,8 @@ All scripts auto-detect your tech stack and dispatch to the right tool:
 | `run-build` | Build the project |
 | `install-deps` | Install dependencies |
 | `security-scan` | Security vulnerability scan |
+| `setup-worktree` | Create or resume a git worktree for a task |
+| `sync-with-remote` | Sync worktree with remote branch |
 
 ---
 
@@ -235,7 +280,11 @@ LOOPER_MAX_ITERATIONS=5 claude
 - [`claude` CLI](https://docs.anthropic.com/en/docs/claude-code) (Claude Code)
 - `git`
 - `jq`
-- `gh` (GitHub CLI, optional — required for PR creation)
+- `gh` (GitHub CLI, optional — required for PR creation and issue automation)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and PR process.
 
 ## License
 


### PR DESCRIPTION
## Problem / Task

The README was outdated (version badge showed 0.24.2, only 4 of 8 skills documented, missing MCP servers and multi-plugin architecture) and there was no CONTRIBUTING.md for contributors.

**Current behavior:** README reflects an older version of the project with incomplete documentation. No contributor guidelines exist.
**Expected behavior:** README accurately documents all plugins, skills, agents, MCP servers, and scripts. CONTRIBUTING.md provides clear guidelines for development setup, code style, commits, and PR process.

Closes #22

## Existing Architecture

The project had a single README.md documenting a subset of features with a stale version badge.

```mermaid
graph TD
    A[README.md] --> B[Partial Skills Table - 4 skills]
    A --> C[Agents Table - 3 agents]
    A --> D[Scripts Table - 8 scripts]
    A --> E["Version Badge (0.24.2)"]
    style E fill:#f66,stroke:#333
    style B fill:#f66,stroke:#333
```

## Proposed Architecture

Both files now comprehensively document the full project structure.

```mermaid
graph TD
    A[README.md] --> B[Complete Skills Table - 8 skills]
    A --> C[Agents Table - 4 agents]
    A --> D[Scripts Table - 13 scripts]
    A --> E["Version Badge (0.26.2)"]
    A --> F[Plugins Section]
    A --> G[MCP Servers Section]
    A --> H[Issue Automation Use Case]
    I[CONTRIBUTING.md] --> J[Dev Setup]
    I --> K[Project Structure]
    I --> L[Code Style]
    I --> M[Commit Conventions]
    I --> N[PR Process]
    I --> O[Adding Skills/Agents]
    A -.-> I
    style B fill:#6f6,stroke:#333
    style E fill:#6f6,stroke:#333
    style F fill:#69f,stroke:#333
    style G fill:#69f,stroke:#333
    style H fill:#69f,stroke:#333
    style I fill:#69f,stroke:#333
```

## Key Changes

- **README.md**: Fixed version badge (0.24.2 → 0.26.2), added all 8 skills, 4 agents (added issue-creator), 13 scripts (added 5 missing), new Plugins section documenting multi-plugin marketplace, new MCP Servers table, new Automated Issue Processing use case, link to CONTRIBUTING.md
- **CONTRIBUTING.md**: New file covering development setup, project structure, code style (shell scripts, agent prompts, skills, manifests), conventional commit conventions with loop trailers, PR process, CI checks, and guides for adding new skills and agents

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No test suite — documentation-only changes |
| Lint | ⏭️ | No code changes to lint |
| Type Check | ⏭️ | N/A |
| Build | ⏭️ | N/A |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>