### PR TITLE
chore: remove attribution footers from skill templates

### DIFF
--- a/plugins/looper/skills/create-github-pr/SKILL.md
+++ b/plugins/looper/skills/create-github-pr/SKILL.md
@@ -246,8 +246,6 @@ git commit -m "$(cat <<'EOF'
 <type>: <short summary>
 
 <optional body: 1-2 sentences of context>
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"
 ```
@@ -321,10 +319,6 @@ gh pr create \
 | Build | ✅ / ❌ / ⏭️ | success / failure |
 
 ---
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"
 ```

--- a/plugins/looper/skills/git-commit/SKILL.md
+++ b/plugins/looper/skills/git-commit/SKILL.md
@@ -122,8 +122,6 @@ git commit -m "$(cat <<'EOF'
 <type>[optional scope][optional !]: <summary>
 
 [optional body]
-
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary
- Remove hardcoded `Co-Authored-By` lines from git-commit and create-github-pr skill templates
- Remove `Generated with Claude Code` footer from PR body template
- Attribution is controlled by user settings, not skill templates