### PR TITLE
fix(agents): add tech stack compliance guardrails to prevent wrong-ecosystem scaffolding

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -155,8 +155,16 @@ reviewer — report all findings but do NOT fix code or modify any files.
    - Review correctness: does the code match the plan's acceptance criteria?
    - Review edge cases: null checks, error handling, boundary conditions, empty
      inputs, concurrent access, resource cleanup
+   - **Tech stack compliance check.** Read the plan's "Tech Stack Constraints"
+     section (if present) and verify the Doer's implementation uses ONLY the
+     specified technologies. Flag each violation as [BLOCKER] — Tech Stack
+     Compliance failure if:
+     - Files from a different ecosystem are present (e.g., package.json when
+       the constraint says Rust-only)
+     - Dependencies from the wrong package manager were installed
+     - A framework other than the one specified was scaffolded
    - Report: logic errors, missing error handling, unmet acceptance criteria,
-     severity, file+line, suggested fixes
+     tech stack compliance violations, severity, file+line, suggested fixes
 
    **Subagent 4 — Code Quality & Maintainability Reviewer:**
    - Run `$SCRIPTS_DIR/run-lint 2>&1; echo "EXIT_CODE=$?"`

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -168,6 +168,12 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
 ## Rules
 
 - Follow the plan closely — don't go off-script unless necessary
+- **Tech stack compliance.** Before implementing, check the plan for any
+  "Tech Stack Constraints" section. If the plan specifies a tech stack,
+  framework, or language, use ONLY that stack. Do not scaffold or install
+  packages from a different ecosystem (e.g., do not use npm/Next.js when
+  the plan says Rust/Axum). If you are unsure whether a dependency fits
+  the specified stack, err on the side of not adding it.
 - **TDD is mandatory.** Always write tests FIRST (RED), commit them, then
   implement (GREEN), commit that. Two commits per iteration, not one.
 - **Do not write implementation during RED.** Only test files.

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -73,6 +73,8 @@ modify any project files — only commit a plan as a git commit message.
    - **Tests to write first** (describe specific test cases with expected
      behavior — these will be written BEFORE implementation)
    - Acceptance criteria (how the Checker will know the task is done)
+   - **Tech Stack Constraints** (list any framework, language, or architecture
+     requirements from the issue body that the implementation must follow)
    - Any risks or considerations
 
    **Scope discipline — TDD-sized slices:** Plan the smallest meaningful slice,
@@ -210,6 +212,15 @@ The `$SCRIPTS_DIR` path is injected as a task variable in your dynamic context.
   dynamic context, derive acceptance criteria from the user's actual reported
   scenario — not just from code reading. The plan must address the specific
   behavior described in the issue.
+- **Tech stack compliance.** If the issue body specifies a tech stack,
+  framework, language, or architecture constraint (e.g., "use Axum + askama",
+  "no JS framework", "same binary"), the plan MUST respect those constraints
+  exactly. Extract tech stack requirements from the issue body and list them
+  explicitly in the plan as "Tech Stack Constraints" before the implementation
+  steps. If the detected project stack (from detect-stack) conflicts with the
+  issue's specified stack, follow the issue — it represents the user's intent.
+  Never substitute a different framework or language than what the issue
+  specifies.
 - **Include reproduction results.** If Track D (Reproduce/Observe) ran, include
   the observed current behavior in the plan so the Doer understands what is
   actually happening vs. what should happen.

