### PR TITLE
feat(looper): enforce TDD red-green cycle in Doer agent

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -16,26 +16,40 @@ reviewer — report all findings but do NOT fix code or modify any files.
 
 ## Instructions
 
-1. **Verify Doer committed work** — Before reviewing, confirm a doer commit exists:
+1. **Verify Doer committed work (TDD sequence)** — The Doer must produce two
+   commits per iteration: `do-red` (tests) then `do-green` (implementation).
+
+   ```bash
+   red_hash=$(git log --grep="Loop-Phase: do-red" --grep="Loop-Iteration: $ITERATION" \
+       --all-match --format="%H" -1)
+   green_hash=$(git log --grep="Loop-Phase: do-green" --grep="Loop-Iteration: $ITERATION" \
+       --all-match --format="%H" -1)
+   ```
+
+   If either is empty, also check for a legacy single `do` commit:
    ```bash
    doer_hash=$(git log --grep="Loop-Phase: do" --grep="Loop-Iteration: $ITERATION" \
        --all-match --format="%H" -1)
    ```
-   If `doer_hash` is empty, the Doer did not commit. Issue a FAIL verdict immediately:
-   ```bash
-   $SCRIPTS_DIR/git-commit-loop \
-       --type "test" \
-       --scope "$TASK_NAME" \
-       --message "check iteration $ITERATION — FAIL (no doer commit)" \
-       --body "Doer did not produce a commit for this iteration.\n\n## Action items for next iteration\n1. Doer must commit work before the Checker can review." \
-       --phase "check" \
-       --iteration $ITERATION \
-       --verdict "FAIL"
-   ```
-   Then stop — do not proceed with the review.
 
-2. **Read context (parallel)** — Run all three git queries as separate Bash
-   tool calls in a single message:
+   - If `red_hash` AND `green_hash` exist: TDD flow followed. Proceed.
+   - If only `doer_hash` exists: Legacy flow — proceed but flag as [WARNING]:
+     "Doer used single commit instead of TDD red-green sequence."
+   - If none exist: Issue FAIL immediately:
+     ```bash
+     $SCRIPTS_DIR/git-commit-loop \
+         --type "test" \
+         --scope "$TASK_NAME" \
+         --message "check iteration $ITERATION — FAIL (no doer commit)" \
+         --body "Doer did not produce a commit for this iteration.\n\n## Action items for next iteration\n1. Doer must commit work before the Checker can review." \
+         --phase "check" \
+         --iteration $ITERATION \
+         --verdict "FAIL"
+     ```
+     Then stop — do not proceed with the review.
+
+2. **Read context (parallel)** — Run git queries as separate Bash tool calls
+   in a single message:
 
    **Call 1 — Get the plan:**
    ```bash
@@ -43,24 +57,30 @@ reviewer — report all findings but do NOT fix code or modify any files.
        --all-match --format="%B" -1
    ```
 
-   **Call 2 — Get the doer's summary:**
+   **Call 2 — Get the RED commit (tests) summary + diff:**
    ```bash
-   git log --grep="Loop-Phase: do" --grep="Loop-Iteration: $ITERATION" \
-       --all-match --format="%B" -1
+   h=$(git log --grep="Loop-Phase: do-red" --grep="Loop-Iteration: $ITERATION" \
+       --all-match --format="%H" -1) && [ -n "$h" ] && git show --stat "$h"
    ```
 
-   **Call 3 — Get the doer's diff (changed files + stats):**
+   **Call 3 — Get the GREEN commit (implementation) summary + diff:**
    ```bash
-   git log --grep="Loop-Phase: do" --grep="Loop-Iteration: $ITERATION" \
-       --all-match --format="%H" -1 | xargs git show --stat
+   h=$(git log --grep="Loop-Phase: do-green" --grep="Loop-Iteration: $ITERATION" \
+       --all-match --format="%H" -1) && [ -n "$h" ] && git show --stat "$h"
    ```
 
-   All three MUST be launched as separate Bash tool calls in one message.
+   **Call 4 (fallback) — Get legacy doer commit if no red/green found:**
+   ```bash
+   h=$(git log --grep="Loop-Phase: do" --grep="Loop-Iteration: $ITERATION" \
+       --all-match --format="%H" -1) && [ -n "$h" ] && git show --stat "$h"
+   ```
+
+   All calls MUST be launched as separate Bash tool calls in one message.
 
    The values for `$TASK_NAME` and `$ITERATION` are provided in the dynamic
    context injected into this session.
 
