### PR TITLE
fix(scripts): guard against core.bare=true on main repo during worktree ops

### DIFF
--- a/plugins/looper/skills/create-github-pr/SKILL.md
+++ b/plugins/looper/skills/create-github-pr/SKILL.md
@@ -428,6 +428,9 @@ cd "$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
 
 # Remove the worktree
 git worktree remove "$WORKTREE_DIR" --force
+
+# Ensure core.bare was not set to true by the worktree removal
+git config core.bare false
 ```
 
 If worktree removal fails, warn but do not abort — the merge already succeeded.

--- a/plugins/looper/skills/looper-ee/scripts/ensure-repo
+++ b/plugins/looper/skills/looper-ee/scripts/ensure-repo
@@ -6,6 +6,13 @@ set -euo pipefail
 # Outputs JSON to stdout: {"repo_dir": "...", "owner": "...", "repo": "...", "issue_number": "...", "full_repo": "..."}
 # Info/warnings go to stderr.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOPER_HELPERS="$SCRIPT_DIR/../../looper/scripts/_helpers.sh"
+if [ -f "$LOOPER_HELPERS" ]; then
+    # shellcheck disable=SC1090,SC1091
+    source "$LOOPER_HELPERS"
+fi
+
 URL=""
 
 while [[ $# -gt 0 ]]; do
@@ -51,6 +58,11 @@ else
         echo "Error: Failed to clone $FULL_REPO" >&2
         exit 1
     fi
+fi
+
+# Guard against core.bare=true which can be set on cloned repos
+if declare -f ensure_not_bare >/dev/null 2>&1; then
+    ensure_not_bare "$REPO_DIR"
 fi
 
 # Output JSON for the caller

--- a/plugins/looper/skills/looper/scripts/_helpers.sh
+++ b/plugins/looper/skills/looper/scripts/_helpers.sh
@@ -44,3 +44,24 @@ load_stack() {
         "$SCRIPT_DIR/detect-stack"
     fi
 }
+
+# ensure_not_bare — Detect and fix core.bare=true on a git repo directory.
+# Usage: ensure_not_bare [repo_dir]
+# If repo_dir is omitted, uses the current git toplevel.
+# Emits a warning to stderr when it fixes the issue.
+ensure_not_bare() {
+    local repo_dir="${1:-}"
+    if [ -z "$repo_dir" ]; then
+        repo_dir=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    fi
+    if [ -z "$repo_dir" ]; then
+        return 0
+    fi
+    local bare_val
+    bare_val=$(git -C "$repo_dir" config --get core.bare 2>/dev/null || echo "")
+    if [ "$bare_val" = "true" ]; then
+        echo "[looper] WARNING: core.bare=true detected on $repo_dir — fixing it now" >&2
+        git -C "$repo_dir" config core.bare false
+        echo "[looper] core.bare has been reset to false on $repo_dir" >&2
+    fi
+}

--- a/plugins/looper/skills/looper/scripts/setup-worktree
+++ b/plugins/looper/skills/looper/scripts/setup-worktree
@@ -6,6 +6,10 @@ set -euo pipefail
 # Outputs the absolute worktree path to stdout.
 # Warnings/info go to stderr.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_helpers.sh"
+
 TASK=""
 
 while [[ $# -gt 0 ]]; do
@@ -18,6 +22,22 @@ done
 if [ -z "$TASK" ]; then
     echo "Usage: setup-worktree --task <name>" >&2
     exit 1
+fi
+
+# Guard against core.bare=true before using git rev-parse (which fails on bare repos).
+# Derive the repo root from the absolute .git path without relying on --show-toplevel.
+_GIT_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || true)
+if [ -n "$_GIT_DIR" ]; then
+    # For a normal repo: .git dir is <repo-root>/.git, so strip trailing /.git
+    _CANDIDATE_ROOT="${_GIT_DIR%/.git}"
+    if [ "$_CANDIDATE_ROOT" != "$_GIT_DIR" ]; then
+        ensure_not_bare "$_CANDIDATE_ROOT"
+    else
+        # Might already be at the root (e.g. bare-style path): try pwd
+        ensure_not_bare "$(pwd)"
+    fi
+else
+    ensure_not_bare "$(pwd)"
 fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -50,6 +70,9 @@ else
     git worktree add -b "$BRANCH" "$WORKTREE_DIR" HEAD >/dev/null 2>&1
     echo "[setup-worktree] Created worktree at $WORKTREE_DIR (new branch $BRANCH)" >&2
 fi
+
+# Guard again after worktree creation (git worktree add can sometimes trigger bare inference)
+ensure_not_bare "$REPO_ROOT"
 
 # Warn about uncommitted changes
 if [ -n "$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null)" ]; then

--- a/plugins/looper/skills/looper/scripts/sync-with-remote
+++ b/plugins/looper/skills/looper/scripts/sync-with-remote
@@ -9,6 +9,21 @@ set -euo pipefail
 #   1 = conflicts (rebase paused, manual resolution needed)
 #   2 = error (fetch failed, no remote, etc.)
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_helpers.sh"
+
+# Guard against core.bare=true which would cause sync operations to fail
+_GIT_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || true)
+if [ -n "$_GIT_DIR" ]; then
+    _CANDIDATE_ROOT="${_GIT_DIR%/.git}"
+    if [ "$_CANDIDATE_ROOT" != "$_GIT_DIR" ]; then
+        ensure_not_bare "$_CANDIDATE_ROOT"
+    else
+        ensure_not_bare "$(pwd)"
+    fi
+fi
+
 # Fetch latest from origin
 if ! git fetch origin 1>&2; then
     echo "[sync] ERROR: git fetch origin failed" >&2

--- a/plugins/looper/tests/test-worktree-enforcement.sh
+++ b/plugins/looper/tests/test-worktree-enforcement.sh
@@ -56,6 +56,13 @@ check "looper SKILL.md uses create-github-pr for merging" \
     "$LOOPER_SKILL" \
     "create-github-pr"
 
+SETUP_WORKTREE_SCRIPT="$SKILLS_DIR/looper/scripts/setup-worktree"
+
+# setup-worktree must contain a bare-repo guard
+check "setup-worktree script contains bare-repo guard" \
+    "$SETUP_WORKTREE_SCRIPT" \
+    "ensure_not_bare\|core\.bare"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 

--- a/tests/test-bare-repo-guard.sh
+++ b/tests/test-bare-repo-guard.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-bare-repo-guard.sh — Tests for bare-repo guard (ensure_not_bare helper)
+# Verifies that looper scripts detect and fix core.bare=true on the main repo.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_SH="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/_helpers.sh"
+SETUP_WORKTREE="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/setup-worktree"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+    if [ -n "${TMPDIR_TEST:-}" ] && [ -d "${TMPDIR_TEST:-}" ]; then
+        # Remove any nested worktrees first
+        git -C "$TMPDIR_TEST" worktree prune 2>/dev/null || true
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_eq() {
+    local description="$1"
+    local actual="$2"
+    local expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_eq() {
+    local description="$1"
+    local actual="$2"
+    local unexpected="$3"
+    if [ "$actual" != "$unexpected" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (value should not be '$unexpected', but it was)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -qi "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output to contain '$expected')"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_not_contains() {
+    local description="$1"
+    local output="$2"
+    local unexpected="$3"
+    if ! echo "$output" | grep -qi "$unexpected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output NOT to contain '$unexpected')"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+setup_test_repo() {
+    TMPDIR_TEST=$(mktemp -d)
+    git init -q "$TMPDIR_TEST"
+    git -C "$TMPDIR_TEST" config user.email "test@test.com"
+    git -C "$TMPDIR_TEST" config user.name "Test User"
+    git -C "$TMPDIR_TEST" config commit.gpgsign false
+    git -C "$TMPDIR_TEST" commit --allow-empty -q -m "initial commit"
+}
+
+# --- Test 1: ensure_not_bare fixes core.bare=true ---
+echo "=== Test 1: ensure_not_bare fixes core.bare=true ==="
+setup_test_repo
+
+git -C "$TMPDIR_TEST" config core.bare true
+BARE_BEFORE=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_eq "core.bare is true before fix" "$BARE_BEFORE" "true"
+
+# Source helpers and call ensure_not_bare
+set +e
+OUTPUT=$(bash -c "
+    set -euo pipefail
+    SCRIPT_DIR='$(dirname "$HELPERS_SH")'
+    source '$HELPERS_SH'
+    ensure_not_bare '$TMPDIR_TEST'
+" 2>&1)
+EXIT_CODE=$?
+set -e
+
+assert_exit_zero "ensure_not_bare exits 0 when fixing bare repo" "$EXIT_CODE"
+BARE_AFTER=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_not_eq "core.bare is no longer true after fix" "$BARE_AFTER" "true"
+assert_output_contains "ensure_not_bare emits a warning when fixing" "$OUTPUT" "warn\|bare\|fix"
+
+cleanup
+
+# --- Test 2: ensure_not_bare is a no-op when core.bare is not set ---
+echo "=== Test 2: ensure_not_bare is a no-op when core.bare is false/unset ==="
+setup_test_repo
+
+# core.bare should not be set (or false) for a freshly init'd repo
+BARE_BEFORE=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_not_eq "core.bare is not true before test" "$BARE_BEFORE" "true"
+
+set +e
+OUTPUT=$(bash -c "
+    set -euo pipefail
+    SCRIPT_DIR='$(dirname "$HELPERS_SH")'
+    source '$HELPERS_SH'
+    ensure_not_bare '$TMPDIR_TEST'
+" 2>&1)
+EXIT_CODE=$?
+set -e
+
+assert_exit_zero "ensure_not_bare exits 0 for normal repo" "$EXIT_CODE"
+assert_output_not_contains "ensure_not_bare emits no warning for normal repo" "$OUTPUT" "warn"
+
+cleanup
+
+# --- Test 3: setup-worktree succeeds even when core.bare=true ---
+echo "=== Test 3: setup-worktree succeeds and fixes core.bare=true ==="
+setup_test_repo
+
+git -C "$TMPDIR_TEST" config core.bare true
+BARE_BEFORE=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_eq "core.bare is true before setup-worktree" "$BARE_BEFORE" "true"
+
+set +e
+OUTPUT=$(cd "$TMPDIR_TEST" && "$SETUP_WORKTREE" --task "test-bare-fix" 2>&1)
+EXIT_CODE=$?
+set -e
+
+assert_exit_zero "setup-worktree exits 0 even when core.bare was true" "$EXIT_CODE"
+
+BARE_AFTER=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_not_eq "core.bare is no longer true after setup-worktree" "$BARE_AFTER" "true"
+
+WORKTREE_PATH="$TMPDIR_TEST/.worktrees/test-bare-fix"
+if [ -d "$WORKTREE_PATH" ]; then
+    echo "PASS: setup-worktree created the worktree directory"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: setup-worktree did not create the worktree directory at $WORKTREE_PATH"
+    FAIL=$((FAIL + 1))
+fi
+
+cleanup
+
+# --- Test 4: After creating a worktree, core.bare stays false ---
+echo "=== Test 4: After creating a worktree, core.bare stays false on main repo ==="
+setup_test_repo
+
+set +e
+OUTPUT=$(cd "$TMPDIR_TEST" && "$SETUP_WORKTREE" --task "test-stays-false" 2>&1)
+EXIT_CODE=$?
+set -e
+
+assert_exit_zero "setup-worktree succeeds on normal repo" "$EXIT_CODE"
+
+BARE_AFTER=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_not_eq "core.bare stays not-true after worktree creation" "$BARE_AFTER" "true"
+
+cleanup
+
+# --- Test 5: After removing a worktree, core.bare stays false ---
+echo "=== Test 5: After removing a worktree, core.bare stays false ==="
+setup_test_repo
+
+# Create a worktree
+cd "$TMPDIR_TEST"
+git -C "$TMPDIR_TEST" worktree add "$TMPDIR_TEST/.worktrees/temp-wt" -b "loop/temp-task" HEAD >/dev/null 2>&1
+
+BARE_AFTER_ADD=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_not_eq "core.bare stays not-true after worktree add" "$BARE_AFTER_ADD" "true"
+
+# Remove the worktree
+git -C "$TMPDIR_TEST" worktree remove "$TMPDIR_TEST/.worktrees/temp-wt" --force >/dev/null 2>&1 || true
+
+BARE_AFTER_REMOVE=$(git -C "$TMPDIR_TEST" config --get core.bare 2>/dev/null || echo "unset")
+assert_not_eq "core.bare stays not-true after worktree removal" "$BARE_AFTER_REMOVE" "true"
+
+cleanup
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem / Task

Worktree operations from `/looper`, `/looper-issue`, and `/looper-ee` can cause `core.bare=true` to be set on the main repository's git config. This makes it impossible for the user to work normally on the main branch (e.g., `git status`, `git rev-parse --show-toplevel` fail).

**Current behavior:** After certain worktree create/remove cycles, `core.bare=true` gets set on the main repo, breaking normal git operations on the default branch.
**Expected behavior:** The main repo's `core.bare` stays `false` regardless of worktree operations.

## Existing Architecture

Before this fix, worktree scripts (`setup-worktree`, `sync-with-remote`, `ensure-repo`) had no protection against `core.bare=true`. If git inferred bare mode during worktree operations, the main repo became unusable.

```mermaid
graph TD
    A["/looper or /looper-issue"] --> B["setup-worktree"]
    B --> C["git worktree add"]
    C --> D["sync-with-remote"]
    D --> E["PDC Loop"]
    E --> F["create-github-pr"]
    F --> G["git worktree remove"]
    G --> H["Main repo: core.bare=true ❌"]
    style H fill:#f66,stroke:#333
