### PR TITLE
fix(setup-worktree): branch from remote default instead of local HEAD

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "looper",
       "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
-      "version": "0.36.5",
+      "version": "0.36.6",
       "author": {
         "name": "code-salad"
       },
@@ -18,7 +18,7 @@
     {
       "name": "webscraping",
       "description": "End-to-end web scraping toolkit — domain recon, method selection, .NET 10 implementation, anti-detection, and proxy management",
-      "version": "0.36.4",
+      "version": "0.36.5",
       "author": {
         "name": "code-salad"
       },
@@ -28,7 +28,7 @@
     {
       "name": "fallback-agent",
       "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
-      "version": "0.36.4",
+      "version": "0.36.5",
       "author": {
         "name": "code-salad"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "fallback-agent"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "rmcp",
  "serde",
@@ -604,7 +604,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/fallback-agent/Cargo.toml
+++ b/crates/fallback-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fallback-agent"
-version = "3.5.2"
+version = "3.5.3"
 edition = "2021"
 description = "Fallback Agent MCP Server — spawns nested Claude processes"
 

--- a/crates/looper-watch/Cargo.toml
+++ b/crates/looper-watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "looper-watch"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 description = "Standalone GitHub issue watcher — polls for unassigned issues and dispatches them to claude"
 

--- a/plugins/fallback-agent/.claude-plugin/plugin.json
+++ b/plugins/fallback-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fallback-agent",
   "description": "Nested subagent — spawns fresh Claude processes with full tool access for unlimited nesting",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "author": {
     "name": "code-salad"
   },

--- a/plugins/looper/.claude-plugin/plugin.json
+++ b/plugins/looper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "looper",
   "description": "Plan-Do-Check loop orchestrator — three agents iterate until a Checker issues PASS",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "author": {
     "name": "code-salad"
   },

--- a/plugins/looper/skills/looper/scripts/setup-worktree
+++ b/plugins/looper/skills/looper/scripts/setup-worktree
@@ -55,8 +55,25 @@ if ! [ -f "$GITIGNORE" ] || ! grep -qxF '.worktrees' "$GITIGNORE"; then
     echo '.worktrees' >> "$GITIGNORE"
     git -C "$REPO_ROOT" add -- .gitignore
     git -C "$REPO_ROOT" diff --cached --quiet || \
-        git -C "$REPO_ROOT" commit -m "chore: gitignore .worktrees"
+        git -C "$REPO_ROOT" commit -m "chore: gitignore .worktrees" >/dev/null 2>&1
     echo "[setup-worktree] Added .worktrees to .gitignore" >&2
+fi
+
+# Detect remote default branch so new worktrees start from origin/<default-branch>
+# instead of local HEAD (which may contain unpushed commits).
+DEFAULT_REMOTE_BRANCH=""
+if git remote get-url origin >/dev/null 2>&1; then
+    git fetch origin 2>/dev/null || true
+    DEFAULT_REMOTE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+        | sed 's@^refs/remotes/origin/@@' || true)
+    if [ -z "$DEFAULT_REMOTE_BRANCH" ]; then
+        for candidate in main master alpha dev; do
+            if git show-ref --quiet "refs/remotes/origin/$candidate"; then
+                DEFAULT_REMOTE_BRANCH="$candidate"
+                break
+            fi
+        done
+    fi
 fi
 
 # Create or reuse worktree
@@ -66,9 +83,13 @@ if [ -d "$WORKTREE_DIR" ]; then
 elif git show-ref --quiet "refs/heads/$BRANCH"; then
     git worktree add "$WORKTREE_DIR" "$BRANCH" >/dev/null 2>&1
     echo "[setup-worktree] Created worktree at $WORKTREE_DIR (existing branch $BRANCH)" >&2
+elif [ -n "$DEFAULT_REMOTE_BRANCH" ] && git show-ref --quiet "refs/remotes/origin/$DEFAULT_REMOTE_BRANCH"; then
+    git worktree add -b "$BRANCH" "$WORKTREE_DIR" "origin/$DEFAULT_REMOTE_BRANCH" >/dev/null 2>&1
+    echo "[setup-worktree] Created worktree at $WORKTREE_DIR (new branch $BRANCH from origin/$DEFAULT_REMOTE_BRANCH)" >&2
 else
+    # Fallback: no remote detected — use local HEAD
     git worktree add -b "$BRANCH" "$WORKTREE_DIR" HEAD >/dev/null 2>&1
-    echo "[setup-worktree] Created worktree at $WORKTREE_DIR (new branch $BRANCH)" >&2
+    echo "[setup-worktree] Created worktree at $WORKTREE_DIR (new branch $BRANCH from HEAD — no remote detected)" >&2
 fi
 
 # Guard again after worktree creation (git worktree add can sometimes trigger bare inference)

--- a/plugins/looper/tests/test-setup-worktree-remote-base.sh
+++ b/plugins/looper/tests/test-setup-worktree-remote-base.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-setup-worktree-remote-base.sh — Regression tests for issue #47:
+# setup-worktree must branch from origin/<default-branch> instead of local HEAD.
+# This prevents unpushed local commits from leaking into task worktrees.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/looper/scripts"
+SETUP_WORKTREE="$SCRIPTS_DIR/setup-worktree"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local result="$2"
+
+    if [ "$result" = "true" ]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- A) Static check: setup-worktree references "origin/" for branch creation ---
+
+check "setup-worktree references origin/ for branch creation" \
+    "$(grep -q 'origin/' "$SETUP_WORKTREE" && echo true || echo false)"
+
+# --- B) Main regression test: unpushed commits must not leak into worktree ---
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+ORIGIN_DIR="$TMPDIR/origin.git"
+LOCAL_DIR="$TMPDIR/local"
+WORKTREE_DIR=""
+
+# Create bare origin repo
+git init --bare --initial-branch=main "$ORIGIN_DIR" >/dev/null 2>&1
+
+# Clone origin
+git clone "$ORIGIN_DIR" "$LOCAL_DIR" >/dev/null 2>&1
+cd "$LOCAL_DIR"
+
+# Configure git identity for commits
+git config user.email "test@test.com"
+git config user.name "Test User"
+git config commit.gpgsign false
+
+# Make initial commit and push to origin
+echo "initial" > INITIAL.md
+git add INITIAL.md
+git commit -m "initial commit" >/dev/null 2>&1
+git push origin main >/dev/null 2>&1
+PUSHED_SHA=$(git rev-parse HEAD)
+
+# Make second commit locally — do NOT push (simulates unpushed work)
+echo "unpushed" > UNPUSHED.md
+git add UNPUSHED.md
+git commit -m "unpushed commit" >/dev/null 2>&1
+LOCAL_HEAD_SHA=$(git rev-parse HEAD)
+
+# Sanity: local HEAD differs from pushed SHA
+check "local HEAD differs from pushed SHA (sanity)" \
+    "$([ "$LOCAL_HEAD_SHA" != "$PUSHED_SHA" ] && echo true || echo false)"
+
+# Run setup-worktree for a new task
+worktree_output=$("$SETUP_WORKTREE" --task test-task 2>/dev/null)
+# setup-worktree may emit multiple lines; the last line is the worktree path
+WORKTREE_DIR=$(echo "$worktree_output" | tail -1)
+
+# Worktree directory should exist
+check "worktree directory exists" \
+    "$([ -d "$WORKTREE_DIR" ] && echo true || echo false)"
+
+# Worktree should be on branch loop/test-task
+if [ -d "$WORKTREE_DIR" ]; then
+    WORKTREE_BRANCH=$(git -C "$WORKTREE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    check "worktree is on branch loop/test-task" \
+        "$([ "$WORKTREE_BRANCH" = "loop/test-task" ] && echo true || echo false)"
+
+    WORKTREE_HEAD=$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || echo "")
+
+    # KEY ASSERTION: worktree HEAD must equal the pushed SHA (not local HEAD)
+    check "worktree HEAD equals pushed (remote) SHA" \
+        "$([ "$WORKTREE_HEAD" = "$PUSHED_SHA" ] && echo true || echo false)"
+
+    # Unpushed commit must NOT be in worktree
+    check "worktree HEAD does not equal local (unpushed) HEAD SHA" \
+        "$([ "$WORKTREE_HEAD" != "$LOCAL_HEAD_SHA" ] && echo true || echo false)"
+
+    # Unpushed file must not exist in worktree
+    check "UNPUSHED.md does not exist in worktree" \
+        "$([ ! -f "$WORKTREE_DIR/UNPUSHED.md" ] && echo true || echo false)"
+else
+    check "worktree HEAD equals pushed (remote) SHA" "false"
+    check "worktree HEAD does not equal local (unpushed) HEAD SHA" "false"
+    check "UNPUSHED.md does not exist in worktree" "false"
+fi
+
+# --- C) Sync scenario: works when local and remote are in sync ---
+
+ORIGIN2_DIR="$TMPDIR/origin2.git"
+LOCAL2_DIR="$TMPDIR/local2"
+
+git init --bare --initial-branch=main "$ORIGIN2_DIR" >/dev/null 2>&1
+git clone "$ORIGIN2_DIR" "$LOCAL2_DIR" >/dev/null 2>&1
+cd "$LOCAL2_DIR"
+git config user.email "test@test.com"
+git config user.name "Test User"
+git config commit.gpgsign false
+
+echo "synced" > SYNCED.md
+git add SYNCED.md
+git commit -m "synced commit" >/dev/null 2>&1
+git push origin main >/dev/null 2>&1
+SYNC_SHA=$(git rev-parse HEAD)
+
+worktree_output2=$("$SETUP_WORKTREE" --task test-sync 2>/dev/null)
+WORKTREE2_DIR=$(echo "$worktree_output2" | tail -1)
+
+check "sync scenario: worktree directory exists" \
+    "$([ -d "$WORKTREE2_DIR" ] && echo true || echo false)"
+
+if [ -d "$WORKTREE2_DIR" ]; then
+    WORKTREE2_HEAD=$(git -C "$WORKTREE2_DIR" rev-parse HEAD 2>/dev/null || echo "")
+    check "sync scenario: worktree HEAD equals remote SHA" \
+        "$([ "$WORKTREE2_HEAD" = "$SYNC_SHA" ] && echo true || echo false)"
+else
+    check "sync scenario: worktree HEAD equals remote SHA" "false"
+fi
+
+# --- D) Resume scenario: re-running setup-worktree for same task resumes ---
+
+cd "$LOCAL_DIR"
+worktree_output_resume=$("$SETUP_WORKTREE" --task test-task 2>/dev/null)
+WORKTREE_RESUME=$(echo "$worktree_output_resume" | tail -1)
+
+check "resume scenario: same worktree path returned" \
+    "$([ "$WORKTREE_RESUME" = "$WORKTREE_DIR" ] && echo true || echo false)"
+
+if [ -d "$WORKTREE_DIR" ]; then
+    WORKTREE_RESUME_HEAD=$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || echo "")
+    check "resume scenario: HEAD unchanged after resume" \
+        "$([ "$WORKTREE_RESUME_HEAD" = "$PUSHED_SHA" ] && echo true || echo false)"
+else
+    check "resume scenario: HEAD unchanged after resume" "false"
+fi
+
+# --- Summary ---
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/plugins/webscraping/.claude-plugin/plugin.json
+++ b/plugins/webscraping/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "webscraping",
   "description": "End-to-end web scraping toolkit — domain recon, method selection, .NET 10 implementation, anti-detection, and proxy management",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "author": {
     "name": "code-salad"
   },