-3. **Spawn 5 parallel review subagents** — Launch all five as separate AgentFallback
+3. **Spawn 6 parallel review subagents** — Launch all six as separate AgentFallback
    tool calls in a single message. Each subagent receives the plan summary,
    doer summary, changed files list, and acceptance criteria from step 2.
 
@@ -71,8 +91,12 @@ reviewer — report all findings but do NOT fix code or modify any files.
 
    ## Context
    - Plan summary: <from step 2 Call 1>
-   - Doer summary: <from step 2 Call 2>
-   - Changed files: <from step 2 Call 3>
+   - RED commit (tests): <from step 2 Call 2>
+   - GREEN commit (implementation): <from step 2 Call 3>
+   - Legacy doer commit (if no red/green): <from step 2 Call 4>
+
+   NOTE: Step 2 provides file lists and stats only. Use Read/Glob to
+   fetch actual file contents for any file you need to review.
 
    ## Your Focus
    <specific focus area — see below>
@@ -158,8 +182,13 @@ reviewer — report all findings but do NOT fix code or modify any files.
 
      **Phase 1 — Before snapshot (baseline):**
      1. Save the current HEAD: `current_head=$(git rev-parse HEAD)`
-     2. Checkout the commit BEFORE the doer's changes:
-        `git stash && git checkout HEAD~1`
+     2. Find the plan commit (the commit just before the doer's work) and
+        checkout it as the baseline:
+        ```
+        baseline=$(git log --grep="Loop-Phase: plan" --grep="Loop-Iteration: $ITERATION" \
+            --all-match --format="%H" -1)
+        git stash && git checkout "$baseline"
+        ```
      3. Install dependencies: `$SCRIPTS_DIR/install-deps`
      4. Start the dev server on `$LOOPER_DEV_PORT` in background.
      5. Exercise the specific endpoints/pages related to the task (see
@@ -201,9 +230,25 @@ reviewer — report all findings but do NOT fix code or modify any files.
    - Report: any runtime errors, broken endpoints, UI regressions, unfixed
      ticket scenarios, unexpected behavior, or crashes. Each issue is a BLOCKER.
 
-   All five MUST be launched as separate AgentFallback tool calls in one message.
+   **Subagent 6 — TDD Sequence Verifier:**
+   - Verify the `do-red` commit exists and contains ONLY test files
+     (files matching common test patterns: `*test*`, `*spec*`, `__tests__/*`,
+     `tests/*`, `*_test.*`). If source files are in the red commit, flag as
+     [BLOCKER]: "RED commit contains implementation files — tests must be
+     written before implementation."
+   - Verify the `do-green` commit exists and contains ONLY source files
+     (no new test files). Minor test fixes (typo, assertion correction) are
+     acceptable as [WARNING], but new test files are [BLOCKER].
+   - Verify the `do-red` commit was created BEFORE `do-green` (check commit
+     timestamps or ancestry: `git merge-base --is-ancestor $red_hash $green_hash`).
+   - If only a legacy `do` commit exists (no red/green split), flag as
+     [WARNING]: "TDD sequence not followed — single commit instead of
+     red-green split."
+   - Report: TDD compliance issues, file classification, severity
 
-4. **Collect and consolidate results** — After all 5 subagents complete:
+   All six MUST be launched as separate AgentFallback tool calls in one message.
+
+4. **Collect and consolidate results** — After all 6 subagents complete:
    - Gather all BLOCKER issues (must fix before PASS)
    - Gather all WARNING issues (should fix)
    - Note SUGGESTION issues for the verdict body only

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -7,12 +7,12 @@ model: sonnet
 
 # Doer Agent
 
-You are the **Doer** agent in a Plan-Do-Check loop.
+You are the **Doer** agent in a Plan-Do-Check loop. You follow **TDD (Test-Driven Development)**.
 
 ## Your Mission
 
-Implement the plan from the Planner agent. Write code and unit tests, run
-checks, fix issues, and commit your work.
+Implement the plan from the Planner agent using a strict red-green TDD cycle:
+write failing tests first, then write just enough code to make them pass.
 
 ## Instructions
 
@@ -27,122 +27,98 @@ checks, fix issues, and commit your work.
 
 2. **Explore before implementing (parallel)** — Before writing code, if the
    plan references 3+ files, spawn Explore subagents in parallel to read the
-   files the plan will modify. Group files by area (source, tests, config) —
-   one subagent per group. Skip this step if the plan only touches 1-2 small
-   files (direct Read is faster than subagent overhead).
+   files the plan will modify and existing test files for convention reference.
+   Group files by area (source, tests, config) — one subagent per group.
+   Skip this step if the plan only touches 1-2 small files (direct Read is
+   faster than subagent overhead).
 
-3. **Implement the plan (delegation strategy)** — Choose based on plan size:
+---
 
-   **Small plans (1-3 files):** Implement directly. Write/edit files yourself:
-   - Create and modify files as specified
-   - Install dependencies if needed (`$SCRIPTS_DIR/install-deps`)
-   - Follow existing project conventions and patterns
-   - After implementation, spawn a test-writing subagent using the
-     **Test-writing subagent prompt template** below. The test subagent
-     receives:
-     - The full plan
-     - The implementation code just written (read the file contents)
-     - The project's existing test conventions (detect from test directory)
-     - Instructions to write tests covering the new/changed functionality
-     - A reminder to follow existing test patterns and naming conventions
-   - Wait for the test subagent to complete BEFORE proceeding to step 4
-     (checks). The test subagent writes files, so it must finish before
-     Round 1 auto-fix checks run to avoid write-write race conditions.
+### Phase 1: RED — Write failing tests
 
-   **Large plans (4+ files):** Delegate to parallel subagents:
-   a. Group the plan steps by area (source, tests, config) or by subsystem.
-   b. For each group, spawn a subagent (using the AgentFallback tool) with:
-      - The relevant subset of the plan
-      - The current contents of files that will be modified (from step 2)
-      - Instructions to write/edit only the files in its group
-      - A reminder to follow project conventions from <project-context>
-   c. Include a dedicated test-writing subagent in the same parallel batch:
-      - It receives the full plan's test-related requirements and the list of
-        source files being implemented
-      - It writes corresponding test files for the new/changed functionality
-      - It MUST NOT modify source files — only create/modify test files
-   d. Launch all implementation subagents AND the test subagent as parallel
-      AgentFallback calls in one message.
-   e. After all subagents complete, review their output for consistency:
-      - Check that imports/exports between subagent groups are compatible
-      - Verify shared types/interfaces are consistent
-      - Fix any integration issues between subagent outputs
-      - Fix any mismatches where tests reference functions not yet implemented
-   f. Install dependencies if needed (`$SCRIPTS_DIR/install-deps`)
-   g. Proceed to step 4 (checks).
+**Resume check:** Before starting RED, check if a `do-red` commit already
+exists for this iteration:
+```bash
+git log --grep="Loop-Phase: do-red" --grep="Loop-Iteration: $ITERATION" \
+    --all-match --format="%H" -1
+```
+If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
 
-   **Subagent prompt template:**
-   ```
-   You are an implementation subagent. Your task is to implement the following
-   portion of a plan. Write and edit ONLY the files listed below.
+3. **Write tests first** — Based on the plan's test descriptions and
+   acceptance criteria, write test files ONLY. Do NOT write any implementation
+   code yet.
 
-   ## Project Context
-   <include project-context>
-
-   ## Your Assignment
-   <subset of the plan for this group>
-
-   ## Files You Own
-   <list of files this subagent should create/modify>
-
-   ## Current File Contents
-   <contents of files from exploration step>
-
-   ## Rules
-   - ONLY modify files in your assignment
-   - Follow the project conventions exactly
-   - Do NOT run tests or commit — the parent agent handles that
-   - Do NOT install dependencies — the parent agent handles that
-   ```
-
-   **Test-writing subagent prompt template:**
-   ```
-   You are a test-writing subagent. Your task is to write unit tests for the
-   implementation described below.
-
-   ## Project Context
-   <include project-context>
-
-   ## Implementation Plan
-   <the full plan>
-
-   ## Issue Context
-   <include issue-context — the original ticket/issue body from the dynamic context>
-
-   ## Source Files Being Implemented
-   <list of source files and their expected contents from the plan>
-
-   ## Existing Test Patterns
-   <contents of 1-2 existing test files for convention reference>
-
-   ## Rules
-   - Write unit tests that cover the new/changed functionality
-   - Follow the existing test conventions and patterns exactly
+   - Follow existing test conventions and patterns exactly
    - Place test files in the project's test directory following existing structure
-   - Test edge cases: null/empty inputs, error conditions, boundary values
-   - Use descriptive test names that describe behavior
-   - Do NOT modify source files — only create/modify test files
-   - Do NOT run tests or commit — the parent agent handles that
-
-   ## CRITICAL: Acceptance Criteria Tests
-   - You MUST write at least one test derived directly from the ticket/issue
-     acceptance criteria or user-reported scenario — NOT from the implementation.
-   - These tests should verify the user's expected behavior as described in the
-     issue, independent of how the code implements it.
+   - Use descriptive test names that describe expected behavior
    - For bug fixes: write a regression test that reproduces the exact bug
-     scenario from the issue. This test should FAIL on the old code and PASS
-     on the new code.
-   - For features: write a test that exercises the feature exactly as described
-     in the user story or acceptance criteria.
-   - Name these tests clearly, e.g.: "should [expected behavior from ticket]"
-   - If no issue context is provided, derive acceptance tests from the plan's
-     acceptance criteria instead.
+     scenario from the issue
+   - For features: write a test that exercises the feature as described in
+     the acceptance criteria
+   - Tests should import/reference functions or modules that may not exist yet —
+     this is expected in TDD. Use the interfaces described in the plan.
+   - **Compiled languages (Rust, Go, Java, TypeScript):** If tests fail to
+     compile because the module/function doesn't exist yet, create minimal
+     stub files to make tests compile but still fail assertions. Stubs should
+     contain only signatures with placeholder bodies (`todo!()`, `panic()`,
+     `throw new Error("not implemented")`, etc.). These stubs are test
+     scaffolding, not implementation — include them in the RED commit.
+   - Install dependencies if needed (`$SCRIPTS_DIR/install-deps`)
+
+4. **Verify tests FAIL** — Run the tests:
+   ```bash
+   $SCRIPTS_DIR/run-tests 2>&1; echo "EXIT_CODE=$?"
    ```
 
-4. **Run checks (two rounds)** — Before committing, verify your work:
+   - **Tests MUST fail.** This is the "red" in red-green.
+   - If tests pass unexpectedly, investigate: is the feature already
+     implemented? If so, note this in the RED commit body ("tests pass —
+     feature already exists") and proceed to GREEN with no changes needed.
+     Do NOT weaken tests to make them artificially fail.
+   - If tests pass because they are tautological (testing nothing meaningful),
+     rewrite them with real assertions.
+   - Tests must fail for the RIGHT reason: missing function, wrong return
+     value, unmet assertion — NOT syntax errors or import failures that
+     prevent compilation. If tests don't compile, fix them until they compile
+     but still fail assertions.
+   - Run lint/format to keep test files clean:
+     ```bash
+     $SCRIPTS_DIR/run-lint --fix
+     $SCRIPTS_DIR/run-format --fix
+     ```
 
-   **Round 1 — Auto-fix (sequential):** These modify files, so they MUST run
-   sequentially, not in parallel:
+5. **Commit RED** — Commit test files only:
+   ```bash
+   $SCRIPTS_DIR/git-commit-loop \
+       --type "test" \
+       --scope "$TASK_NAME" \
+       --message "red: add failing tests for iteration $ITERATION" \
+       --body "<describe what the tests verify and why they fail>" \
+       --phase "do-red" \
+       --iteration $ITERATION
+   ```
+
+---
+
+### Phase 2: GREEN — Write minimal implementation
+
+6. **Implement just enough to pass** — Write the minimum code to make the
+   failing tests pass. Do NOT:
+   - Add features beyond what the tests require
+   - Write additional tests (you already have them)
+   - Refactor or optimize (that comes later)
+   - Gold-plate error handling for untested paths
+
+   For large plans (4+ files), you may delegate implementation to parallel
+   subagents grouped by area. Each subagent receives:
+   - The relevant subset of the plan
+   - The current test files (so they know what interface to implement)
+   - Instructions to write/edit only source files in their group
+   After subagents complete, review for consistency between groups.
+
+7. **Run checks (two rounds):**
+
+   **Round 1 — Auto-fix (sequential):**
    ```bash
    $SCRIPTS_DIR/run-lint --fix
    ```
@@ -151,35 +127,30 @@ checks, fix issues, and commit your work.
    $SCRIPTS_DIR/run-format --fix
    ```
 
-   **Round 2 — Validation (parallel):** These are read-only after Round 1.
-   Run them as separate Bash calls in a single message:
+   **Round 2 — Validation (parallel):** Run as separate Bash calls in one
+   message:
    - `$SCRIPTS_DIR/run-tests`
    - `$SCRIPTS_DIR/run-typecheck`
 
-   **Error handling:** If Round 2 fails:
-   1. Read the full error output carefully.
-   2. Fix the root cause (not just suppress the error). If test files written by
-      the test subagent fail, fix the test code directly (do not re-spawn a
-      subagent — direct edits are faster for small fixes).
-   3. Re-run Round 1 (lint --fix, then format --fix) to keep formatting clean
-      after code fixes.
-   4. Re-run Round 2 (tests + typecheck in parallel) to confirm the fix.
-   5. Only proceed to commit if all checks pass. If a check cannot be fixed
-      (e.g., a pre-existing flaky test), document it explicitly in the commit body.
+   **Tests MUST pass.** This is the "green" in red-green. If tests still fail:
+   1. Read the full error output carefully
+   2. Fix the implementation (not the tests — tests were locked in the RED phase)
+   3. Re-run Round 1 + Round 2
+   4. Only modify tests if they have a genuine bug (wrong assertion, typo),
+      NOT because the implementation took a different approach
 
-5. **Commit your work** — Use git-commit-loop with the appropriate type:
+8. **Commit GREEN** — Commit implementation files. Choose the commit type
+   based on the nature of the change: `feat` for new features, `fix` for
+   bug fixes, `refactor` for restructuring.
    ```bash
    $SCRIPTS_DIR/git-commit-loop \
-       --type "feat" \
+       --type "<feat|fix|refactor>" \
        --scope "$TASK_NAME" \
-       --message "<concise description>" \
-       --body "<summary of changes>" \
-       --phase "do" \
+       --message "green: implement to pass tests for iteration $ITERATION" \
+       --body "<summary of implementation>" \
+       --phase "do-green" \
        --iteration $ITERATION
    ```
-
-   Use `feat` for new features, `fix` for bug fixes, `refactor` for restructuring,
-   `test` for test-only changes, `docs` for documentation.
 
 ## Available Skills
 
@@ -197,13 +168,14 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
 ## Rules
 
 - Follow the plan closely — don't go off-script unless necessary
-- Always write unit tests alongside implementation — use a test subagent for this
-- **Ensure the test subagent receives the issue context** from the dynamic
-  context (the `## Issue Context` section). The test subagent MUST write at
-  least one acceptance-criteria test derived from the ticket, not just from
-  the implementation code.
+- **TDD is mandatory.** Always write tests FIRST (RED), commit them, then
+  implement (GREEN), commit that. Two commits per iteration, not one.
+- **Do not write implementation during RED.** Only test files.
+- **Do not write new tests during GREEN.** Only source files. Fix tests only
+  if they have a genuine bug (wrong assertion, typo).
+- Tests must be derived from acceptance criteria and issue context, not from
+  implementation details.
 - Run tests and fix failures before committing
-- Create a SINGLE commit at the end with all your changes
 - If a skill exits with non-zero, investigate and fix the issue
 - If you cannot complete part of the plan, still commit what you have and
   document what's incomplete in the commit body

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -45,8 +45,8 @@ modify any project files — only commit a plan as a git commit message.
      6. If the bug cannot be reproduced, report that — it changes the plan.
      This subagent has: Read, Bash, Glob, Grep, Skill.
 
-   All tracks MUST be launched as separate tool calls in one message to
-   maximize parallelism.
+   All applicable tracks MUST be launched as separate tool calls in one
+   message to maximize parallelism.
 
 3. **Deep exploration (parallel)** — If the task involves multiple areas
    (e.g., source + tests, frontend + backend, multiple services), spawn up to 5
@@ -70,14 +70,25 @@ modify any project files — only commit a plan as a git commit message.
    - Goal statement (what this iteration will accomplish)
    - Specific files to create or modify
    - Implementation details for each step
-   - Expected test approach
+   - **Tests to write first** (describe specific test cases with expected
+     behavior — these will be written BEFORE implementation)
    - Acceptance criteria (how the Checker will know the task is done)
    - Any risks or considerations
 
-   **Scope discipline:** Prefer the smallest change that satisfies the task.
-   A plan that touches 3 files and has clear acceptance criteria is better than
-   one that touches 10 files. If the task is large, plan only the first
-   meaningful slice and note what is deferred.
+   **Scope discipline — TDD-sized slices:** Plan the smallest meaningful slice,
+   not the full task. One behavior, one test case, one code change. A plan that
+   adds one test and one function is better than a plan that touches 10 files.
+   If the task is large, plan only the first vertical slice and note what is
+   deferred to later iterations. Each iteration should be completable in a
+   single red-green cycle:
+   1. Write a failing test (red)
+   2. Write just enough code to make it pass (green)
+
+   The Doer follows TDD — tests are written first, then implementation. Your
+   plan must describe the tests clearly enough for the Doer to write them
+   WITHOUT having seen the implementation yet. Frame tests in terms of
+   expected behavior ("when X happens, Y should result"), not implementation
+   details ("function Z should call W").
 
 4.5. **Review the draft plan (parallel subagents)** — Spawn 3 review subagents
    in parallel via separate AgentFallback tool calls in a single message. Each receives
@@ -147,7 +158,7 @@ modify any project files — only commit a plan as a git commit message.
    - Flag risky changes (modifying shared utilities, changing public APIs,
      altering DB schemas)
    - Suggest simpler alternatives if the approach is over-engineered
-   - Check the plan is achievable in a single Doer commit
+   - Check the plan is achievable in a single red-green cycle
    - Report: [WARNING] for scope creep, [SUGGESTION] for simplifications
 
    All three MUST be launched as separate AgentFallback tool calls in one message.

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -201,7 +201,7 @@ to complete before proceeding to the next.
 1. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: PLAN phase ===`
    `Agent(subagent_type="looper:planner", prompt=<context from 7c>)`
 
-2. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: DO phase ===`
+2. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: DO phase (TDD: red→green) ===`
    `Agent(subagent_type="looper:doer", prompt=<context from 7c>)`
 
 3. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: CHECK phase ===`

--- a/plugins/looper/skills/looper/scripts/detect-resume
+++ b/plugins/looper/skills/looper/scripts/detect-resume
@@ -6,8 +6,12 @@ set -euo pipefail
 # Outputs a single integer (the start iteration) to stdout.
 # Info messages go to stderr.
 
-LAST_ITERATION=$(git log --grep="Loop-Iteration:" --format="%B" -1 2>/dev/null \
-    | grep -oE 'Loop-Iteration: [0-9]+' | sed 's/Loop-Iteration: //' || echo "0")
+# Single query to extract all loop metadata from the most recent loop commit
+LAST_COMMIT=$(git log --grep="Loop-Iteration:" --format="%B" -1 2>/dev/null || echo "")
+
+LAST_ITERATION=$(echo "$LAST_COMMIT" | grep -oE 'Loop-Iteration: [0-9]+' | sed 's/Loop-Iteration: //' || echo "0")
+LAST_VERDICT=$(echo "$LAST_COMMIT" | grep -oE 'Loop-Verdict: (PASS|FAIL)' | sed 's/Loop-Verdict: //' || echo "")
+LAST_PHASE=$(echo "$LAST_COMMIT" | grep -oE 'Loop-Phase: [a-z-]+' | sed 's/Loop-Phase: //' || echo "")
 
 # Validate that the extracted iteration number is a valid integer
 if ! [[ "$LAST_ITERATION" =~ ^[0-9]+$ ]]; then
@@ -15,15 +19,21 @@ if ! [[ "$LAST_ITERATION" =~ ^[0-9]+$ ]]; then
     LAST_ITERATION=0
 fi
 
-LAST_VERDICT=$(git log --grep="Loop-Verdict:" -1 --format="%B" 2>/dev/null \
-    | grep -oE 'Loop-Verdict: (PASS|FAIL)' | sed 's/Loop-Verdict: //' || echo "")
-
-if [ "$LAST_VERDICT" = "FAIL" ]; then
+if [ "$LAST_VERDICT" = "PASS" ]; then
+    START=$(( LAST_ITERATION + 1 ))
+    echo "[detect-resume] Prior iteration $LAST_ITERATION PASSED. Starting fresh iteration $START" >&2
+elif [ "$LAST_VERDICT" = "FAIL" ]; then
     START=$(( LAST_ITERATION + 1 ))
     echo "[detect-resume] Resuming from iteration $START (last verdict: FAIL)" >&2
 elif [ "$LAST_ITERATION" -gt 0 ] 2>/dev/null; then
     START=$LAST_ITERATION
-    echo "[detect-resume] Resuming mid-iteration $START" >&2
+    # Report TDD phase progress for mid-iteration resume
+    case "$LAST_PHASE" in
+        plan)     echo "[detect-resume] Resuming mid-iteration $START (PLAN committed, DO pending)" >&2 ;;
+        do-red)   echo "[detect-resume] Resuming mid-iteration $START (RED committed, GREEN pending)" >&2 ;;
+        do-green) echo "[detect-resume] Resuming mid-iteration $START (RED+GREEN committed, CHECK pending)" >&2 ;;
+        *)        echo "[detect-resume] Resuming mid-iteration $START" >&2 ;;
+    esac
 else
     START=1
 fi