--- a/plugins/looper/tests/test-tech-stack-prompts.sh
+++ b/plugins/looper/tests/test-tech-stack-prompts.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-tech-stack-prompts.sh — Verify that agent prompt files contain
+# tech stack compliance instructions added to address issue #42.
+
+AGENTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../agents" && pwd)"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local file="$2"
+    local pattern="$3"
+
+    if grep -q "$pattern" "$file"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  Expected pattern '$pattern' in $file"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# planner.md must contain a "Tech stack compliance" rule
+check "planner.md contains Tech stack compliance rule" \
+    "$AGENTS_DIR/planner.md" \
+    "Tech stack compliance"
+
+# planner.md must mention extracting tech stack constraints from the issue body
+check "planner.md instructs to extract tech stack from issue body" \
+    "$AGENTS_DIR/planner.md" \
+    "Tech Stack Constraints"
+
+# doer.md must contain a "Tech stack compliance" rule
+check "doer.md contains Tech stack compliance rule" \
+    "$AGENTS_DIR/doer.md" \
+    "Tech stack compliance"
+
+# doer.md must warn against using wrong ecosystem (e.g., npm/Next.js when plan says Rust/Axum)
+check "doer.md warns against wrong ecosystem" \
+    "$AGENTS_DIR/doer.md" \
+    "Tech Stack Constraints"
+
+# checker.md must contain a tech stack compliance check in the Logic Reviewer section
+check "checker.md contains tech stack compliance check" \
+    "$AGENTS_DIR/checker.md" \
+    "[Tt]ech [Ss]tack [Cc]ompliance"
+
+# checker.md must flag wrong-ecosystem files as BLOCKER
+check "checker.md flags wrong-ecosystem files as BLOCKER" \
+    "$AGENTS_DIR/checker.md" \
+    "BLOCKER.*[Tt]ech [Ss]tack\|[Tt]ech [Ss]tack.*BLOCKER"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/plugins/looper/tests/test-worktree-enforcement.sh
+++ b/plugins/looper/tests/test-worktree-enforcement.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-worktree-enforcement.sh — Verify that looper skill enforces
+# worktree isolation and prevents committing directly to main/default branch.
+# Addresses issue #42: Looper committed directly to main without worktree.
+
+SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills" && pwd)"
+LOOPER_SKILL="$SKILLS_DIR/looper/SKILL.md"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local file="$2"
+    local pattern="$3"
+
+    if grep -q "$pattern" "$file"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  Expected pattern '$pattern' in $file"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# looper/SKILL.md must require creating a worktree before any work
+check "looper SKILL.md requires worktree creation" \
+    "$LOOPER_SKILL" \
+    "setup-worktree"
+
+# looper/SKILL.md must have a gate that aborts if worktree creation fails
+check "looper SKILL.md has worktree creation gate" \
+    "$LOOPER_SKILL" \
+    "WORKTREE_DIR.*empty.*abort\|abort.*WORKTREE_DIR.*empty\|setup-worktree.*exits non-zero"
+
+# looper/SKILL.md must state CRITICAL: never commit directly to default branch
+check "looper SKILL.md forbids committing directly to default branch" \
+    "$LOOPER_SKILL" \
+    "NEVER commit directly to the default branch"
+
+# looper/SKILL.md must verify loop/ branch before proceeding
+check "looper SKILL.md verifies loop/ branch" \
+    "$LOOPER_SKILL" \
+    "loop/"
+
+# looper/SKILL.md must forbid local merges
+check "looper SKILL.md forbids local merges" \
+    "$LOOPER_SKILL" \
+    "never merge locally\|CRITICAL.*never merge\|never merge.*CRITICAL"
+
+# looper/SKILL.md must direct to create-github-pr for merging
+check "looper SKILL.md uses create-github-pr for merging" \
+    "$LOOPER_SKILL" \
+    "create-github-pr"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem / Task

Closes #42. The looper ignored tech stack constraints specified in a GitHub issue body (e.g., "use Axum + askama, no JS framework") and scaffolded a Next.js app instead. It also committed directly to `main` without using a worktree or feature branch.

**Current behavior:** Agent prompts have no mechanism to extract, propagate, or enforce tech stack requirements from issue descriptions. The Planner doesn't extract them, the Doer doesn't check them, and the Checker doesn't flag violations.

**Expected behavior:** When an issue specifies a tech stack, all three agents respect it — the Planner extracts constraints into the plan, the Doer follows them, and the Checker blocks wrong-ecosystem implementations.

## Existing Architecture

The three PDC agents (Planner, Doer, Checker) each have prompt files that guide their behavior. The worktree enforcement was already fixed in commit `2efbfa9`, but no tech stack compliance guardrails existed in any agent prompt.

```mermaid
graph TD
    P[Planner Agent] -->|produces plan| D[Doer Agent]
    D -->|produces code| C[Checker Agent]
    C -->|verdict| V{PASS/FAIL}
    style P fill:#f66,stroke:#333
    style D fill:#f66,stroke:#333
    style C fill:#f66,stroke:#333
```

## Proposed Architecture

Each agent now has a "Tech stack compliance" rule that forms a chain: Planner extracts constraints → Doer follows them → Checker enforces them.

```mermaid
graph TD
    P[Planner Agent] -->|"plan + Tech Stack Constraints section"| D[Doer Agent]
    D -->|"code using correct stack"| C[Checker Agent]
    C -->|"tech stack compliance check"| V{PASS/FAIL}
    style P fill:#6f6,stroke:#333
    style D fill:#6f6,stroke:#333
    style C fill:#6f6,stroke:#333
```

## Key Changes

### 1. Planner: Extract tech stack from issue body
- New "Tech stack compliance" rule requires extracting tech stack requirements from issue body
- New "Tech Stack Constraints" section added to the plan structure template
- If detect-stack conflicts with the issue's specified stack, the issue takes precedence

### 2. Doer: Follow specified stack only
- New rule: check plan's "Tech Stack Constraints" before implementing
- Explicit prohibition against scaffolding from wrong ecosystem (e.g., npm/Next.js when plan says Rust/Axum)

### 3. Checker: Block wrong-ecosystem violations
- Logic Reviewer (Subagent 3) now includes tech stack compliance check
- Wrong-ecosystem files, wrong package manager, wrong framework scaffolding are flagged as [BLOCKER]

### 4. Regression tests
- `test-tech-stack-prompts.sh` — 6 assertions verifying all three agent prompts contain tech stack compliance keywords
- `test-worktree-enforcement.sh` — 6 assertions verifying SKILL.md enforces worktree isolation (regression test for the worktree fix in 2efbfa9)

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| test-tech-stack-prompts.sh | ✅ | 6 passed, 0 failed |
| test-worktree-enforcement.sh | ✅ | 6 passed, 0 failed |
| ShellCheck | ✅ | All scripts clean |
| JSON validation | ✅ | plugin.json and marketplace.json valid |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>