### PR TITLE
refactor(looper): extract inline SKILL.md logic into reusable scripts (#61)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "chrono",
  "clap",

--- a/plugins/looper/skills/looper-issue/SKILL.md
+++ b/plugins/looper/skills/looper-issue/SKILL.md
@@ -49,46 +49,21 @@ Store the result as `ISSUES`.
 
 ### 1b. Filter out blocked issues
 
-For each issue in `ISSUES`, apply the three blocking checks below. Remove any
-issue that fails at least one check.
-
-#### Label-based blocking
-
-Skip (block) the issue if any of its labels contain "blocked" or "dependencies"
-(case-insensitive match).
-
-```
-labels[].name | ascii_downcase | contains("blocked") or contains("dependencies")
-```
-
-#### Task-list dependency references
-
-Parse the issue body for lines matching either of these patterns:
-- `- [ ] Depends on #N`
-- `- [ ] #N`
-
-(where `N` is one or more digits)
-
-For each referenced issue number `N` found, check whether it is still open:
+For each issue in `ISSUES`, check if it is blocked using `check-blocked`:
 
 ```bash
-gh issue view N --json state --jq '.state'
+SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/plugins/looper}/skills/looper/scripts"
+ELIGIBLE_ISSUES=()
+for issue_number in $(echo "$ISSUES" | jq -r '.[].number'); do
+    if $SCRIPTS_DIR/check-blocked --issue "$issue_number" >/dev/null 2>&1; then
+        ELIGIBLE_ISSUES+=("$issue_number")
+    fi
+done
 ```
 
-If the result is `"OPEN"`, the issue is blocked. Skip it.
-
-#### "Blocked by" references
-
-Parse the issue body for lines matching the pattern:
-- `Blocked by #N` (case-insensitive)
-
-For each referenced issue number `N`, check whether it is still open:
-
-```bash
-gh issue view N --json state --jq '.state'
-```
-
-If the result is `"OPEN"`, the issue is blocked. Skip it.
+`check-blocked` applies three checks: label-based blocking ("blocked" or
+"dependencies" labels), task-list dependency references (`- [ ] Depends on #N`
+or `- [ ] #N`), and "Blocked by #N" references. Exit 0 means not blocked.
 
 ### 1c. Select issue
 

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -79,110 +79,27 @@ eval "$SYNC_OUTPUT"   # sets DEFAULT_BRANCH, STATUS
 
 ### 4c. Fetch issue body and check blocking deps (if referenced)
 
-Check if `$ARGUMENTS` contains a GitHub issue reference. Look for:
-- A GitHub issue URL matching `https://github.com/.+/issues/(\d+)`
-- A hash-prefixed issue number like `#123`
-- A plain issue number at the start of the arguments (e.g., "42 fix the bug")
-
-If an issue reference is found, extract the issue number and:
-
-1. **Fetch the full issue metadata** for blocking checks and agent context:
-   ```bash
-   ISSUE_JSON=$(gh issue view <NUMBER> --json title,body,labels,state)
-   # If the issue URL included a repo (owner/repo), add: --repo owner/repo
-   ```
-   - If fetch fails, set `ISSUE_BODY=""` and skip to step 5 (do not abort).
-
-2. **Check for blocking dependencies** — apply the same three checks used by
-   `looper-issue` and `looper-watch`. If any check triggers, **abort** with a
-   clear message instead of assigning and working on a blocked issue.
-
-   #### Label-based blocking
-
-   Skip (block) the issue if any of its labels contain "blocked" or
-   "dependencies" (case-insensitive match).
-
-   #### Task-list dependency references
-
-   Parse the issue body for lines matching either of these patterns:
-   - `- [ ] Depends on #N`
-   - `- [ ] #N`
-
-   (where `N` is one or more digits)
-
-   For each referenced issue number `N` found, check whether it is still open:
-
-   ```bash
-   gh issue view N --json state --jq '.state'
-   ```
-
-   If the result is `"OPEN"`, the issue is blocked.
-
-   #### "Blocked by" references
-
-   Parse the issue body for lines matching the pattern:
-   - `Blocked by #N` (case-insensitive)
-
-   For each referenced issue number `N`, check whether it is still open:
-
-   ```bash
-   gh issue view N --json state --jq '.state'
-   ```
-
-   If the result is `"OPEN"`, the issue is blocked.
-
-   **If blocked:** Log "Issue #<NUMBER> is blocked by open dependencies. Aborting."
-   and **abort** — do NOT assign or proceed with the loop.
-
-3. **Assign the issue** (only after confirming it is not blocked):
-   ```bash
-   gh issue edit <NUMBER> --add-assignee @me
-   # If the issue URL included a repo (owner/repo), add: --repo owner/repo
-   ```
-   - **Success:** Log "Assigned issue #<NUMBER> to current user." and continue.
-   - **Failure:** Warn "Could not assign issue #<NUMBER>. Continuing anyway."
-     Do NOT abort — the loop should proceed regardless.
-
-4. **Format the issue body** for use as grounding context by all agents:
-   ```bash
-   ISSUE_BODY=$(gh issue view <NUMBER> --json title,body,labels --template '## Issue #{{.number}}: {{.title}}{{"\n\n"}}### Labels{{"\n"}}{{range .labels}}- {{.name}}{{"\n"}}{{end}}{{"\n"}}### Description{{"\n"}}{{.body}}')
-   ```
-   - If fetch fails, set `ISSUE_BODY=""` and continue.
-
-If no issue reference is found in `$ARGUMENTS`, set `ISSUE_BODY=""` and skip this step silently.
-
-### 5. Build project context (role-specific slices)
-
-Read the following files (skip any that don't exist) and assemble role-specific
-context slices. Each agent receives only the context it needs.
-
-**Build config helpers** (read once, used in all slices):
-- `package.json` — extract the `scripts` object
-- `Makefile` — extract target names (lines matching `^[a-zA-Z_-]+:`)
-- `pyproject.toml` — read entire file
-- `Cargo.toml` — read entire file
-
-Format each file as:
-```
----
-## File: <filename>
-
-<contents>
+```bash
+FETCH_OUTPUT=$($SCRIPTS_DIR/fetch-issue-context --args "$ARGUMENTS") \
+    && FETCH_EXIT=0 || FETCH_EXIT=$?
+if [ "$FETCH_EXIT" -eq 1 ]; then
+    echo "Issue is blocked. Aborting."
+    exit 1
+fi
+# First line is NUMBER=<num>, rest is formatted body
+ISSUE_NUMBER=$(echo "$FETCH_OUTPUT" | head -1 | sed 's/^NUMBER=//')
+ISSUE_BODY=$(echo "$FETCH_OUTPUT" | tail -n +2)
+if [ -n "$ISSUE_NUMBER" ]; then
+    gh issue edit "$ISSUE_NUMBER" --add-assignee @me 2>/dev/null \
+        && echo "Assigned issue #$ISSUE_NUMBER to current user." \
+        || echo "Warning: Could not assign issue #$ISSUE_NUMBER. Continuing."
+fi
 ```
 
-**`PROJECT_CONTEXT_PLANNER`** — Full context for the Planner:
-- All project docs: `CONTRIBUTING.md`, `AGENTS.md`, `README.md`,
-  `.github/PULL_REQUEST_TEMPLATE.md`, `.editorconfig`
-- All build config files (from above)
+### 5. Project context assembly
 
-**`PROJECT_CONTEXT_DOER`** — Focused context for the Doer (build commands only):
-- `CONTRIBUTING.md` — "Code Style" section only (skip other sections)
-- `.editorconfig` — full file
-- Build config files (from above) — scripts/targets only, not full config prose
-
-**`PROJECT_CONTEXT_CHECKER`** — Minimal context for the Checker (test/lint commands):
-- `CONTRIBUTING.md` — "Code Style" and "CI Checks" sections only
-- Build config files (from above) — test/lint/build commands only
+Role-specific project context is assembled by `build-agent-context` in step 7c.
+No manual file reading is needed here.
 
 ### 6. Detect resume iteration
 
@@ -240,81 +157,8 @@ The override file (`docker-compose.looper.yml`) and connection string file
 
 #### 7c. Build the agent context prompts (role-specific)
 
-Build separate context strings for Planner, Doer, and Checker using the
-role-specific context slices from step 5.
+First, compute the diff context for the Checker:
 
-**For Planner** — full project context. On iteration > 1, prune to a brief:
-```
-<project-context>
-${PROJECT_CONTEXT_PLANNER}
-</project-context>
-
-You MUST follow the conventions and instructions in <project-context>.
-Pay special attention to CONTRIBUTING.md for build/test/lint/commit conventions.
-
----
-
-## Task Variables
-
-- **TASK_NAME:** ${TASK_NAME}
-- **ITERATION:** ${ITERATION}
-- **TASK_PROMPT:** ${TASK_PROMPT}
-- **SCRIPTS_DIR:** ${SCRIPTS_DIR}
-- **WORKTREE_DIR:** ${WORKTREE_DIR}
-- **LOOPER_DEV_PORT:** ${LOOPER_DEV_PORT}
-- **HAS_COMPOSE:** ${HAS_COMPOSE:-false}
-- **COMPOSE_SERVICES:** ${COMPOSE_SERVICES:-none}
-
-## Issue Context
-
-${ISSUE_BODY:-No issue linked. Use the TASK_PROMPT above as the source of requirements.}
-
-## Prior Loop Context
-
-${LOOP_CONTEXT}
-```
-
-On iteration > 1, add this note to the Planner context:
-```
-NOTE: This is iteration ${ITERATION}. Project context is the same as iteration 1.
-Spawn Explore subagents ONLY for the areas the Checker flagged — do not
-re-explore the entire codebase. The action items above are your focus.
-```
-
-**For Doer** — focused build/style context only:
-```
-<project-context>
-${PROJECT_CONTEXT_DOER}
-</project-context>
-
-You MUST follow the conventions and instructions in <project-context>.
-Pay special attention to CONTRIBUTING.md for build/test/lint/commit conventions.
-
----
-
-## Task Variables
-
-- **TASK_NAME:** ${TASK_NAME}
-- **ITERATION:** ${ITERATION}
-- **TASK_PROMPT:** ${TASK_PROMPT}
-- **SCRIPTS_DIR:** ${SCRIPTS_DIR}
-- **WORKTREE_DIR:** ${WORKTREE_DIR}
-- **LOOPER_DEV_PORT:** ${LOOPER_DEV_PORT}
-- **HAS_COMPOSE:** ${HAS_COMPOSE:-false}
-- **COMPOSE_SERVICES:** ${COMPOSE_SERVICES:-none}
-
-## Issue Context
-
-${ISSUE_BODY:-No issue linked. Use the TASK_PROMPT above as the source of requirements.}
-
-## Prior Loop Context
-
-${LOOP_CONTEXT}
-```
-
-**For Checker** — minimal test/lint context plus diff-only on iteration > 1:
-
-First, compute the diff context (what changed this iteration):
 ```bash
 if [ "$ITERATION" -gt 1 ]; then
     LAST_CHECK_HASH=$(git log --grep="Loop-Phase: check" \
@@ -330,39 +174,21 @@ else
 fi
 ```
 
-Then build the Checker context:
-```
-<project-context>
-${PROJECT_CONTEXT_CHECKER}
-</project-context>
+Then build role-specific context using `build-agent-context`:
 
-You MUST follow the conventions and instructions in <project-context>.
-Pay special attention to CONTRIBUTING.md for build/test/lint/commit conventions.
+```bash
+CTX_COMMON=(
+    --task "$TASK_NAME" --iteration "$ITERATION"
+    --task-prompt "$TASK_PROMPT" --scripts-dir "$SCRIPTS_DIR"
+    --worktree-dir "$WORKTREE_DIR" --dev-port "$LOOPER_DEV_PORT"
+    --compose "${HAS_COMPOSE:-false}" --compose-services "${COMPOSE_SERVICES:-none}"
+    --issue-body "$ISSUE_BODY" --loop-context "$LOOP_CONTEXT"
+)
 
----
-
-## Task Variables
-
-- **TASK_NAME:** ${TASK_NAME}
-- **ITERATION:** ${ITERATION}
-- **TASK_PROMPT:** ${TASK_PROMPT}
-- **SCRIPTS_DIR:** ${SCRIPTS_DIR}
-- **WORKTREE_DIR:** ${WORKTREE_DIR}
-- **LOOPER_DEV_PORT:** ${LOOPER_DEV_PORT}
-- **HAS_COMPOSE:** ${HAS_COMPOSE:-false}
-- **COMPOSE_SERVICES:** ${COMPOSE_SERVICES:-none}
-
-## Issue Context
-
-${ISSUE_BODY:-No issue linked. Use the TASK_PROMPT above as the source of requirements.}
-
-## Changes This Iteration (diff from last check)
-
-${DIFF_CONTEXT}
-
-## Prior Loop Context
-
-${LOOP_CONTEXT}
+PLANNER_CONTEXT=$($SCRIPTS_DIR/build-agent-context --role planner "${CTX_COMMON[@]}")
+DOER_CONTEXT=$($SCRIPTS_DIR/build-agent-context --role doer "${CTX_COMMON[@]}")
+CHECKER_CONTEXT=$($SCRIPTS_DIR/build-agent-context --role checker "${CTX_COMMON[@]}" \
+    --diff-context "$DIFF_CONTEXT")
 ```
 
 #### 7d. Spawn agents

--- a/plugins/looper/skills/looper/scripts/build-agent-context
+++ b/plugins/looper/skills/looper/scripts/build-agent-context
@@ -13,8 +13,6 @@ set -euo pipefail
 #
 # Outputs fully assembled context string to stdout.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # Required flags
 ROLE=""
 TASK_NAME=""
@@ -144,7 +142,7 @@ PR_TEMPLATE_CONTENT=$(read_file_if_exists "$PR_TEMPLATE_FILE")
 # Build config files
 PACKAGE_JSON_CONTENT=""
 if [ -f "$PACKAGE_JSON_FILE" ]; then
-    PACKAGE_JSON_CONTENT=$(cat "$PACKAGE_JSON_FILE" | python3 -c "
+    PACKAGE_JSON_CONTENT=$(python3 -c "
 import json,sys
 try:
     data = json.load(sys.stdin)
@@ -152,7 +150,7 @@ try:
     print(json.dumps({'scripts': scripts}, indent=2))
 except Exception:
     pass
-" 2>/dev/null || cat "$PACKAGE_JSON_FILE")
+" < "$PACKAGE_JSON_FILE" 2>/dev/null || cat "$PACKAGE_JSON_FILE")
 fi
 
 MAKEFILE_CONTENT=""

--- a/plugins/looper/skills/looper/scripts/build-agent-context
+++ b/plugins/looper/skills/looper/scripts/build-agent-context
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build-agent-context — Assemble role-specific context strings for PDC loop agents
+#
+# Usage:
+#   build-agent-context --role planner|doer|checker \
+#     --task TASK_NAME --iteration N \
+#     --task-prompt PROMPT --scripts-dir DIR \
+#     --worktree-dir DIR --dev-port PORT \
+#     --compose BOOL --compose-services SERVICES \
+#     [--issue-body BODY] [--loop-context CTX] [--diff-context DIFF]
+#
+# Outputs fully assembled context string to stdout.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Required flags
+ROLE=""
+TASK_NAME=""
+ITERATION=""
+TASK_PROMPT=""
+SCRIPTS_DIR=""
+WORKTREE_DIR=""
+DEV_PORT=""
+COMPOSE=""
+COMPOSE_SERVICES=""
+
+# Optional flags
+ISSUE_BODY=""
+LOOP_CONTEXT=""
+DIFF_CONTEXT=""
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --role) ROLE="$2"; shift 2 ;;
+        --task) TASK_NAME="$2"; shift 2 ;;
+        --iteration) ITERATION="$2"; shift 2 ;;
+        --task-prompt) TASK_PROMPT="$2"; shift 2 ;;
+        --scripts-dir) SCRIPTS_DIR="$2"; shift 2 ;;
+        --worktree-dir) WORKTREE_DIR="$2"; shift 2 ;;
+        --dev-port) DEV_PORT="$2"; shift 2 ;;
+        --compose) COMPOSE="$2"; shift 2 ;;
+        --compose-services) COMPOSE_SERVICES="$2"; shift 2 ;;
+        --issue-body) ISSUE_BODY="$2"; shift 2 ;;
+        --loop-context) LOOP_CONTEXT="$2"; shift 2 ;;
+        --diff-context) DIFF_CONTEXT="$2"; shift 2 ;;
+        *)
+            echo "Usage: build-agent-context --role planner|doer|checker --task NAME --iteration N ..." >&2
+            echo "Error: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Validate required flags
+MISSING=""
+[ -z "$ROLE" ] && MISSING="$MISSING --role"
+[ -z "$TASK_NAME" ] && MISSING="$MISSING --task"
+[ -z "$ITERATION" ] && MISSING="$MISSING --iteration"
+[ -z "$TASK_PROMPT" ] && MISSING="$MISSING --task-prompt"
+[ -z "$SCRIPTS_DIR" ] && MISSING="$MISSING --scripts-dir"
+[ -z "$WORKTREE_DIR" ] && MISSING="$MISSING --worktree-dir"
+[ -z "$DEV_PORT" ] && MISSING="$MISSING --dev-port"
+[ -z "$COMPOSE" ] && MISSING="$MISSING --compose"
+[ -z "$COMPOSE_SERVICES" ] && MISSING="$MISSING --compose-services"
+
+if [ -n "$MISSING" ]; then
+    echo "Usage: build-agent-context --role planner|doer|checker --task NAME --iteration N ..." >&2
+    echo "Error: required flags missing:$MISSING" >&2
+    exit 2
+fi
+
+# Validate role
+case "$ROLE" in
+    planner|doer|checker) ;;
+    *)
+        echo "Error: --role must be one of: planner, doer, checker (got: $ROLE)" >&2
+        exit 2
+        ;;
+esac
+
+# --- Helper: read file if it exists, empty string otherwise ---
+read_file_if_exists() {
+    local path="$1"
+    if [ -f "$path" ]; then
+        cat "$path"
+    else
+        echo ""
+    fi
+}
+
+# --- Helper: format file content as project-context entry ---
+format_file_section() {
+    local filename="$1"
+    local content="$2"
+    if [ -n "$content" ]; then
+        printf '\n---\n## File: %s\n\n%s\n' "$filename" "$content"
+    fi
+}
+
+# --- Helper: extract a section from CONTRIBUTING.md by ## header ---
+# Extracts from "## HEADER" to the next "## " or EOF
+extract_section() {
+    local file="$1"
+    local header="$2"
+    if [ ! -f "$file" ]; then
+        echo ""
+        return
+    fi
+    # Use awk to extract from the header to the next ## header
+    awk -v header="## $header" '
+        $0 == header { found=1; next }
+        found && /^## / { exit }
+        found { print }
+    ' "$file"
+}
+
+# --- Read project files ---
+CONTRIBUTING_FILE="$WORKTREE_DIR/CONTRIBUTING.md"
+README_FILE="$WORKTREE_DIR/README.md"
+AGENTS_FILE="$WORKTREE_DIR/AGENTS.md"
+EDITORCONFIG_FILE="$WORKTREE_DIR/.editorconfig"
+PR_TEMPLATE_FILE="$WORKTREE_DIR/.github/PULL_REQUEST_TEMPLATE.md"
+PACKAGE_JSON_FILE="$WORKTREE_DIR/package.json"
+MAKEFILE_FILE="$WORKTREE_DIR/Makefile"
+PYPROJECT_FILE="$WORKTREE_DIR/pyproject.toml"
+CARGO_TOML_FILE="$WORKTREE_DIR/Cargo.toml"
+
+# Read full CONTRIBUTING.md
+CONTRIBUTING_FULL=$(read_file_if_exists "$CONTRIBUTING_FILE")
+
+# Extract sections from CONTRIBUTING.md
+CONTRIBUTING_CODE_STYLE=$(extract_section "$CONTRIBUTING_FILE" "Code Style")
+CONTRIBUTING_TESTING=$(extract_section "$CONTRIBUTING_FILE" "Testing and CI")
+
+# Read other docs
+README_CONTENT=$(read_file_if_exists "$README_FILE")
+AGENTS_CONTENT=$(read_file_if_exists "$AGENTS_FILE")
+EDITORCONFIG_CONTENT=$(read_file_if_exists "$EDITORCONFIG_FILE")
+PR_TEMPLATE_CONTENT=$(read_file_if_exists "$PR_TEMPLATE_FILE")
+
+# Build config files
+PACKAGE_JSON_CONTENT=""
+if [ -f "$PACKAGE_JSON_FILE" ]; then
+    PACKAGE_JSON_CONTENT=$(cat "$PACKAGE_JSON_FILE" | python3 -c "
+import json,sys
+try:
+    data = json.load(sys.stdin)
+    scripts = data.get('scripts', {})
+    print(json.dumps({'scripts': scripts}, indent=2))
+except Exception:
+    pass
+" 2>/dev/null || cat "$PACKAGE_JSON_FILE")
+fi
+
+MAKEFILE_CONTENT=""
+if [ -f "$MAKEFILE_FILE" ]; then
+    MAKEFILE_CONTENT=$(grep -E '^[a-zA-Z_-]+:' "$MAKEFILE_FILE" | sed 's/:.*//' || true)
+fi
+
+PYPROJECT_CONTENT=$(read_file_if_exists "$PYPROJECT_FILE")
+CARGO_TOML_CONTENT=$(read_file_if_exists "$CARGO_TOML_FILE")
+
+# --- Build role-specific PROJECT_CONTEXT ---
+PROJECT_CONTEXT=""
+
+case "$ROLE" in
+    planner)
+        # Full context: all docs + all build configs
+        if [ -n "$CONTRIBUTING_FULL" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md" "$CONTRIBUTING_FULL")"
+        fi
+        if [ -n "$README_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "README.md" "$README_CONTENT")"
+        fi
+        if [ -n "$AGENTS_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "AGENTS.md" "$AGENTS_CONTENT")"
+        fi
+        if [ -n "$PR_TEMPLATE_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".github/PULL_REQUEST_TEMPLATE.md" "$PR_TEMPLATE_CONTENT")"
+        fi
+        if [ -n "$EDITORCONFIG_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".editorconfig" "$EDITORCONFIG_CONTENT")"
+        fi
+        if [ -n "$PACKAGE_JSON_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json" "$PACKAGE_JSON_CONTENT")"
+        fi
+        if [ -n "$MAKEFILE_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
+        fi
+        if [ -n "$PYPROJECT_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
+        fi
+        if [ -n "$CARGO_TOML_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
+        fi
+        ;;
+
+    doer)
+        # Focused: Code Style section + .editorconfig + build config scripts only
+        CODE_STYLE_CONTENT=""
+        if [ -n "$CONTRIBUTING_CODE_STYLE" ]; then
+            CODE_STYLE_CONTENT="## Code Style
+
+$CONTRIBUTING_CODE_STYLE"
+        fi
+        if [ -n "$CODE_STYLE_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md (Code Style)" "$CODE_STYLE_CONTENT")"
+        fi
+        if [ -n "$EDITORCONFIG_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".editorconfig" "$EDITORCONFIG_CONTENT")"
+        fi
+        if [ -n "$PACKAGE_JSON_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json (scripts)" "$PACKAGE_JSON_CONTENT")"
+        fi
+        if [ -n "$MAKEFILE_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
+        fi
+        if [ -n "$PYPROJECT_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
+        fi
+        if [ -n "$CARGO_TOML_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
+        fi
+        ;;
+
+    checker)
+        # Minimal: Code Style + Testing sections + test/lint/build commands
+        CHECKER_CONTRIBUTING=""
+        if [ -n "$CONTRIBUTING_CODE_STYLE" ]; then
+            CHECKER_CONTRIBUTING="${CHECKER_CONTRIBUTING}## Code Style
+
+$CONTRIBUTING_CODE_STYLE
+"
+        fi
+        if [ -n "$CONTRIBUTING_TESTING" ]; then
+            CHECKER_CONTRIBUTING="${CHECKER_CONTRIBUTING}## Testing and CI
+
+$CONTRIBUTING_TESTING"
+        fi
+        if [ -n "$CHECKER_CONTRIBUTING" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md (Code Style + Testing)" "$CHECKER_CONTRIBUTING")"
+        fi
+        if [ -n "$PACKAGE_JSON_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json (scripts)" "$PACKAGE_JSON_CONTENT")"
+        fi
+        if [ -n "$MAKEFILE_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
+        fi
+        if [ -n "$PYPROJECT_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
+        fi
+        if [ -n "$CARGO_TOML_CONTENT" ]; then
+            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
+        fi
+        ;;
+esac
+
+# --- Assemble issue context ---
+ISSUE_SECTION="${ISSUE_BODY:-No issue linked. Use the TASK_PROMPT above as the source of requirements.}"
+
+# --- Build output ---
+cat << CONTEXT_EOF
+<project-context>
+${PROJECT_CONTEXT}
+</project-context>
+
+You MUST follow the conventions and instructions in <project-context>.
+Pay special attention to CONTRIBUTING.md for build/test/lint/commit conventions.
+
+---
+
+## Task Variables
+
+- **TASK_NAME:** ${TASK_NAME}
+- **ITERATION:** ${ITERATION}
+- **TASK_PROMPT:** ${TASK_PROMPT}
+- **SCRIPTS_DIR:** ${SCRIPTS_DIR}
+- **WORKTREE_DIR:** ${WORKTREE_DIR}
+- **LOOPER_DEV_PORT:** ${DEV_PORT}
+- **HAS_COMPOSE:** ${COMPOSE}
+- **COMPOSE_SERVICES:** ${COMPOSE_SERVICES}
+
+## Issue Context
+
+${ISSUE_SECTION}
+CONTEXT_EOF
+
+# Checker-specific: Changes This Iteration section
+if [ "$ROLE" = "checker" ]; then
+    DIFF_OUTPUT="${DIFF_CONTEXT:-First iteration — full review required.}"
+    cat << DIFF_EOF
+
+## Changes This Iteration (diff from last check)
+
+${DIFF_OUTPUT}
+DIFF_EOF
+fi
+
+# Prior Loop Context
+cat << LOOP_EOF
+
+## Prior Loop Context
+
+${LOOP_CONTEXT:-This is the first iteration. No prior context available.}
+LOOP_EOF
+
+# Planner iteration > 1: add pruning note
+if [ "$ROLE" = "planner" ] && [ "$ITERATION" -gt 1 ]; then
+    cat << PRUNE_EOF
+
+NOTE: This is iteration ${ITERATION}. Project context is the same as iteration 1.
+Spawn Explore subagents ONLY for the areas the Checker flagged — do not
+re-explore the entire codebase. The action items above are your focus.
+PRUNE_EOF
+fi

--- a/plugins/looper/skills/looper/scripts/check-blocked
+++ b/plugins/looper/skills/looper/scripts/check-blocked
@@ -7,8 +7,6 @@ set -euo pipefail
 # Exit 0: issue is NOT blocked (no output)
 # Exit 1: issue IS blocked (prints reason to stdout)
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 ISSUE_NUMBER=""
 REPO_ARG=""
 

--- a/plugins/looper/skills/looper/scripts/check-blocked
+++ b/plugins/looper/skills/looper/scripts/check-blocked
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-blocked — Check if a GitHub issue is blocked by open dependencies
+#
+# Usage: check-blocked --issue <NUMBER> [--repo owner/repo]
+# Exit 0: issue is NOT blocked (no output)
+# Exit 1: issue IS blocked (prints reason to stdout)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ISSUE_NUMBER=""
+REPO_ARG=""
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --issue)
+            ISSUE_NUMBER="$2"
+            shift 2
+            ;;
+        --repo)
+            REPO_ARG="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: check-blocked --issue <NUMBER> [--repo owner/repo]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$ISSUE_NUMBER" ]; then
+    echo "Usage: check-blocked --issue <NUMBER> [--repo owner/repo]" >&2
+    echo "Error: --issue is required" >&2
+    exit 2
+fi
+
+# Build gh base args
+GH_REPO_ARGS=()
+if [ -n "$REPO_ARG" ]; then
+    GH_REPO_ARGS=("--repo" "$REPO_ARG")
+fi
+
+# Fetch issue metadata
+ISSUE_JSON=$(gh issue view "$ISSUE_NUMBER" --json labels,body "${GH_REPO_ARGS[@]}" 2>/dev/null) || {
+    echo "Warning: could not fetch issue #$ISSUE_NUMBER" >&2
+    exit 0
+}
+
+# --- Label-based blocking ---
+LABELS=$(echo "$ISSUE_JSON" | jq -r '(.labels // []) | .[].name' 2>/dev/null || true)
+while IFS= read -r label; do
+    [ -z "$label" ] && continue
+    label_lower=$(echo "$label" | tr '[:upper:]' '[:lower:]')
+    if echo "$label_lower" | grep -q "blocked\|dependencies"; then
+        echo "Issue #$ISSUE_NUMBER is blocked: label '$label' matches blocking pattern"
+        exit 1
+    fi
+done <<< "$LABELS"
+
+# --- Body-based checks ---
+BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""' 2>/dev/null || true)
+if [ -z "$BODY" ] || [ "$BODY" = "null" ]; then
+    exit 0
+fi
+
+check_issue_state() {
+    local dep_num="$1"
+    gh issue view "$dep_num" --json state --jq '.state' "${GH_REPO_ARGS[@]}" 2>/dev/null || echo "CLOSED"
+}
+
+# --- Task-list dependency references: "- [ ] Depends on #N" or "- [ ] #N" ---
+DEP_NUMS=$(echo "$BODY" | grep -oE '\- \[ \] (Depends on )?#[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
+while IFS= read -r dep_num; do
+    [ -z "$dep_num" ] && continue
+    STATE=$(check_issue_state "$dep_num")
+    if [ "$STATE" = "OPEN" ]; then
+        echo "Issue #$ISSUE_NUMBER is blocked: depends on open issue #$dep_num"
+        exit 1
+    fi
+done <<< "$DEP_NUMS"
+
+# --- "Blocked by #N" references (case-insensitive) ---
+BLOCKED_BY_NUMS=$(echo "$BODY" | grep -ioE 'blocked by #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#' || true)
+while IFS= read -r dep_num; do
+    [ -z "$dep_num" ] && continue
+    STATE=$(check_issue_state "$dep_num")
+    if [ "$STATE" = "OPEN" ]; then
+        echo "Issue #$ISSUE_NUMBER is blocked: blocked by open issue #$dep_num"
+        exit 1
+    fi
+done <<< "$BLOCKED_BY_NUMS"
+
+# Not blocked
+exit 0

--- a/plugins/looper/skills/looper/scripts/fetch-issue-context
+++ b/plugins/looper/skills/looper/scripts/fetch-issue-context
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fetch-issue-context — Extract issue number from args, check if blocked, format context
+#
+# Usage: fetch-issue-context --args "ARGUMENTS" [--repo owner/repo]
+#
+# Output protocol:
+#   Line 1:  NUMBER=<num>   (or empty if no issue found)
+#   Lines 2+: Formatted issue body (empty if no issue found or fetch failed)
+#
+# Exit codes:
+#   0: success (issue context output, or no issue ref found, or fetch failed gracefully)
+#   1: issue is blocked (blocking reason on stderr)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ARGS_STRING=""
+REPO_ARG=""
+ARGS_PROVIDED=false
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --args)
+            ARGS_STRING="$2"
+            ARGS_PROVIDED=true
+            shift 2
+            ;;
+        --repo)
+            REPO_ARG="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: fetch-issue-context --args \"ARGUMENTS\" [--repo owner/repo]" >&2
+            echo "Error: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ "$ARGS_PROVIDED" = "false" ]; then
+    echo "Usage: fetch-issue-context --args \"ARGUMENTS\" [--repo owner/repo]" >&2
+    echo "Error: --args is required" >&2
+    exit 2
+fi
+
+# Extract issue number from args, trying three patterns in priority order:
+# 1. GitHub URL: https://github.com/<owner>/<repo>/issues/<NUMBER>
+# 2. Hash reference: #<NUMBER>
+# 3. Plain number at start: <NUMBER> <rest>
+
+ISSUE_NUMBER=""
+EXTRACTED_REPO=""
+
+# Pattern 1: GitHub URL
+if echo "$ARGS_STRING" | grep -qE 'https://github\.com/[^/]+/[^/]+/issues/[0-9]+'; then
+    URL=$(echo "$ARGS_STRING" | grep -oE 'https://github\.com/[^/]+/[^/]+/issues/[0-9]+' | head -1)
+    ISSUE_NUMBER=$(echo "$URL" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+')
+    # Extract owner/repo from URL
+    EXTRACTED_REPO=$(echo "$URL" | grep -oE 'github\.com/[^/]+/[^/]+' | sed 's|github\.com/||')
+fi
+
+# Pattern 2: Hash reference #N
+if [ -z "$ISSUE_NUMBER" ]; then
+    if echo "$ARGS_STRING" | grep -qE '#[0-9]+'; then
+        ISSUE_NUMBER=$(echo "$ARGS_STRING" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+    fi
+fi
+
+# Pattern 3: Plain number at start of args
+if [ -z "$ISSUE_NUMBER" ]; then
+    if echo "$ARGS_STRING" | grep -qE '^[0-9]+( |$)'; then
+        ISSUE_NUMBER=$(echo "$ARGS_STRING" | grep -oE '^[0-9]+')
+    fi
+fi
+
+# No issue reference found
+if [ -z "$ISSUE_NUMBER" ]; then
+    exit 0
+fi
+
+# Build repo args
+GH_REPO_ARGS=()
+if [ -n "$REPO_ARG" ]; then
+    GH_REPO_ARGS=("--repo" "$REPO_ARG")
+elif [ -n "$EXTRACTED_REPO" ]; then
+    GH_REPO_ARGS=("--repo" "$EXTRACTED_REPO")
+fi
+
+# Allow overriding check-blocked path for testing
+CHECK_BLOCKED="${CHECK_BLOCKED_PATH:-$SCRIPT_DIR/check-blocked}"
+
+# Fetch issue metadata to verify it exists and is not blocked
+FETCH_OK=true
+gh issue view "$ISSUE_NUMBER" --json title,body,labels "${GH_REPO_ARGS[@]}" >/dev/null 2>&1 || FETCH_OK=false
+
+if [ "$FETCH_OK" = "false" ]; then
+    # Graceful degradation: gh failed, output empty and exit 0
+    exit 0
+fi
+
+# Check if the issue is blocked
+BLOCKED_REASON=$("$CHECK_BLOCKED" --issue "$ISSUE_NUMBER" "${GH_REPO_ARGS[@]}" 2>/dev/null) && BLOCKED_EXIT=0 || BLOCKED_EXIT=$?
+if [ "$BLOCKED_EXIT" -eq 1 ]; then
+    echo "${BLOCKED_REASON:-Issue #$ISSUE_NUMBER is blocked by open dependencies.}" >&2
+    exit 1
+fi
+
+# Format the issue body using gh template
+FORMATTED=$(gh issue view "$ISSUE_NUMBER" \
+    --json number,title,body,labels \
+    --template '## Issue #{{.number}}: {{.title}}{{"\n\n"}}### Labels{{"\n"}}{{range .labels}}- {{.name}}{{"\n"}}{{end}}{{"\n"}}### Description{{"\n"}}{{.body}}' \
+    "${GH_REPO_ARGS[@]}" 2>/dev/null) || FORMATTED=""
+
+# Output: first line is NUMBER=<num>, rest is formatted body
+printf 'NUMBER=%s\n' "$ISSUE_NUMBER"
+if [ -n "$FORMATTED" ]; then
+    printf '%s\n' "$FORMATTED"
+fi

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # run-corner-case-tests.sh — Run all corner-case tests for looper scripts
 # Executes: test-detect-stack.sh, test-detect-resume.sh,
 #           test-git-commit-loop-validation.sh, test-git-loop-context.sh,
-#           test-sync-with-remote.sh
+#           test-sync-with-remote.sh, test-check-blocked.sh,
+#           test-fetch-issue-context.sh, test-build-agent-context.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -30,6 +31,9 @@ run_suite "test-detect-resume.sh"
 run_suite "test-git-commit-loop-validation.sh"
 run_suite "test-git-loop-context.sh"
 run_suite "test-sync-with-remote.sh"
+run_suite "test-check-blocked.sh"
+run_suite "test-fetch-issue-context.sh"
+run_suite "test-build-agent-context.sh"
 
 echo "=============================="
 echo "Corner-case suite: $PASS suites passed, $FAIL suites failed"

--- a/tests/test-build-agent-context.sh
+++ b/tests/test-build-agent-context.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-build-agent-context.sh — Tests for build-agent-context script
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_CTX="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/build-agent-context"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+    if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+assert_output_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -q "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output to contain '$expected')"
+        echo "  Actual output snippet (first 5 lines): $(echo "$output" | head -5)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_not_contains() {
+    local description="$1"
+    local output="$2"
+    local unexpected="$3"
+    if ! echo "$output" | grep -q "$unexpected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output NOT to contain '$unexpected')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_nonzero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -ne 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected non-zero exit, got 0)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+setup_fixture_dir() {
+    TMPDIR_TEST=$(mktemp -d)
+
+    # Create fixture CONTRIBUTING.md with known sections
+    cat > "$TMPDIR_TEST/CONTRIBUTING.md" << 'EOF'
+# Contributing Guide
+
+## Getting Started
+
+Clone the repo and run npm install.
+
+## Code Style
+
+Follow existing code patterns. Use 2-space indentation.
+Scripts must pass ShellCheck.
+
+## Testing and CI
+
+Run tests with `npm test`. CI runs on GitHub Actions.
+All tests must pass before merging.
+
+## Deployment
+
+Deploy via GitHub Actions on merge to main.
+EOF
+
+    # Create fixture README.md
+    cat > "$TMPDIR_TEST/README.md" << 'EOF'
+# My Project
+
+A cool project description.
+EOF
+
+    # Create fixture .editorconfig
+    cat > "$TMPDIR_TEST/.editorconfig" << 'EOF'
+root = true
+
+[*]
+indent_size = 2
+EOF
+
+    # Create fixture package.json with scripts
+    cat > "$TMPDIR_TEST/package.json" << 'EOF'
+{
+  "name": "test-project",
+  "scripts": {
+    "test": "jest",
+    "build": "tsc",
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "next": "14.0.0"
+  }
+}
+EOF
+}
+
+COMMON_FLAGS="--task my-task --iteration 1 --task-prompt 'Fix the bug' --scripts-dir /tmp/scripts --dev-port 9876 --compose false --compose-services none"
+
+# --- Test 1: --role planner: output contains <project-context> tags with CONTRIBUTING.md ---
+echo "=== Test 1: Planner role has project-context and CONTRIBUTING.md ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "planner: exit 0" "$EXIT_CODE"
+assert_output_contains "planner: has <project-context> open tag" "$OUTPUT" "<project-context>"
+assert_output_contains "planner: has </project-context> close tag" "$OUTPUT" "</project-context>"
+assert_output_contains "planner: has CONTRIBUTING.md content" "$OUTPUT" "Code Style"
+cleanup
+
+# --- Test 2: --role planner: output contains README.md content ---
+echo "=== Test 2: Planner includes README.md ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "planner: has README.md content" "$OUTPUT" "My Project"
+cleanup
+
+# --- Test 3: --role doer: output contains only Code Style section of CONTRIBUTING.md ---
+echo "=== Test 3: Doer role has Code Style section only ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role doer $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "doer: exit 0" "$EXIT_CODE"
+assert_output_contains "doer: has Code Style content" "$OUTPUT" "ShellCheck"
+assert_output_not_contains "doer: does NOT have Deployment section" "$OUTPUT" "Deploy via GitHub"
+cleanup
+
+# --- Test 4: --role doer: output contains .editorconfig content ---
+echo "=== Test 4: Doer includes .editorconfig ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role doer $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "doer: has .editorconfig content" "$OUTPUT" "indent_size"
+cleanup
+
+# --- Test 5: --role checker: output contains Code Style and Testing sections ---
+echo "=== Test 5: Checker has Code Style and Testing sections ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role checker $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "checker: exit 0" "$EXIT_CODE"
+assert_output_contains "checker: has Code Style" "$OUTPUT" "ShellCheck"
+assert_output_contains "checker: has Testing section" "$OUTPUT" "GitHub Actions"
+cleanup
+
+# --- Test 6: --role checker with --diff-context: has Changes This Iteration section ---
+echo "=== Test 6: Checker with diff-context has Changes section ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role checker $COMMON_FLAGS --worktree-dir $TMPDIR_TEST --diff-context 'src/foo.ts | 5 ++'" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "checker: has Changes This Iteration section" "$OUTPUT" "Changes This Iteration"
+assert_output_contains "checker: diff content included" "$OUTPUT" "src/foo.ts"
+cleanup
+
+# --- Test 7: All roles: output contains Task Variables block ---
+echo "=== Test 7: Task Variables block present in all roles ==="
+setup_fixture_dir
+for role in planner doer checker; do
+    OUTPUT=$(eval "$BUILD_CTX --role $role $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+    assert_output_contains "$role: has TASK_NAME" "$OUTPUT" "TASK_NAME.*my-task"
+    assert_output_contains "$role: has ITERATION" "$OUTPUT" "ITERATION.*1"
+    assert_output_contains "$role: has LOOPER_DEV_PORT" "$OUTPUT" "LOOPER_DEV_PORT.*9876"
+done
+cleanup
+
+# --- Test 8: --issue-body provided: output contains Issue Context section ---
+echo "=== Test 8: Issue body provided ==="
+setup_fixture_dir
+ISSUE_BODY="## Issue #42: Fix the login bug"
+OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST --issue-body \"$ISSUE_BODY\"" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "issue body: has Issue Context section" "$OUTPUT" "Issue Context"
+assert_output_contains "issue body: body content present" "$OUTPUT" "Issue #42"
+cleanup
+
+# --- Test 9: --issue-body empty/omitted: has "No issue linked" fallback ---
+echo "=== Test 9: No issue body -> fallback text ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "no issue: has fallback text" "$OUTPUT" "No issue linked"
+cleanup
+
+# --- Test 10: --loop-context provided: has Prior Loop Context section ---
+echo "=== Test 10: Loop context provided ==="
+setup_fixture_dir
+LOOP_CTX="Previous iteration: fixed typo in README"
+OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST --loop-context \"$LOOP_CTX\"" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "loop ctx: has Prior Loop Context section" "$OUTPUT" "Prior Loop Context"
+assert_output_contains "loop ctx: content present" "$OUTPUT" "fixed typo"
+cleanup
+
+# --- Test 11: --role planner with --iteration > 1: has pruning note ---
+echo "=== Test 11: Planner with iteration > 1 has pruning note ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role planner --task my-task --iteration 2 --task-prompt 'Fix the bug' --scripts-dir /tmp/scripts --worktree-dir $TMPDIR_TEST --dev-port 9876 --compose false --compose-services none" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "planner iter>1: has pruning note" "$OUTPUT" "Spawn Explore subagents ONLY\|re-explore\|action items"
+cleanup
+
+# --- Test 12: --role planner with --iteration 1: NO pruning note ---
+echo "=== Test 12: Planner with iteration 1 has no pruning note ==="
+setup_fixture_dir
+OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_not_contains "planner iter=1: no pruning note" "$OUTPUT" "re-explore the entire codebase"
+cleanup
+
+# --- Test 13: Missing required flags -> exit nonzero ---
+echo "=== Test 13: Missing required flags ==="
+OUTPUT=$("$BUILD_CTX" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_nonzero "missing flags: non-zero exit" "$EXIT_CODE"
+assert_output_contains "missing flags: usage message" "$OUTPUT" "usage\|--role\|required"
+
+# --- Test 14: Missing CONTRIBUTING.md -> gracefully skips, no error ---
+echo "=== Test 14: Missing CONTRIBUTING.md -> graceful skip ==="
+TMPDIR_TEST=$(mktemp -d)
+# No CONTRIBUTING.md created
+OUTPUT=$(eval "$BUILD_CTX --role doer $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "no CONTRIBUTING.md: exit 0" "$EXIT_CODE"
+assert_output_contains "no CONTRIBUTING.md: still has task vars" "$OUTPUT" "TASK_NAME"
+cleanup
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-check-blocked.sh
+++ b/tests/test-check-blocked.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-check-blocked.sh — Corner-case tests for the check-blocked script
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_BLOCKED="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/check-blocked"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+    if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_nonzero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -ne 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected non-zero exit, got 0)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_one() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 1 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 1, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -qi "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output to contain '$expected')"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Create a mock gh that reads from files in its own directory.
+# issue_json.txt: JSON for the main issue view (labels, body)
+# dep_states.txt: lines of "NUMBER STATE", e.g. "5 OPEN"
+write_mock_gh() {
+    local mock_dir="$1"
+    cat > "$mock_dir/gh" << 'EOF'
+#!/usr/bin/env bash
+MOCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+    issue_num="$3"
+    shift 3
+    args="$*"
+    # Full metadata fetch (labels,body or labels,body,state)
+    if echo "$args" | grep -q -- "--json"; then
+        json_fields=$(echo "$args" | grep -o -- '--json [^ ]*' | sed 's/--json //')
+        if echo "$json_fields" | grep -q "body\|labels"; then
+            if [ -f "$MOCK_DIR/issue_json.txt" ]; then
+                cat "$MOCK_DIR/issue_json.txt"
+            else
+                echo '{"labels":[],"body":""}'
+            fi
+            exit 0
+        fi
+        if echo "$json_fields" | grep -q "state"; then
+            # Dep state lookup
+            state="CLOSED"
+            if [ -f "$MOCK_DIR/dep_states.txt" ]; then
+                match=$(grep "^${issue_num} " "$MOCK_DIR/dep_states.txt" 2>/dev/null || true)
+                if [ -n "$match" ]; then
+                    state=$(echo "$match" | awk '{print $2}')
+                fi
+            fi
+            # Handle --jq '.state' flag - just output the state
+            echo "$state"
+            exit 0
+        fi
+    fi
+fi
+exit 1
+EOF
+    chmod +x "$mock_dir/gh"
+}
+
+# --- Test 1: No blocking labels, no deps, no blocked-by refs -> exit 0 ---
+echo "=== Test 1: Clean issue (not blocked) ==="
+TMPDIR_TEST=$(mktemp -d)
+echo '{"labels":[],"body":"Just a simple issue with no dependencies."}' > "$TMPDIR_TEST/issue_json.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 1 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "clean issue: exit 0" "$EXIT_CODE"
+cleanup
+
+# --- Test 2: Label containing "blocked" -> exit 1 ---
+echo "=== Test 2: Label with 'blocked' ==="
+TMPDIR_TEST=$(mktemp -d)
+echo '{"labels":[{"name":"blocked"}],"body":"This issue is blocked."}' > "$TMPDIR_TEST/issue_json.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 2 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "blocked label: exit 1" "$EXIT_CODE"
+assert_output_contains "blocked label: output contains reason" "$OUTPUT" "blocked"
+cleanup
+
+# --- Test 3: Label containing "dependencies" -> exit 1 ---
+echo "=== Test 3: Label with 'dependencies' ==="
+TMPDIR_TEST=$(mktemp -d)
+echo '{"labels":[{"name":"dependencies"}],"body":"Dependency issue."}' > "$TMPDIR_TEST/issue_json.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 3 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "dependencies label: exit 1" "$EXIT_CODE"
+cleanup
+
+# --- Test 4: "- [ ] Depends on #5" where #5 is OPEN -> exit 1 ---
+echo "=== Test 4: Task-list dep 'Depends on #5' with OPEN dep ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '{"labels":[],"body":"This depends on another issue.\\n- [ ] Depends on #5\\nSome more text."}\n' > "$TMPDIR_TEST/issue_json.txt"
+printf '5 OPEN\n' > "$TMPDIR_TEST/dep_states.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 4 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "depends-on OPEN: exit 1" "$EXIT_CODE"
+cleanup
+
+# --- Test 5: "- [ ] Depends on #5" where #5 is CLOSED -> exit 0 ---
+echo "=== Test 5: Task-list dep 'Depends on #5' with CLOSED dep ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '{"labels":[],"body":"- [ ] Depends on #5\\nThis dependency is satisfied."}\n' > "$TMPDIR_TEST/issue_json.txt"
+printf '5 CLOSED\n' > "$TMPDIR_TEST/dep_states.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 5 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "depends-on CLOSED: exit 0" "$EXIT_CODE"
+cleanup
+
+# --- Test 6: "- [ ] #7" where #7 is OPEN -> exit 1 ---
+echo "=== Test 6: Task-list dep '#7' (no 'Depends on') with OPEN dep ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '{"labels":[],"body":"Checklist:\\n- [ ] #7\\n- [x] Something done"}\n' > "$TMPDIR_TEST/issue_json.txt"
+printf '7 OPEN\n' > "$TMPDIR_TEST/dep_states.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 6 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "task-list #N OPEN: exit 1" "$EXIT_CODE"
+cleanup
+
+# --- Test 7: "Blocked by #3" where #3 is OPEN -> exit 1 ---
+echo "=== Test 7: 'Blocked by #3' with OPEN dep ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '{"labels":[],"body":"This feature requires auth.\\nBlocked by #3\\nWill implement after."}\n' > "$TMPDIR_TEST/issue_json.txt"
+printf '3 OPEN\n' > "$TMPDIR_TEST/dep_states.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 7 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "blocked-by OPEN: exit 1" "$EXIT_CODE"
+cleanup
+
+# --- Test 8: "blocked by #3" (lowercase) where #3 is CLOSED -> exit 0 ---
+echo "=== Test 8: 'blocked by #3' (case-insensitive) with CLOSED dep ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '{"labels":[],"body":"blocked by #3\\nNow resolved."}\n' > "$TMPDIR_TEST/issue_json.txt"
+printf '3 CLOSED\n' > "$TMPDIR_TEST/dep_states.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 8 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "blocked-by CLOSED: exit 0" "$EXIT_CODE"
+cleanup
+
+# --- Test 9: Missing --issue flag -> exit nonzero with usage message ---
+echo "=== Test 9: Missing --issue flag ==="
+TMPDIR_TEST=$(mktemp -d)
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_nonzero "missing --issue: non-zero exit" "$EXIT_CODE"
+assert_output_contains "missing --issue: usage in output" "$OUTPUT" "usage\|--issue\|required"
+cleanup
+
+# --- Test 10: Issue with empty body (null) -> exit 0 ---
+echo "=== Test 10: Empty/null body ==="
+TMPDIR_TEST=$(mktemp -d)
+echo '{"labels":[],"body":null}' > "$TMPDIR_TEST/issue_json.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 10 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "null body: exit 0" "$EXIT_CODE"
+cleanup
+
+# --- Test 11: Issue with no labels field -> exit 0 ---
+echo "=== Test 11: No labels field ==="
+TMPDIR_TEST=$(mktemp -d)
+echo '{"body":"Some body text with no labels."}' > "$TMPDIR_TEST/issue_json.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 11 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "no labels field: exit 0" "$EXIT_CODE"
+cleanup
+
+# --- Test 12: Multiple blocking conditions -> exit 1 ---
+echo "=== Test 12: Multiple blocking conditions ==="
+TMPDIR_TEST=$(mktemp -d)
+echo '{"labels":[{"name":"blocked"}],"body":"Blocked by #5\n- [ ] Depends on #6"}' > "$TMPDIR_TEST/issue_json.txt"
+printf '5 OPEN\n6 OPEN\n' > "$TMPDIR_TEST/dep_states.txt"
+write_mock_gh "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$CHECK_BLOCKED" --issue 12 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "multiple conditions: exit 1" "$EXIT_CODE"
+cleanup
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-fetch-issue-context.sh
+++ b/tests/test-fetch-issue-context.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-fetch-issue-context.sh — Corner-case tests for fetch-issue-context script
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FETCH_ISSUE="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/fetch-issue-context"
+CHECK_BLOCKED_REAL="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/check-blocked"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+    if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_one() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 1 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 1, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_nonzero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -ne 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected non-zero exit, got 0)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -qi "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output to contain '$expected')"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_empty() {
+    local description="$1"
+    local output="$2"
+    if [ -z "$output" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected empty output, got: $output)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+make_test_env() {
+    local mock_dir="$1"
+
+    # Mock gh: handles issue view calls
+    cat > "$mock_dir/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+    issue_num="$3"
+    shift 3
+    # full json fetch
+    if echo "$*" | grep -q "\-\-json"; then
+        echo "{\"number\":$issue_num,\"title\":\"Test Issue $issue_num\",\"body\":\"Issue body for #$issue_num\",\"labels\":[]}"
+        exit 0
+    fi
+    # template fetch for formatting
+    if echo "$*" | grep -q "\-\-template"; then
+        echo "## Issue #$issue_num: Test Issue $issue_num"
+        echo ""
+        echo "### Description"
+        echo "Issue body for #$issue_num"
+        exit 0
+    fi
+fi
+exit 1
+GHEOF
+    chmod +x "$mock_dir/gh"
+
+    # Mock check-blocked: default to not blocked (exit 0)
+    cat > "$mock_dir/check-blocked" << 'CBEOF'
+#!/usr/bin/env bash
+# Default mock: issue is not blocked
+exit 0
+CBEOF
+    chmod +x "$mock_dir/check-blocked"
+}
+
+make_blocked_env() {
+    local mock_dir="$1"
+    make_test_env "$mock_dir"
+
+    # Override check-blocked to signal blocked
+    cat > "$mock_dir/check-blocked" << 'CBEOF'
+#!/usr/bin/env bash
+# Mock: issue is blocked
+echo "Issue is blocked by open dependencies." >&2
+exit 1
+CBEOF
+    chmod +x "$mock_dir/check-blocked"
+}
+
+make_failing_gh_env() {
+    local mock_dir="$1"
+
+    cat > "$mock_dir/gh" << 'GHEOF'
+#!/usr/bin/env bash
+# Mock gh that always fails
+exit 2
+GHEOF
+    chmod +x "$mock_dir/gh"
+
+    cat > "$mock_dir/check-blocked" << 'CBEOF'
+#!/usr/bin/env bash
+exit 0
+CBEOF
+    chmod +x "$mock_dir/check-blocked"
+}
+
+# --- Test 1: Args containing "#123" -> extracts issue 123, outputs formatted body ---
+echo "=== Test 1: Args with '#123' hash reference ==="
+TMPDIR_TEST=$(mktemp -d)
+make_test_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "#123 do something" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "hash ref: exit 0" "$EXIT_CODE"
+FIRST_LINE=$(echo "$OUTPUT" | head -1)
+REST=$(echo "$OUTPUT" | tail -n +2)
+if echo "$FIRST_LINE" | grep -q "NUMBER=123"; then
+    echo "PASS: hash ref: first line is NUMBER=123"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: hash ref: expected first line NUMBER=123, got: $FIRST_LINE"
+    FAIL=$((FAIL + 1))
+fi
+assert_output_contains "hash ref: body contains issue content" "$REST" "Issue"
+cleanup
+
+# --- Test 2: GitHub URL -> extracts number and repo ---
+echo "=== Test 2: GitHub URL reference ==="
+TMPDIR_TEST=$(mktemp -d)
+make_test_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "https://github.com/foo/bar/issues/42" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "github url: exit 0" "$EXIT_CODE"
+FIRST_LINE=$(echo "$OUTPUT" | head -1)
+if echo "$FIRST_LINE" | grep -q "NUMBER=42"; then
+    echo "PASS: github url: first line is NUMBER=42"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: github url: expected first line NUMBER=42, got: $FIRST_LINE"
+    FAIL=$((FAIL + 1))
+fi
+cleanup
+
+# --- Test 3: Plain number at start "42 fix bug" -> extracts issue 42 ---
+echo "=== Test 3: Plain number at start ==="
+TMPDIR_TEST=$(mktemp -d)
+make_test_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "42 fix the navbar bug" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "plain number: exit 0" "$EXIT_CODE"
+FIRST_LINE=$(echo "$OUTPUT" | head -1)
+if echo "$FIRST_LINE" | grep -q "NUMBER=42"; then
+    echo "PASS: plain number: first line is NUMBER=42"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: plain number: expected first line NUMBER=42, got: $FIRST_LINE"
+    FAIL=$((FAIL + 1))
+fi
+cleanup
+
+# --- Test 4: Args with no issue reference -> empty output, exit 0 ---
+echo "=== Test 4: No issue reference in args ==="
+TMPDIR_TEST=$(mktemp -d)
+make_test_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "fix the navbar" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "no ref: exit 0" "$EXIT_CODE"
+assert_output_empty "no ref: empty output" "$OUTPUT"
+cleanup
+
+# --- Test 5: gh issue view fails -> empty output, exit 0 ---
+echo "=== Test 5: gh fails -> graceful degradation ==="
+TMPDIR_TEST=$(mktemp -d)
+make_failing_gh_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "#99" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "gh fails: exit 0" "$EXIT_CODE"
+assert_output_empty "gh fails: empty output" "$OUTPUT"
+cleanup
+
+# --- Test 6: Issue is blocked -> exit 1 ---
+echo "=== Test 6: Issue is blocked -> exit 1 ==="
+TMPDIR_TEST=$(mktemp -d)
+make_blocked_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "#50" 2>/tmp/fetch_stderr_test6) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "blocked issue: exit 1" "$EXIT_CODE"
+STDERR_OUT=$(cat /tmp/fetch_stderr_test6 2>/dev/null || echo "")
+if echo "$STDERR_OUT" | grep -qi "blocked\|dependencies\|open"; then
+    echo "PASS: blocked issue: stderr contains blocking reason"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: blocked issue: expected blocking reason in stderr, got: $STDERR_OUT"
+    FAIL=$((FAIL + 1))
+fi
+cleanup
+
+# --- Test 7: Missing --args flag -> exit nonzero with usage message ---
+echo "=== Test 7: Missing --args flag ==="
+TMPDIR_TEST=$(mktemp -d)
+make_test_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" "$FETCH_ISSUE" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_nonzero "missing --args: non-zero exit" "$EXIT_CODE"
+assert_output_contains "missing --args: usage message" "$OUTPUT" "usage\|--args\|required"
+cleanup
+
+# --- Test 8: Malformed GitHub URL (no /issues/ path) -> treated as no issue ref ---
+echo "=== Test 8: Malformed GitHub URL ==="
+TMPDIR_TEST=$(mktemp -d)
+make_test_env "$TMPDIR_TEST"
+OUTPUT=$(PATH="$TMPDIR_TEST:$PATH" \
+    CHECK_BLOCKED_PATH="$TMPDIR_TEST/check-blocked" \
+    "$FETCH_ISSUE" --args "https://github.com/foo/bar/pulls/42" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "malformed url: exit 0" "$EXIT_CODE"
+assert_output_empty "malformed url: empty output" "$OUTPUT"
+cleanup
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem / Task

The `looper/SKILL.md` (470 lines) contains large blocks of procedural logic that the LLM must interpret and follow step-by-step. These blocks consume context window and are duplicated across `looper/SKILL.md` and `looper-issue/SKILL.md`. Moving them into shell scripts eliminates context window usage and removes cross-file duplication.

**Current behavior:** Blocking check logic (~40 lines), agent context assembly (~130 lines), and issue reference detection (~50 lines) are inline in SKILL.md, consuming LLM context window every invocation.
**Expected behavior:** These blocks execute as shell scripts outside the context window, reducing SKILL.md from 470 to 296 lines.

Closes #61

## Existing Architecture

The SKILL.md files contain inline procedural blocks that the LLM reads and interprets verbatim each invocation. Blocking checks are duplicated in both looper and looper-issue skills.

```mermaid
graph TD
    S["looper/SKILL.md (470 lines)"] --> BC["Inline blocking checks (~40 lines)"]
    S --> IC["Inline issue context fetch (~70 lines)"]
    S --> AC["Inline agent context assembly (~130 lines)"]
    LI["looper-issue/SKILL.md"] --> BC2["Inline blocking checks (~40 lines, duplicated)"]
    style BC fill:#f66,stroke:#333
    style BC2 fill:#f66,stroke:#333
    style IC fill:#f66,stroke:#333
    style AC fill:#f66,stroke:#333
```

## Proposed Architecture

Procedural logic is extracted into three reusable shell scripts that execute outside the LLM context window. Both SKILL.md files call the same `check-blocked` script, eliminating duplication.

```mermaid
graph TD
    S["looper/SKILL.md (296 lines)"] -->|"1-line call"| CB["scripts/check-blocked"]
    S -->|"1-line call"| FI["scripts/fetch-issue-context"]
    S -->|"3-line call"| BA["scripts/build-agent-context"]
    LI["looper-issue/SKILL.md (116 lines)"] -->|"1-line call"| CB
    FI -->|"calls internally"| CB
    style CB fill:#6f6,stroke:#333
    style FI fill:#6f6,stroke:#333
    style BA fill:#6f6,stroke:#333
    style S fill:#69f,stroke:#333
    style LI fill:#69f,stroke:#333
```

## Key Changes

### New scripts (3 files)
- **`scripts/check-blocked`** — Checks if a GitHub issue is blocked by labels, task-list dependency refs, or "Blocked by" refs. Exit 0 = not blocked, exit 1 = blocked with reason on stdout.
- **`scripts/fetch-issue-context`** — Extracts issue references from arguments (GitHub URL, `#N`, or plain number), calls `check-blocked`, outputs `NUMBER=<num>` then formatted issue body.
- **`scripts/build-agent-context`** — Assembles role-specific context strings for planner/doer/checker agents with appropriate project context slicing.

### Updated SKILL.md files (2 files)
- **`looper/SKILL.md`** — Reduced from 470 to 296 lines (-174). Step 4c replaced with `fetch-issue-context` call, step 5 removed (handled by `build-agent-context`), step 7c replaced with `build-agent-context` calls.
- **`looper-issue/SKILL.md`** — Reduced from 141 to 116 lines (-25). Phase 1b blocking checks replaced with `check-blocked` loop.

### Tests (3 files)
- **`tests/test-check-blocked.sh`** — 12 test cases with mock `gh`
- **`tests/test-fetch-issue-context.sh`** — 8 test cases with mock `gh`
- **`tests/test-build-agent-context.sh`** — 14 test cases with fixture files

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Shell tests | ✅ | 8 suites, 160 assertions, 0 failures |
| Cargo test | ✅ | 74 passed, 0 failed |
| Cargo clippy | ✅ | No warnings |
| Build | ✅ | Clean |

---