### PR TITLE
feat(create-github-pr): use regular merge when DB migrations detected

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "looper",
       "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "author": {
         "name": "code-salad"
       },
@@ -18,7 +18,7 @@
     {
       "name": "webscraping",
       "description": "End-to-end web scraping toolkit — domain recon, method selection, .NET 10 implementation, anti-detection, and proxy management",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "author": {
         "name": "code-salad"
       },
@@ -28,7 +28,7 @@
     {
       "name": "fallback-agent",
       "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "author": {
         "name": "code-salad"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "looper",
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "author": {
     "name": "code-salad"
   },

--- a/crates/fallback-agent/Cargo.toml
+++ b/crates/fallback-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fallback-agent"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 description = "Fallback Agent MCP Server — spawns nested Claude processes"
 

--- a/crates/looper-watch/Cargo.toml
+++ b/crates/looper-watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "looper-watch"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Standalone GitHub issue watcher — polls for unassigned issues and dispatches them to claude"
 

--- a/plugins/fallback-agent/.claude-plugin/plugin.json
+++ b/plugins/fallback-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fallback-agent",
   "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "author": {
     "name": "code-salad"
   },

--- a/plugins/looper/.claude-plugin/plugin.json
+++ b/plugins/looper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "looper",
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "author": {
     "name": "code-salad"
   },

--- a/plugins/looper/skills/create-github-pr/SKILL.md
+++ b/plugins/looper/skills/create-github-pr/SKILL.md
@@ -404,16 +404,50 @@ Check status manually: gh pr checks $PR_NUMBER
 
 ---
 
-## Phase 6: Squash Merge (if CI passed)
+## Phase 6: Merge (if CI passed)
 
-After CI passes, squash-merge the PR and clean up.
+After CI passes, merge the PR using the appropriate strategy and clean up.
 
-### 6a. Squash merge
+### 6a-pre. Detect DB migrations in changeset
+
+Before merging, check whether the PR contains DB migration files. This determines
+which merge strategy to use.
+
+```bash
+# Detect if PR contains DB migration files
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+HAS_MIGRATIONS=false
+
+# Check for common migration directory patterns
+if echo "$CHANGED_FILES" | grep -qiE \
+    '(migrations?/|db/migrate|alembic/versions|flyway|prisma/migrations|drizzle/|knex/migrations|sequelize/migrations|typeorm/migrations|migrate.*\.sql$|migration.*\.sql$)'; then
+    HAS_MIGRATIONS=true
+fi
+```
+
+Migration patterns detected:
+- `migrations/` or `migration/` — generic migration directories (Django, Flask, Knex, Sequelize, TypeORM, etc.)
+- `db/migrate/` — Rails ActiveRecord migrations
+- `alembic/versions/` — Python/Alembic migrations
+- `prisma/migrations/` — Prisma ORM migrations
+- `drizzle/` — Drizzle ORM migration files
+- `knex/migrations/` — Knex.js migrations
+- `sequelize/migrations/` — Sequelize migrations
+- `typeorm/migrations/` — TypeORM migrations
+- `flyway/` — Flyway SQL migrations
+- Files matching `migrate*.sql` or `migration*.sql`
+
+### 6a. Merge using appropriate strategy
 
 Only proceed if ALL CI checks passed in Phase 5. If any check failed or timed out, skip this phase entirely.
 
 ```bash
-gh pr merge $PR_NUMBER --squash --delete-branch
+if [ "$HAS_MIGRATIONS" = true ]; then
+    echo "DB migrations detected — using regular merge to preserve migration commit history."
+    gh pr merge $PR_NUMBER --merge --delete-branch
+else
+    gh pr merge $PR_NUMBER --squash --delete-branch
+fi
 ```
 
 If the merge fails (e.g., merge conflicts, branch protection rules), report the error to the user and do NOT retry. The user may need to resolve conflicts or adjust branch protection settings.
@@ -437,9 +471,15 @@ If worktree removal fails, warn but do not abort — the merge already succeeded
 
 ### 6c. Report final status
 
-**If merge succeeded:**
+**If merge succeeded (no migrations detected — squash merge):**
 ```
 ✅ PR #<number> squash-merged into <BASE_BRANCH> and branch deleted.
+<PR URL>
+```
+
+**If merge succeeded (DB migrations detected — regular merge):**
+```
+✅ PR #<number> merged (non-squash — DB migrations detected) into <BASE_BRANCH> and branch deleted.
 <PR URL>
 ```
 
@@ -448,8 +488,9 @@ If worktree removal fails, warn but do not abort — the merge already succeeded
 ⚠️ PR #<number> CI passed but merge failed: <error reason>
 <PR URL>
 
-Merge manually: gh pr merge <number> --squash
+Merge manually: gh pr merge <number> --merge
 ```
+(Use `--squash` instead of `--merge` if no migrations were detected.)
 
 ---
 
@@ -468,8 +509,9 @@ Merge manually: gh pr merge <number> --squash
 | CI checks time out (>20 min) | Report timeout, print PR URL, give manual check command |
 | No CI checks configured | Note "no CI checks configured", print PR URL, complete normally |
 | `gh pr checks --watch` not supported | Fall back to manual polling loop (30s intervals, 40 attempts) |
-| Squash merge fails (conflicts) | Report error, print manual merge command, do NOT retry |
+| Squash merge fails (conflicts) | Report error, print manual merge command (`--squash` or `--merge` depending on migration detection), do NOT retry |
 | Squash merge fails (branch protection) | Report error, suggest user review branch protection settings |
+| Regular merge fails (migrations detected) | Report error, print manual merge command `gh pr merge <number> --merge`, do NOT retry |
 | Worktree cleanup fails | Warn but do not abort — merge already succeeded |
 
 ---

--- a/plugins/looper/skills/looper-ee/SKILL.md
+++ b/plugins/looper/skills/looper-ee/SKILL.md
@@ -15,7 +15,7 @@ locally, then delegating to the looper skill.
 **CRITICAL:** All work MUST happen in an isolated git worktree (the `/looper`
 skill creates one). Changes are delivered via a GitHub pull request — never
 merged locally into the default branch. The full flow is:
-worktree → PDC loop → push branch → create PR → wait CI → squash merge.
+worktree → PDC loop → push branch → create PR → wait CI → merge (squash, or regular if DB migrations are present).
 
 ---
 

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -294,13 +294,15 @@ eval "$SYNC_OUTPUT"   # sets DEFAULT_BRANCH, STATUS
 
 - **PASS:** Report success with iteration count, then **you MUST invoke
   `/create-github-pr`** to push the branch and open a pull request against
-  the default branch. The PR skill will wait for CI, squash-merge on
-  success, and clean up the worktree automatically. If CI fails or merge
-  fails, the worktree is preserved for manual inspection.
+  the default branch. The PR skill will wait for CI, then merge on success
+  (squash merge by default, or regular merge if DB migration files are
+  detected in the changeset), and clean up the worktree automatically.
+  If CI fails or merge fails, the worktree is preserved for manual inspection.
 
   **CRITICAL — never merge locally:** Do NOT run `git merge`, `git checkout
   <default-branch>`, or any command that merges the loop branch into the
-  local default branch. All merging happens via the GitHub PR (squash merge).
+  local default branch. All merging happens via the GitHub PR (merge strategy
+  depends on whether migration files are present).
 
 - **FAIL (max iterations):** Report that max iterations were reached. Show
   the last checker verdict: `git log --grep="Loop-Verdict: FAIL" -1 --format="%B"`

--- a/plugins/looper/tests/test-migration-merge-strategy.sh
+++ b/plugins/looper/tests/test-migration-merge-strategy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-migration-merge-strategy.sh — Verify that create-github-pr skill contains
+# migration-aware merge logic that switches from squash to regular merge when
+# DB migration files are detected in the PR's changeset.
+
+SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills" && pwd)"
+CREATE_PR_SKILL="$SKILLS_DIR/create-github-pr/SKILL.md"
+LOOPER_SKILL="$SKILLS_DIR/looper/SKILL.md"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local file="$2"
+    local pattern="$3"
+
+    if grep -q "$pattern" "$file"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  Expected pattern '$pattern' in $file"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Test 1: create-github-pr SKILL.md contains migration detection logic
+check "create-github-pr SKILL.md contains migration detection logic" \
+    "$CREATE_PR_SKILL" \
+    "migration"
+
+# Test 2: create-github-pr SKILL.md supports regular merge for migrations
+check "create-github-pr SKILL.md supports regular merge for migrations" \
+    "$CREATE_PR_SKILL" \
+    "\-\-merge"
+
+# Test 3: create-github-pr SKILL.md lists migration path patterns
+check "create-github-pr SKILL.md lists migration path patterns" \
+    "$CREATE_PR_SKILL" \
+    "migrations/\|db/migrate\|alembic"
+
+# Test 4: create-github-pr SKILL.md conditionally chooses merge strategy
+check "create-github-pr SKILL.md conditionally chooses merge strategy" \
+    "$CREATE_PR_SKILL" \
+    "HAS_MIGRATIONS"
+
+# Test 5: looper SKILL.md references migration-aware merging
+check "looper SKILL.md references migration-aware merging" \
+    "$LOOPER_SKILL" \
+    "migration"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/plugins/webscraping/.claude-plugin/plugin.json
+++ b/plugins/webscraping/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "webscraping",
   "description": "End-to-end web scraping toolkit — domain recon, method selection, .NET 10 implementation, anti-detection, and proxy management",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "author": {
     "name": "code-salad"
   },


### PR DESCRIPTION
## Problem / Task

When a PR contains DB migration files, squash-merging collapses individual migration commits into a single commit. This can break migration ordering, lose migration metadata, and cause issues with ORMs that track migration history by commit.

**Current behavior:** All PRs are squash-merged regardless of content.
**Expected behavior:** PRs containing DB migration files should use a regular merge to preserve individual migration commits and their ordering.

## Existing Architecture

The `create-github-pr` skill always used `gh pr merge --squash --delete-branch` in Phase 6, with no awareness of the PR's content.

```mermaid
graph TD
    A[CI Passes] --> B[Phase 6: Squash Merge]
    B --> C["gh pr merge --squash --delete-branch"]
    C --> D[Worktree Cleanup]
    style B fill:#f66,stroke:#333
```

## Proposed Architecture

Phase 6 now includes a migration detection step (6a-pre) that scans changed files for common migration directory patterns. The merge strategy is chosen conditionally.

```mermaid
graph TD
    A[CI Passes] --> B["Phase 6a-pre: Detect DB Migrations"]
    B --> C{HAS_MIGRATIONS?}
    C -->|true| D["gh pr merge --merge --delete-branch"]
    C -->|false| E["gh pr merge --squash --delete-branch"]
    D --> F[Worktree Cleanup]
    E --> F
    style B fill:#69f,stroke:#333
    style C fill:#69f,stroke:#333
    style D fill:#6f6,stroke:#333
```

## Key Changes

### Migration-aware merge strategy (create-github-pr/SKILL.md)
- Added **Phase 6a-pre** that scans `git diff --name-only` for migration patterns
- Patterns cover: Django/Flask migrations/, Rails db/migrate, Alembic, Prisma, Drizzle, Knex, Sequelize, TypeORM, Flyway, and generic `*.sql` migration files
- Phase 6a conditionally uses `--merge` (migrations present) or `--squash` (no migrations)
- Updated reporting messages and error handling table

### Looper skill references (looper/SKILL.md, looper-ee/SKILL.md)
- Updated Step 8 and flow descriptions to reflect the conditional merge strategy

### Tests (tests/test-migration-merge-strategy.sh)
- 5 tests verifying migration detection logic, `--merge` flag, path patterns, `HAS_MIGRATIONS` conditional, and looper SKILL.md cross-reference

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Migration merge tests | ✅ | 5 passed, 0 failed |
| ShellCheck | ✅ | Clean |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>