```

## Proposed Architecture

Added `ensure_not_bare()` helper to `_helpers.sh` that detects and fixes `core.bare=true`. All entry points now call this guard before and after worktree operations.

```mermaid
graph TD
    A["/looper or /looper-issue"] --> B["setup-worktree"]
    B --> B1["ensure_not_bare ✓"]
    B1 --> C["git worktree add"]
    C --> B2["ensure_not_bare ✓"]
    B2 --> D["sync-with-remote"]
    D --> D1["ensure_not_bare ✓"]
    D1 --> E["PDC Loop"]
    E --> F["create-github-pr"]
    F --> G["git worktree remove"]
    G --> G1["git config core.bare false ✓"]
    G1 --> H["Main repo: core.bare=false ✅"]
    style B1 fill:#6f6,stroke:#333
    style B2 fill:#6f6,stroke:#333
    style D1 fill:#6f6,stroke:#333
    style G1 fill:#6f6,stroke:#333
    style H fill:#6f6,stroke:#333
```

## Key Changes

- **`_helpers.sh`**: Added `ensure_not_bare()` function — detects `core.bare=true` via `git -C`, fixes it with `git config core.bare false`, and logs a warning to stderr.
- **`setup-worktree`**: Guards before `git rev-parse --show-toplevel` (using `--absolute-git-dir` to derive repo root even when bare) and again after `git worktree add`.
- **`sync-with-remote`**: Guards at script start before any fetch/rebase operations.
- **`ensure-repo` (looper-ee)**: Guards after clone/fetch to catch bare repos.
- **`create-github-pr/SKILL.md`**: Added `git config core.bare false` after `git worktree remove` in Phase 6b.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Bare repo guard tests | ✅ | 15 passed, 0 failed |
| Worktree enforcement tests | ✅ | 7 passed, 0 failed |
| ShellCheck | ✅ | All modified scripts clean |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>