--- a/plugins/looper/skills/looper/scripts/git-commit-loop
+++ b/plugins/looper/skills/looper/scripts/git-commit-loop
@@ -34,8 +34,8 @@ if [ -z "$TYPE" ] || [ -z "$SCOPE" ] || [ -z "$MESSAGE" ] || [ -z "$PHASE" ] || 
 fi
 
 # Validate phase
-if [[ "$PHASE" != "plan" && "$PHASE" != "do" && "$PHASE" != "check" ]]; then
-    echo "Error: --phase must be plan, do, or check" >&2
+if [[ "$PHASE" != "plan" && "$PHASE" != "do" && "$PHASE" != "check" && "$PHASE" != "do-red" && "$PHASE" != "do-green" ]]; then
+    echo "Error: --phase must be plan, do, do-red, do-green, or check" >&2
     exit 1
 fi
 

--- a/plugins/looper/skills/looper/scripts/git-loop-context
+++ b/plugins/looper/skills/looper/scripts/git-loop-context
@@ -55,20 +55,25 @@ _extract_body() {
     '
 }
 
-# Helper: extract doer commit hash
-_extract_doer_hash() {
-    local iter="$1"
-    echo "$ALL_LOG" | awk -v iter="$iter" '
-        /^__COMMIT__/ { hash=substr($0,11); in_commit=1; is_do=0; is_iter=0; next }
+# Helper: extract commit hash for a given phase and iteration
+_extract_hash() {
+    local phase="$1" iter="$2"
+    echo "$ALL_LOG" | awk -v phase="$phase" -v iter="$iter" '
+        /^__COMMIT__/ { hash=substr($0,11); in_commit=1; is_phase=0; is_iter=0; next }
         /^__END__$/ {
-            if (in_commit && is_do && is_iter) print hash
+            if (in_commit && is_phase && is_iter) print hash
             in_commit=0; next
         }
         in_commit {
-            if ($0 ~ "^Loop-Phase: do$") is_do=1
+            if ($0 ~ "^Loop-Phase: " phase "$") is_phase=1
             if ($0 ~ "^Loop-Iteration: " iter "$") is_iter=1
         }
     '
+}
+
+# Helper: extract doer commit hash (legacy do phase)
+_extract_doer_hash() {
+    _extract_hash "do" "$1"
 }
 
 # Helper: strip loop trailers from body text
@@ -133,13 +138,19 @@ for (( i=1; i<ITERATION; i++ )); do
             echo ""
         fi
 
-        doer_hash=$(_extract_doer_hash "$i")
-        if [ -n "$doer_hash" ]; then
-            echo "#### Files changed"
-            echo '```'
-            git show --stat --format="" "$doer_hash" 2>/dev/null || true
-            echo '```'
+        # TDD: check for red/green commits or fallback to legacy do
+        if [ -n "$(_extract_body "do-red" "$i")" ] || [ -n "$(_extract_body "do-green" "$i")" ]; then
+            echo "#### TDD: RED then GREEN"
             echo ""
+        else
+            doer_hash=$(_extract_doer_hash "$i")
+            if [ -n "$doer_hash" ]; then
+                echo "#### Files changed"
+                echo '```'
+                git show --stat --format="" "$doer_hash" 2>/dev/null || true
+                echo '```'
+                echo ""
+            fi
         fi
 
         if [ -n "$verdict_body" ]; then
@@ -169,19 +180,58 @@ for (( i=1; i<ITERATION; i++ )); do
         echo ""
     fi
 
-    doer_info_hash=$(_extract_doer_hash "$i")
-    doer_body=$(_extract_body "do" "$i")
-    if [ -n "$doer_body" ]; then
-        echo "#### Changes"
-        echo ""
-        echo "$doer_body" | _strip_trailers
-        echo ""
-        if [ -n "$doer_info_hash" ]; then
-            echo "**Files changed:**"
-            echo '```'
-            git show --stat --format="" "$doer_info_hash" 2>/dev/null || true
-            echo '```'
+    # TDD: check for do-red and do-green commits first
+    red_body=$(_extract_body "do-red" "$i")
+    green_body=$(_extract_body "do-green" "$i")
+
+    if [ -n "$red_body" ] || [ -n "$green_body" ]; then
+        if [ -n "$red_body" ]; then
+            echo "#### RED (Tests)"
             echo ""
+            echo "$red_body" | _strip_trailers
+            echo ""
+            red_hash=$(_extract_hash "do-red" "$i")
+            if [ -n "$red_hash" ]; then
+                echo "**Files changed:**"
+                echo '```'
+                git show --stat --format="" "$red_hash" 2>/dev/null || true
+                echo '```'
+                echo ""
+            fi
+        fi
+        if [ -n "$green_body" ]; then
+            echo "#### GREEN (Implementation)"
+            echo ""
+            echo "$green_body" | _strip_trailers
+            echo ""
+            green_hash=$(_extract_hash "do-green" "$i")
+            if [ -n "$green_hash" ]; then
+                echo "**Files changed:**"
+                echo '```'
+                git show --stat --format="" "$green_hash" 2>/dev/null || true
+                echo '```'
+                echo ""
+            fi
+        elif [ -n "$red_body" ]; then
+            echo "#### GREEN (Implementation) — not committed"
+            echo ""
+        fi
+    else
+        # Fallback: legacy single do commit
+        doer_info_hash=$(_extract_doer_hash "$i")
+        doer_body=$(_extract_body "do" "$i")
+        if [ -n "$doer_body" ]; then
+            echo "#### Changes"
+            echo ""
+            echo "$doer_body" | _strip_trailers
+            echo ""
+            if [ -n "$doer_info_hash" ]; then
+                echo "**Files changed:**"
+                echo '```'
+                git show --stat --format="" "$doer_info_hash" 2>/dev/null || true
+                echo '```'
+                echo ""
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary

- **Doer** now follows strict TDD: writes failing tests first (RED commit with `do-red` phase), then writes minimal implementation (GREEN commit with `do-green` phase). Includes resume-skip for mid-iteration recovery, compiled-language stub guidance, and handling for "tests pass unexpectedly."
- **Checker** gains a 6th review subagent (TDD Sequence Verifier) that validates the red→green commit sequence, file classification, and ordering. Also fixes fragile `HEAD~1` baseline with plan-commit lookup and replaces non-portable `xargs -r`.
- **Planner** scopes to TDD-sized slices (one behavior, one test, one code change) and frames test descriptions in terms of expected behavior so the Doer can write them before implementation.
- **Scripts**: `git-commit-loop` accepts `do-red`/`do-green` phases; `detect-resume` consolidates 3 queries into 1 and handles PASS re-invocation; `git-loop-context` shows file stats for RED/GREEN commits and indicates missing GREEN on crash/resume.

## Test plan

- [ ] Run `/looper` on a simple feature task — verify Doer produces two commits (do-red then do-green)
- [ ] Verify Checker's TDD Sequence Verifier flags missing red/green commits
- [ ] Test resume: kill looper after do-red commit, re-invoke — verify it skips RED and goes straight to GREEN
- [ ] Test compiled language project (Rust/TS) — verify stubs are created in RED phase
- [ ] Verify legacy single `do` commit workflows still work with WARNING (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)