### PR TITLE
feat(looper): systematic corner-case enumeration in Planner and Checker

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -173,6 +173,13 @@ reviewer — report all findings but do NOT fix code or modify any files.
      function calls or implementation details, flag as [BLOCKER]: "Missing
      behavioral tests — feature tests must verify user-observable behavior
      from the acceptance criteria, not just implementation internals."
+   - **Corner-case coverage is MANDATORY.** If the plan includes a "Corner
+     cases" section, verify that every listed corner case has a corresponding
+     test. List each corner case and whether it is covered. Each missing
+     corner-case test is a [BLOCKER]: "Missing corner-case test for: <case>.
+     The plan enumerated this corner case but no test covers it." If the plan
+     does NOT include a corner-case section, flag as [WARNING]: "Plan did not
+     enumerate corner cases — consider requesting the Planner add them."
    - **Acceptance-criteria coverage.** Verify that every acceptance criterion
      from the plan has at least one corresponding test. List each criterion
      and whether it is covered. Uncovered criteria are [BLOCKER]s.

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -84,6 +84,22 @@ modify any project files — only commit a plan as a git commit message.
        would, derived from the acceptance criteria. Cover the happy path and
        at least one edge case or error scenario.
      - Frame tests in terms of observable behavior, not implementation details.
+   - **Corner cases** — enumerate a dedicated list of corner cases to test.
+     Do not stop at "at least one edge case." Systematically consider:
+     - **Boundary values:** zero, one, max, off-by-one, empty collections
+     - **Null / missing input:** nil, undefined, empty string, missing keys
+     - **Error paths:** invalid input, permission denied, network failure,
+       timeout, malformed data
+     - **Type edge cases:** wrong types, unicode, special characters, very
+       long strings, negative numbers
+     - **Concurrency / ordering:** race conditions, duplicate calls,
+       out-of-order events (where applicable)
+     - **State transitions:** already-exists, already-deleted,
+       partially-completed, idempotency
+     Not every category will apply — skip irrelevant ones, but explicitly
+     list each corner case with its expected behavior. The Doer will write
+     a test for each one. Aim for 3-7 corner cases per task depending on
+     complexity.
    - Acceptance criteria (how the Checker will know the task is done)
    - **Tech Stack Constraints** (list any framework, language, or architecture
      requirements from the issue body that the implementation must follow)
@@ -175,6 +191,10 @@ modify any project files — only commit a plan as a git commit message.
      - For features: the plan MUST describe behavioral tests covering the
        happy path and at least one edge case. If tests are vague ("add tests
        for the feature") without specific scenarios, flag as [WARNING]
+     - The plan MUST include a "Corner cases" section enumerating specific
+       corner cases with expected behavior. If missing or contains only one
+       generic case, flag as [WARNING]: "Plan should enumerate systematic
+       corner cases (boundary values, null/missing input, error paths, etc.)"
    - Report: [BLOCKER] for unaddressed Checker feedback or missing regression
      test descriptions, [WARNING] for gaps
 


### PR DESCRIPTION
## Summary
- **Planner** now requires a dedicated "Corner cases" section listing 3-7 specific corner cases per task, drawn from categories: boundary values, null/missing input, error paths, type edge cases, concurrency, and state transitions. Replaces the old "at least one edge case" floor.
- **Planner's Completeness Reviewer** (subagent 2) now flags plans missing the corner-case section as [WARNING].
- **Checker's Test Checker** (subagent 2) now cross-references the plan's enumerated corner cases against actual tests, flagging each missing corner-case test as [BLOCKER].

## Test plan
- [ ] Run a looper loop on a feature task and verify the Planner outputs a "Corner cases" section
- [ ] Verify the Checker flags missing corner-case tests as BLOCKERs
- [ ] Verify the Completeness Reviewer warns when the corner-case section is absent