### PR DESCRIPTION
## Problem / Task

`setup-worktree` creates new loop branches from `HEAD` (the local branch tip) instead of the remote default branch. When the local default branch has unpushed commits, the new worktree inherits them, causing PRs to include unrelated changes.

**Current behavior:** `git worktree add -b "$BRANCH" "$WORKTREE_DIR" HEAD` uses local HEAD, which may contain unpushed commits from other completed loops.
**Expected behavior:** Worktrees should branch from `origin/<default-branch>` so each loop starts from the same baseline as the remote, producing clean PRs with only relevant changes.

Closes #47

## Existing Architecture

The `setup-worktree` script creates or resumes git worktrees for loop tasks. Previously, new branches always started from local `HEAD`.

```mermaid
graph TD
    A["setup-worktree --task NAME"] --> B{"Worktree exists?"}
    B -->|Yes| C["Resume existing worktree"]
    B -->|No branch| D{"Branch exists?"}
    D -->|Yes| E["Attach worktree to existing branch"]
    D -->|No| F["git worktree add -b BRANCH DIR HEAD"]
    style F fill:#f66,stroke:#333
```

## Proposed Architecture

New worktrees now branch from the remote tracking branch. Detection uses `git symbolic-ref refs/remotes/origin/HEAD` with fallback to common branch names (`main`, `master`, `alpha`, `dev`). If no remote is available, falls back gracefully to local `HEAD`.

