### PR TITLE
feat(looper-watch): add elapsed timer per session in TUI

### DIFF
--- a/crates/looper-watch/src/state.rs
+++ b/crates/looper-watch/src/state.rs
@@ -9,6 +9,8 @@ pub struct Entry {
     pub issue_title: String,
     pub timestamp: String,
     pub outcome: String,
+    #[serde(default)]
+    pub started_at: Option<String>,
 }
 
 /// Persisted state — history only. Live in-progress state comes from tmux.
@@ -81,16 +83,29 @@ pub async fn list_repo_sessions(repo: &str) -> Vec<String> {
     }
 }
 
-/// Kill all tmux sessions for this repo.
-pub async fn kill_all_repo_sessions(repo: &str) -> usize {
-    let sessions = list_repo_sessions(repo).await;
-    for s in &sessions {
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", s.as_str()])
-            .output()
-            .await;
+/// List all tmux sessions for this repo, paired with their Unix creation timestamps.
+pub async fn list_repo_sessions_with_age(repo: &str) -> Vec<(String, Option<i64>)> {
+    let prefix = session_prefix(repo);
+    let output = Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}:#{session_created}"])
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .filter(|l| l.starts_with(&prefix))
+            .map(|l| {
+                if let Some((name, ts)) = l.split_once(':') {
+                    let created = ts.trim().parse::<i64>().ok();
+                    (name.to_string(), created)
+                } else {
+                    (l.to_string(), None)
+                }
+            })
+            .collect(),
+        _ => vec![],
     }
-    sessions.len()
 }
 
 #[cfg(test)]
@@ -98,28 +113,71 @@ mod tests {
     use super::*;
 
     #[test]
-    fn session_name_formats_correctly() {
-        assert_eq!(session_name("owner/repo", 42), "looper-owner-repo-42");
+    fn entry_deserializes_without_started_at_for_backward_compat() {
+        // Regression test: existing state JSON files without started_at must
+        // deserialize correctly (started_at defaults to None)
+        let json = r#"{
+            "issue_number": 42,
+            "issue_title": "Fix the bug",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "outcome": "completed (tmux)"
+        }"#;
+        let entry: Entry = serde_json::from_str(json).expect("should deserialize old Entry format");
+        assert_eq!(entry.issue_number, 42);
+        assert_eq!(entry.started_at, None);
+    }
+
+    #[test]
+    fn entry_deserializes_with_started_at() {
+        let json = r#"{
+            "issue_number": 7,
+            "issue_title": "New feature",
+            "timestamp": "2024-06-15T12:00:00Z",
+            "outcome": "success",
+            "started_at": "2024-06-15T11:50:00Z"
+        }"#;
+        let entry: Entry =
+            serde_json::from_str(json).expect("should deserialize Entry with started_at");
+        assert_eq!(entry.started_at, Some("2024-06-15T11:50:00Z".to_string()));
+    }
+
+    #[test]
+    fn entry_serializes_with_started_at_none_as_null() {
+        let entry = Entry {
+            issue_number: 1,
+            issue_title: "Test".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            outcome: "success".to_string(),
+            started_at: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        // started_at: None serializes as null (serde default)
+        assert!(json.contains("started_at"));
+    }
+
+    #[test]
+    fn session_name_uses_repo_with_slash_sanitized() {
+        let name = session_name("owner/repo", 42);
+        assert_eq!(name, "looper-owner-repo-42");
+    }
+
+    #[test]
+    fn issue_from_session_parses_correctly() {
+        let result = issue_from_session("owner/repo", "looper-owner-repo-42");
+        assert_eq!(result, Some(42));
+    }
+
+    #[test]
+    fn issue_from_session_returns_none_for_different_repo() {
+        let result = issue_from_session("owner/repo", "looper-other-repo-42");
+        assert_eq!(result, None);
     }
 
     #[test]
     fn session_name_sanitizes_slash_in_repo() {
-        assert_eq!(session_name("my-org/my-repo", 1), "looper-my-org-my-repo-1");
-    }
-
-    #[test]
-    fn issue_from_session_parses_valid_session() {
         assert_eq!(
-            issue_from_session("owner/repo", "looper-owner-repo-99"),
-            Some(99)
-        );
-    }
-
-    #[test]
-    fn issue_from_session_returns_none_for_wrong_prefix() {
-        assert_eq!(
-            issue_from_session("owner/repo", "other-owner-repo-99"),
-            None
+            session_name("my-org/my-repo", 1),
+            "looper-my-org-my-repo-1"
         );
     }
 
@@ -146,16 +204,30 @@ mod tests {
             issue_title: "First issue".to_string(),
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             outcome: "success".to_string(),
+            started_at: None,
         });
         state.add_history(Entry {
             issue_number: 2,
             issue_title: "Second issue".to_string(),
             timestamp: "2024-01-01T00:01:00Z".to_string(),
             outcome: "failed".to_string(),
+            started_at: None,
         });
 
         assert_eq!(state.history.len(), 2);
         assert_eq!(state.history[0].issue_number, 1);
         assert_eq!(state.history[1].issue_number, 2);
     }
