### PR TITLE
docs(looper): add built-in agent reference to subagents skill

### DIFF
--- a/plugins/looper/skills/subagents/SKILL.md
+++ b/plugins/looper/skills/subagents/SKILL.md
@@ -18,6 +18,30 @@ Spawn subagents using `claude -p` when the **Agent tool is not available** — e
 
 ---
 
+## Built-in agents reference
+
+These agents are provided by the Claude Code harness and are always available for spawning:
+
+| Agent | Model | Best for |
+|-------|-------|----------|
+| **Explore** | haiku | Fast, read-only codebase exploration. Use for finding files by pattern, searching code for keywords, understanding how subsystems work, or answering questions about the codebase. **Prefer this over manual Glob/Grep when the search requires multiple rounds or cross-cutting context** (e.g. "how does auth flow through the app", "find all callers of X"). Cheaper and faster than general-purpose. |
+| **Plan** | inherit | Software architect agent. Use when you need to design an implementation strategy, identify critical files, and consider architectural trade-offs before writing code. Returns step-by-step plans. |
+| **general-purpose** | inherit | General-purpose research and multi-step tasks. Use for complex questions that span the codebase, web searches, or tasks that don't fit a specialized agent. Has access to all tools. |
+| **claude-code-guide** | haiku | Answers questions about Claude Code features, hooks, slash commands, MCP servers, settings, IDE integrations, the Agent SDK, and the Claude API. |
+| **statusline-setup** | sonnet | Configures the Claude Code status line setting. Narrow use case. |
+
+### When to spawn Explore vs. using Grep/Glob directly
+
+- **Use Grep/Glob directly** when you know exactly what you're looking for (a specific symbol, file name, or pattern) and a single query will suffice.
+- **Spawn Explore** when:
+  - The search is open-ended or requires multiple rounds of searching
+  - You need to understand how multiple files/modules relate to each other
+  - You need to trace a flow across the codebase (e.g. request handling, data pipeline)
+  - You're unfamiliar with the area of code and need orientation
+  - You'd otherwise need 3+ sequential Grep/Glob calls to find what you need
+
+---
+
 ## Phase 1: Discover available subagents
 
 Run the discovery script:

--- a/plugins/looper/skills/subagents/scripts/list-agents
+++ b/plugins/looper/skills/subagents/scripts/list-agents
@@ -19,8 +19,8 @@ done
 
 echo ""
 echo "Built-in agents:"
-echo "  claude-code-guide · haiku — Answer questions about Claude Code, Agent SDK, Claude API"
-echo "  Explore · haiku — Fast codebase exploration"
-echo "  general-purpose · inherit — General-purpose research and multi-step tasks"
-echo "  Plan · inherit — Software architect for implementation plans"
-echo "  statusline-setup · sonnet — Configure status line settings"
+echo "  Explore · haiku — Fast read-only codebase exploration; prefer over manual Glob/Grep for multi-round or cross-cutting searches"
+echo "  Plan · inherit — Software architect for designing implementation strategies and step-by-step plans"
+echo "  general-purpose · inherit — General-purpose research, web search, and complex multi-step tasks (all tools)"
+echo "  claude-code-guide · haiku — Answer questions about Claude Code features, Agent SDK, and Claude API"
+echo "  statusline-setup · sonnet — Configure the Claude Code status line setting"


### PR DESCRIPTION
## Summary
- Adds a built-in agents reference table to the subagents skill (`SKILL.md`) documenting Explore, Plan, general-purpose, claude-code-guide, and statusline-setup agents
- Adds guidance on when to spawn Explore vs using Grep/Glob directly
- Updates `list-agents` script with better descriptions matching the skill doc

## Problem
Looper subagents underutilize the Explore agent because the subagents skill had no documentation about what built-in agents are available or when to use them. Agents default to manual Glob/Grep which is shallower for cross-cutting searches.

## Test plan
- [ ] Verify `list-agents` output shows updated descriptions
- [ ] Verify looper planner/doer spawns Explore more readily on multi-file tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)