```mermaid
graph TD
    A["setup-worktree --task NAME"] --> B{"Worktree exists?"}
    B -->|Yes| C["Resume existing worktree"]
    B -->|No branch| D{"Branch exists?"}
    D -->|Yes| E["Attach worktree to existing branch"]
    D -->|No| F{"Remote detected?"}
    F -->|Yes| G["Detect default remote branch"]
    G --> H["git worktree add -b BRANCH DIR origin/DEFAULT"]
    F -->|No| I["git worktree add -b BRANCH DIR HEAD (fallback)"]
    style G fill:#69f,stroke:#333
    style H fill:#6f6,stroke:#333
```

## Key Changes

**Remote default branch detection** — Before creating a new worktree, the script now fetches from origin and detects the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to checking for `main`/`master`/`alpha`/`dev` refs. This ensures worktrees start from the remote baseline.

**Graceful fallback** — If no remote is configured (e.g., local-only repos), the script falls back to `HEAD` as before, so existing workflows aren't broken.

**Regression test suite** — 11 tests covering: unpushed commit isolation, synced-repo scenario, resume behavior, and a static check that `origin/` is referenced.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Regression Tests | ✅ | 11 passed, 0 failed |
| Existing Worktree Tests | ✅ | 7 passed, 0 failed |
| ShellCheck | ✅ | Clean |
| Cargo Test | ✅ | 95 passed, 0 failed |
| Cargo Clippy | ✅ | No warnings |

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>