+}
+
+/// Kill all tmux sessions for this repo.
+pub async fn kill_all_repo_sessions(repo: &str) -> usize {
+    let sessions = list_repo_sessions(repo).await;
+    for s in &sessions {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", s.as_str()])
+            .output()
+            .await;
+    }
+    sessions.len()
 }

--- a/crates/looper-watch/src/tui.rs
+++ b/crates/looper-watch/src/tui.rs
@@ -17,6 +17,24 @@ use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap};
 use crate::state;
 use crate::worker::{self, AppState};
 
+/// Format a duration in seconds as a human-readable string.
+/// - < 60s:    "Xs"        (e.g. "45s")
+/// - < 3600s:  "Xm Ys"    (e.g. "12m 34s")
+/// - >= 3600s: "Xh Ym Zs" (e.g. "1h 23m 45s")
+pub fn format_elapsed(seconds: i64) -> String {
+    let seconds = seconds.max(0) as u64;
+    let h = seconds / 3600;
+    let m = (seconds % 3600) / 60;
+    let s = seconds % 60;
+    if h > 0 {
+        format!("{h}h {m}m {s}s")
+    } else if m > 0 {
+        format!("{m}m {s}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
 pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -39,7 +57,8 @@ pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result
 
         // Source of truth: live tmux sessions
         let in_progress = state::in_progress_issues(&repo).await;
-        let tmux_sessions = state::list_repo_sessions(&repo).await;
+        let tmux_sessions = state::list_repo_sessions_with_age(&repo).await;
+        let now_ts = chrono::Utc::now().timestamp();
 
         terminal.draw(|f| {
             let chunks = Layout::default()
@@ -83,14 +102,38 @@ pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result
             let rows: Vec<Row> = open_issues
                 .iter()
                 .map(|issue| {
-                    let status = if in_progress.contains(&issue.number) {
-                        Span::styled("⚙ running", Style::default().fg(Color::Yellow))
-                    } else if history.iter().any(|e| {
+                    let session = state::session_name(&repo, issue.number);
+                    let status_text = if in_progress.contains(&issue.number) {
+                        // Find the session's created timestamp from our snapshot
+                        let elapsed_str = tmux_sessions
+                            .iter()
+                            .find(|(s, _)| s == &session)
+                            .and_then(|(_, ts)| *ts)
+                            .map(|ts| format!("  {}", format_elapsed(now_ts - ts)))
+                            .unwrap_or_default();
+                        let text = format!("⚙ running{elapsed_str}");
+                        Span::styled(text, Style::default().fg(Color::Yellow))
+                    } else if let Some(entry) = history.iter().find(|e| {
                         e.issue_number == issue.number
                             && (e.outcome.starts_with("success")
                                 || e.outcome.starts_with("completed"))
                     }) {
-                        Span::styled("✓ done", Style::default().fg(Color::Green))
+                        // Compute duration from started_at to timestamp
+                        let elapsed_str = entry
+                            .started_at
+                            .as_deref()
+                            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                            .and_then(|start| {
+                                chrono::DateTime::parse_from_rfc3339(&entry.timestamp)
+                                    .ok()
+                                    .map(|end| {
+                                        let secs = (end - start).num_seconds();
+                                        format!("  {}", format_elapsed(secs))
+                                    })
+                            })
+                            .unwrap_or_default();
+                        let text = format!("✓ done{elapsed_str}");
+                        Span::styled(text, Style::default().fg(Color::Green))
                     } else {
                         Span::styled("○ open", Style::default().fg(Color::White))
                     };
@@ -103,7 +146,7 @@ pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result
                     Row::new(vec![
                         Cell::from(format!("#{}", issue.number)),
                         Cell::from(issue.title.chars().take(50).collect::<String>()),
-                        Cell::from(status),
+                        Cell::from(status_text),
                         Cell::from(labels),
                     ])
                 })
@@ -114,7 +157,7 @@ pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result
                 [
                     Constraint::Length(6),
                     Constraint::Min(30),
-                    Constraint::Length(12),
+                    Constraint::Length(24),
                     Constraint::Length(20),
                 ],
             )
@@ -125,27 +168,37 @@ pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result
             // Tmux sessions
             let session_rows: Vec<Row> = tmux_sessions
                 .iter()
-                .map(|s| {
+                .map(|(s, created_ts)| {
+                    let elapsed_str = created_ts
+                        .map(|ts| format_elapsed(now_ts - ts))
+                        .unwrap_or_else(|| "—".to_string());
                     Row::new(vec![
                         Cell::from(s.as_str()),
                         Cell::from(format!("tmux attach -t {s}")),
+                        Cell::from(elapsed_str),
                     ])
                 })
                 .collect();
-            let session_table =
-                Table::new(session_rows, [Constraint::Length(40), Constraint::Min(30)])
-                    .header(
-                        Row::new(["Session", "Attach command"]).style(
-                            Style::default()
-                                .fg(Color::Yellow)
-                                .add_modifier(Modifier::BOLD),
-                        ),
-                    )
-                    .block(
-                        Block::default()
-                            .title(" Claude Sessions (tmux) ")
-                            .borders(Borders::ALL),
-                    );
+            let session_table = Table::new(
+                session_rows,
+                [
+                    Constraint::Length(40),
+                    Constraint::Min(30),
+                    Constraint::Length(12),
+                ],
+            )
+            .header(
+                Row::new(["Session", "Attach command", "Elapsed"]).style(
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            )
+            .block(
+                Block::default()
+                    .title(" Claude Sessions (tmux) ")
+                    .borders(Borders::ALL),
+            );
             f.render_widget(session_table, chunks[2]);
 
             // Log
@@ -202,4 +255,77 @@ pub async fn run_tui(app: AppState, repo: &str, state_path: &Path) -> io::Result
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_elapsed;
+
+    #[test]
+    fn format_elapsed_zero_seconds() {
+        assert_eq!(format_elapsed(0), "0s");
+    }
+
+    #[test]
+    fn format_elapsed_negative_clamped_to_zero() {
+        // Negative durations (clock skew, etc.) should display as 0s
+        assert_eq!(format_elapsed(-100), "0s");
+    }
+
+    #[test]
+    fn format_elapsed_seconds_only_below_one_minute() {
+        assert_eq!(format_elapsed(1), "1s");
+        assert_eq!(format_elapsed(45), "45s");
+        assert_eq!(format_elapsed(59), "59s");
+    }
+
+    #[test]
+    fn format_elapsed_minutes_and_seconds_below_one_hour() {
+        // Issue #27 example: "12m 34s"
+        assert_eq!(format_elapsed(754), "12m 34s");
+        assert_eq!(format_elapsed(60), "1m 0s");
+        assert_eq!(format_elapsed(3599), "59m 59s");
+    }
+
+    #[test]
+    fn format_elapsed_hours_minutes_seconds_at_or_above_one_hour() {
+        // Issue #27 example: "1h 23m 45s"
+        assert_eq!(format_elapsed(5025), "1h 23m 45s");
+        assert_eq!(format_elapsed(3600), "1h 0m 0s");
+        assert_eq!(format_elapsed(7384), "2h 3m 4s");
+    }
+
+    #[test]
+    fn format_elapsed_omits_hours_when_less_than_one_hour() {
+        // Acceptance criterion: omit hours if < 1h
+        let result = format_elapsed(500);
+        assert!(
+            !result.contains('h'),
+            "should not contain 'h' for < 1h: {result}"
+        );
+    }
+
+    #[test]
+    fn format_elapsed_omits_minutes_when_less_than_one_minute() {
+        // Acceptance criterion: omit minutes if < 1m
+        let result = format_elapsed(30);
+        assert!(
+            !result.contains('m'),
+            "should not contain 'm' for < 1m: {result}"
+        );
+    }
+
+    #[test]
+    fn format_elapsed_issue_27_running_session_example() {
+        // From the issue: "⚙ running  12m 34s"
+        let elapsed = format_elapsed(12 * 60 + 34);
+        assert_eq!(elapsed, "12m 34s");
+    }
+
+    #[test]
+    fn format_elapsed_issue_27_done_session_example() {
+        // From the issue: "✓ done      8m 12s"
+        let elapsed = format_elapsed(8 * 60 + 12);
+        assert_eq!(elapsed, "8m 12s");
+    }
 }

--- a/crates/looper-watch/src/worker.rs
+++ b/crates/looper-watch/src/worker.rs
@@ -200,6 +200,7 @@ async fn run_claude(
         allowed_tools.replace('\'', "'\\''"),
     );
 
+    let started_at = chrono::Utc::now().to_rfc3339();
     app.log(&format!(
         "#{issue_number}: spawning tmux session '{session}'"
     ))
@@ -238,6 +239,7 @@ async fn run_claude(
             issue_title: issue_title.to_string(),
             timestamp: chrono::Utc::now().to_rfc3339(),
             outcome,
+            started_at: Some(started_at),
         });
         s.save(state_path).await;
         return;
@@ -271,6 +273,7 @@ async fn run_claude(
         issue_title: issue_title.to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         outcome,
+        started_at: Some(started_at),
     });
     s.save(state_path).await;
 }


### PR DESCRIPTION
## Problem / Task

The looper-watch TUI dashboard shows active tmux sessions but lacks timing information. Users cannot see how long each Claude process has been running or how long completed sessions took.

**Current behavior:** Sessions display only status (⚙ running / ✓ done) with no timing.
**Expected behavior:** Each session shows elapsed time: `⚙ running  12m 34s` / `✓ done  8m 12s`.

Closes #27

## Existing Architecture

The TUI renders an Issues table and a Claude Sessions panel. `state.rs` tracks `Entry` history with issue number, title, timestamp, and outcome. `worker.rs` spawns tmux sessions but doesn't record start times. `tui.rs` renders status without timing data.

```mermaid
graph TD
    W[worker.rs] -->|spawns| T[tmux sessions]
    W -->|writes Entry| S[state.rs]
    TUI[tui.rs] -->|reads sessions| S
    TUI -->|reads tmux| T
    S -->|Entry: number, title, timestamp, outcome| DB[(state.json)]
    style S fill:#f66,stroke:#333
    style TUI fill:#f66,stroke:#333
```

## Proposed Architecture

Added `started_at` to `Entry` for duration calculation. Added `list_repo_sessions_with_age()` to batch-query tmux `session_created` timestamps. TUI now computes and displays elapsed time for both running and completed sessions.

```mermaid
graph TD
    W[worker.rs] -->|spawns + records started_at| T[tmux sessions]
    W -->|writes Entry with started_at| S[state.rs]
    TUI[tui.rs] -->|reads sessions + age| S
    TUI -->|reads tmux session_created| T
    S -->|Entry: + started_at| DB[(state.json)]
    TUI -->|format_elapsed| FE[elapsed display]
    style S fill:#6f6,stroke:#333
    style TUI fill:#6f6,stroke:#333
    style FE fill:#69f,stroke:#333
```

## Key Changes

### Timing infrastructure (state.rs + worker.rs)
- Added `started_at: Option<String>` to `Entry` with `#[serde(default)]` for backward compatibility
- `list_repo_sessions_with_age()` batch-queries tmux for `session_created` timestamps
- `worker.rs` captures `started_at = Utc::now().to_rfc3339()` before spawning

### TUI display (tui.rs)
- `format_elapsed(seconds)` formats as `Xs` / `Xm Ys` / `Xh Ym Zs`
- Issues table Status column widened to 24 chars, shows elapsed next to status
- Claude Sessions panel has new "Elapsed" column with live timer

### Clippy cleanup (lock.rs, tui.rs)
- Collapsed nested `if`/`if let` to let-chains (pre-existing clippy warnings)
- Changed `&PathBuf` → `&Path` parameter type
- Removed dead `session_created_timestamp` function

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 15 passed (format_elapsed, Entry serde, session parsing) |
| Clippy | ✅ | `cargo clippy -- -D warnings` clean |
| Build | ✅ | `cargo check` succeeds |
| Format | ✅ | `cargo fmt --check` clean |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>