### PR TITLE
feat(looper-watch): prevent concurrent claims via write-then-verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +443,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -456,10 +481,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -515,6 +558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.42.1"
+version = "0.42.3"
 dependencies = [
  "chrono",
  "clap",
@@ -564,6 +613,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -572,7 +622,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -656,6 +706,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +732,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ratatui"
@@ -709,7 +775,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
@@ -744,6 +810,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -964,16 +1036,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1018,6 +1125,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1182,6 +1323,94 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/looper-watch/Cargo.toml
+++ b/crates/looper-watch/Cargo.toml
@@ -19,3 +19,4 @@ clap = { version = "4", features = ["derive"] }
 dirs = "6"
 libc = "0.2"
 futures = "0.3"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/looper-watch/src/claim.rs
+++ b/crates/looper-watch/src/claim.rs
@@ -1,0 +1,677 @@
+/// Claim module: write-then-verify protocol for preventing concurrent Claude
+/// instances from claiming the same GitHub issue.
+///
+/// ## Protocol overview
+///
+/// 1. **Local lock (fast-path):** Create `.looper/locks/<sanitized_repo>-<issue>.lock`
+///    with O_EXCL. If the file already exists, return `LocalLockHeld` without
+///    hitting the GitHub API at all — same-host races are caught here.
+///
+/// 2. **Remote claim:** Run `gh issue edit --add-assignee @me --add-label
+///    looper-claimed` and post a comment `looper-claim:<run_id>`.
+///
+/// 3. **Settle window:** Sleep `config.settle_ms` to allow concurrent writes
+///    from other hosts to land.
+///
+/// 4. **Verify:** Fetch the issue's comments and assignees. Find the earliest
+///    `looper-claim:` comment. If its run_id is ours, we win — return `Ok(ClaimGuard)`.
+///    Otherwise, cede (remove assignee + label, delete lockfile) and return
+///    `LostRace`.
+///
+/// ## Tiebreaker
+///
+/// Earliest-comment-wins is deterministic: GitHub returns comments in creation
+/// order and both instances see the same server state, so both always agree on
+/// the winner. Two comments at the same `createdAt` second are rare; we break
+/// ties on input order (first in the JSON array). A 3-second settle window is
+/// well above observed GitHub comment replication lag; if a second instance
+/// posts its claim within 3 s the first will see it at verify time.
+///
+/// ## Label creation
+///
+/// `--add-label looper-claimed` fails if the label does not exist in the repo.
+/// The assignment and claim comment are the load-bearing parts of the protocol;
+/// the label is a convenience for filtering. Therefore label creation/addition
+/// is best-effort and the claim is NOT aborted on label error.
+///
+/// `LABEL_IS_BEST_EFFORT = true` — see `try_claim` implementation.
+pub const LABEL_IS_BEST_EFFORT: bool = true;
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// A successful claim. Holds the local lockfile path and the run_id.
+/// Drop removes the local lockfile (winner cleanup on session end).
+/// Remote un-assignment is NOT done on drop — only the winner holds a guard,
+/// and un-assignment on PR close is handled elsewhere.
+pub struct ClaimGuard {
+    lock_path: PathBuf,
+    pub run_id: String,
+    pub repo: String,
+    pub issue_number: u64,
+}
+
+impl Drop for ClaimGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.lock_path);
+    }
+}
+
+/// Configuration for the claim protocol.
+pub struct ClaimConfig {
+    /// Milliseconds to sleep between claim and verify. Default: 3000.
+    pub settle_ms: u64,
+    /// Directory where per-issue lock files are stored.
+    pub locks_dir: PathBuf,
+}
+
+impl ClaimConfig {
+    /// Construct a config using the default locks directory
+    /// (`<data_local>/looper-watch/locks`).
+    pub fn default_for(_repo: &str) -> Self {
+        let locks_dir = dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("looper-watch")
+            .join("locks");
+        Self {
+            settle_ms: 3000,
+            locks_dir,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ClaimError {
+    /// Another process on this host holds the local O_EXCL lock.
+    LocalLockHeld,
+    /// Another instance posted its claim comment earlier; `winner` is its run_id.
+    LostRace { winner: String },
+    /// A `gh` CLI invocation failed.
+    GhFailure(String),
+    /// An I/O error.
+    Io(String),
+}
+
+impl std::fmt::Display for ClaimError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClaimError::LocalLockHeld => write!(f, "local lock held by another process"),
+            ClaimError::LostRace { winner } => write!(f, "lost race to {winner}"),
+            ClaimError::GhFailure(msg) => write!(f, "gh failure: {msg}"),
+            ClaimError::Io(msg) => write!(f, "io error: {msg}"),
+        }
+    }
+}
+
+/// Internal decision enum used by `decide_winner`.
+#[derive(Debug, PartialEq)]
+pub enum Decision {
+    Won,
+    Lost { winner: String },
+}
+
+// ── JSON structures for gh output ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Comment {
+    pub body: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+// ── Pure helpers (all unit-tested, no network) ────────────────────────────────
+
+/// Extract the run_id from a claim comment body.
+///
+/// Returns `Some(run_id)` if the body starts with `"looper-claim:"`, where
+/// `run_id` is everything after the first colon. Returns `None` otherwise.
+///
+/// Note: run_ids may contain colons (e.g. IPv6 hostnames like `host::1-123-abc`).
+/// We split on the *first* colon after the `looper-claim` prefix.
+pub fn parse_claim_body(body: &str) -> Option<&str> {
+    body.strip_prefix("looper-claim:")
+}
+
+/// Find the earliest claim comment from a slice of comments.
+///
+/// Returns `Some((created_at, run_id))` for the claim comment with the
+/// smallest `createdAt` timestamp string (RFC3339 lexicographic comparison).
+/// Ties on identical `createdAt` are broken by input order (first in slice).
+/// Returns `None` if no claim comments are present.
+pub fn earliest_claim<'a>(comments: &'a [Comment]) -> Option<(&'a str, &'a str)> {
+    comments
+        .iter()
+        .filter_map(|c| {
+            parse_claim_body(&c.body).map(|run_id| (c.created_at.as_str(), run_id))
+        })
+        .min_by(|a, b| a.0.cmp(b.0))
+}
+
+/// Decide whether we won or lost the race.
+///
+/// `our_run_id` is the run id we posted. `comments` is the full comment list
+/// from `gh issue view --json comments`.
+///
+/// - If no claim comment exists at all → `Lost { winner: "" }` (unexpected;
+///   our comment should be there; safe default is to cede).
+/// - If the earliest claim comment's run_id equals `our_run_id` → `Won`.
+/// - Otherwise → `Lost { winner: <other_run_id> }`.
+pub fn decide_winner(comments: &[Comment], our_run_id: &str) -> Decision {
+    match earliest_claim(comments) {
+        None => Decision::Lost {
+            winner: String::new(),
+        },
+        Some((_ts, run_id)) => {
+            if run_id == our_run_id {
+                Decision::Won
+            } else {
+                Decision::Lost {
+                    winner: run_id.to_string(),
+                }
+            }
+        }
+    }
+}
+
+/// Replace `/` with `-` in a repo slug so it can be used in a filename.
+///
+/// Matches the sanitization in `main.rs::default_state_path`.
+pub fn sanitize_repo(repo: &str) -> String {
+    repo.replace('/', "-")
+}
+
+/// Generate a unique run id for this invocation.
+///
+/// Format: `<hostname>-<pid>-<uuid_v4>`.
+/// Uses `uuid::Uuid::new_v4()` for the UUID component and reads the hostname
+/// from `/proc/sys/kernel/hostname` (Linux) or falls back to `"unknown"`.
+/// We avoid adding a `hostname` crate dependency by reading the file directly;
+/// `libc::gethostname` would be an alternative but the file read is simpler.
+pub fn generate_run_id() -> String {
+    let hostname = std::fs::read_to_string("/proc/sys/kernel/hostname")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let pid = std::process::id();
+    let uuid = uuid::Uuid::new_v4();
+    format!("{hostname}-{pid}-{uuid}")
+}
+
+/// Create the local lock file with O_EXCL semantics.
+///
+/// Writes `run_id` into the lock file for debugging.
+///
+/// Returns:
+/// - `Ok(lock_path)` — lock acquired, caller is responsible for deleting it.
+/// - `Err(ClaimError::LocalLockHeld)` — another process holds the lock.
+/// - `Err(ClaimError::Io(...))` — unexpected I/O error.
+pub fn try_local_lock(locks_dir: &Path, lock_name: &str, run_id: &str) -> Result<PathBuf, ClaimError> {
+    std::fs::create_dir_all(locks_dir)
+        .map_err(|e| ClaimError::Io(format!("create_dir_all failed: {e}")))?;
+    let lock_path = locks_dir.join(lock_name);
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true) // O_CREAT | O_EXCL
+        .open(&lock_path)
+    {
+        Ok(mut f) => {
+            let _ = write!(f, "{run_id}");
+            Ok(lock_path)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(ClaimError::LocalLockHeld),
+        Err(e) => Err(ClaimError::Io(e.to_string())),
+    }
+}
+
+// ── Network-touching claim function ──────────────────────────────────────────
+
+/// Attempt to claim an issue using the write-then-verify protocol.
+///
+/// This function calls `gh` and is not covered by unit tests. Unit tests cover
+/// all pure helpers above. Manual smoke testing validates this integration.
+pub async fn try_claim(
+    repo: &str,
+    issue_number: u64,
+    config: &ClaimConfig,
+) -> Result<ClaimGuard, ClaimError> {
+    let run_id = generate_run_id();
+    let lock_name = format!("{}-{}.lock", sanitize_repo(repo), issue_number);
+
+    // Step 1: local lock (fast-path — no API call if already locked)
+    let lock_path = try_local_lock(&config.locks_dir, &lock_name, &run_id)?;
+
+    // Step 2: remote claim (best-effort label, mandatory assignee + comment)
+    // Add label first (best-effort — don't fail if label doesn't exist)
+    let _ = tokio::process::Command::new("gh")
+        .args([
+            "label",
+            "create",
+            "looper-claimed",
+            "--repo",
+            repo,
+            "--force",
+        ])
+        .output()
+        .await;
+
+    let assign_result = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "edit",
+            &issue_number.to_string(),
+            "--repo",
+            repo,
+            "--add-assignee",
+            "@me",
+            "--add-label",
+            "looper-claimed",
+        ])
+        .output()
+        .await;
+
+    match assign_result {
+        Ok(o) if o.status.success() => {}
+        Ok(o) => {
+            // Assignment failed — clean up local lock and return error
+            let _ = std::fs::remove_file(&lock_path);
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            return Err(ClaimError::GhFailure(format!("assign failed: {stderr}")));
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&lock_path);
+            return Err(ClaimError::GhFailure(format!("gh exec failed: {e}")));
+        }
+    }
+
+    // Post claim comment
+    let comment_body = format!("looper-claim:{run_id}");
+    let comment_result = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "comment",
+            &issue_number.to_string(),
+            "--repo",
+            repo,
+            "--body",
+            &comment_body,
+        ])
+        .output()
+        .await;
+
+    match comment_result {
+        Ok(o) if o.status.success() => {}
+        Ok(o) => {
+            let _ = std::fs::remove_file(&lock_path);
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            return Err(ClaimError::GhFailure(format!(
+                "comment failed: {stderr}"
+            )));
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&lock_path);
+            return Err(ClaimError::GhFailure(format!("gh exec failed: {e}")));
+        }
+    }
+
+    // Step 3: settle
+    tokio::time::sleep(tokio::time::Duration::from_millis(config.settle_ms)).await;
+
+    // Step 4: verify
+    let view_result = tokio::process::Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &issue_number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "comments,assignees",
+        ])
+        .output()
+        .await;
+
+    let output = match view_result {
+        Ok(o) if o.status.success() => o,
+        Ok(o) => {
+            let _ = std::fs::remove_file(&lock_path);
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            return Err(ClaimError::GhFailure(format!("view failed: {stderr}")));
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&lock_path);
+            return Err(ClaimError::GhFailure(format!("gh exec failed: {e}")));
+        }
+    };
+
+    #[derive(Deserialize)]
+    struct IssueView {
+        comments: Vec<Comment>,
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let view: IssueView = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = std::fs::remove_file(&lock_path);
+            return Err(ClaimError::Io(format!("parse view failed: {e}")));
+        }
+    };
+
+    match decide_winner(&view.comments, &run_id) {
+        Decision::Won => Ok(ClaimGuard {
+            lock_path,
+            run_id,
+            repo: repo.to_string(),
+            issue_number,
+        }),
+        Decision::Lost { winner } => {
+            // Cede: best-effort remove assignee + label
+            let _ = tokio::process::Command::new("gh")
+                .args([
+                    "issue",
+                    "edit",
+                    &issue_number.to_string(),
+                    "--repo",
+                    repo,
+                    "--remove-assignee",
+                    "@me",
+                    "--remove-label",
+                    "looper-claimed",
+                ])
+                .output()
+                .await;
+            let _ = std::fs::remove_file(&lock_path);
+            Err(ClaimError::LostRace { winner })
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp_locks_dir() -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = std::env::temp_dir()
+            .join("looper-watch-claim-tests")
+            .join(format!("{}-{n}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn make_comment(body: &str, created_at: &str) -> Comment {
+        Comment {
+            body: body.to_string(),
+            created_at: created_at.to_string(),
+        }
+    }
+
+    // ── parse_claim_body ──────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_claim_body_extracts_run_id() {
+        let result = parse_claim_body("looper-claim:host-123-abcd");
+        assert_eq!(result, Some("host-123-abcd"));
+    }
+
+    #[test]
+    fn parse_claim_body_returns_none_for_non_claim() {
+        let result = parse_claim_body("some other comment");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn parse_claim_body_handles_empty_run_id() {
+        // "looper-claim:" with no run_id returns Some("") — still a valid claim
+        // marker; the decide_winner comparator will never match "" against a real
+        // non-empty generated run_id, so this safely resolves to Lost.
+        let result = parse_claim_body("looper-claim:");
+        assert_eq!(result, Some(""));
+    }
+
+    #[test]
+    fn parse_claim_body_handles_colon_in_run_id() {
+        // IPv6-style hostname like host::1-123-abc
+        let result = parse_claim_body("looper-claim:host::1-123-abc");
+        assert_eq!(result, Some("host::1-123-abc"));
+    }
+
+    // ── earliest_claim ────────────────────────────────────────────────────────
+
+    #[test]
+    fn earliest_claim_picks_oldest_by_created_at() {
+        let comments = vec![
+            make_comment("looper-claim:run-c", "2024-01-01T00:00:03Z"),
+            make_comment("looper-claim:run-a", "2024-01-01T00:00:01Z"),
+            make_comment("looper-claim:run-b", "2024-01-01T00:00:02Z"),
+        ];
+        let result = earliest_claim(&comments);
+        assert_eq!(result, Some(("2024-01-01T00:00:01Z", "run-a")));
+    }
+
+    #[test]
+    fn earliest_claim_ignores_non_claim_comments() {
+        let comments = vec![
+            make_comment("regular comment", "2024-01-01T00:00:01Z"),
+            make_comment("looper-claim:run-x", "2024-01-01T00:00:02Z"),
+            make_comment("another regular comment", "2024-01-01T00:00:00Z"),
+        ];
+        let result = earliest_claim(&comments);
+        assert_eq!(result, Some(("2024-01-01T00:00:02Z", "run-x")));
+    }
+
+    #[test]
+    fn earliest_claim_returns_none_when_no_claim_comments() {
+        let comments = vec![
+            make_comment("regular comment", "2024-01-01T00:00:01Z"),
+            make_comment("another comment", "2024-01-01T00:00:02Z"),
+        ];
+        let result = earliest_claim(&comments);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn earliest_claim_breaks_ties_on_identical_timestamps() {
+        // When two claim comments have the same createdAt, we take the first in
+        // input order (stable sort / min_by prefers earlier in slice on equal keys).
+        let comments = vec![
+            make_comment("looper-claim:run-first", "2024-01-01T00:00:01Z"),
+            make_comment("looper-claim:run-second", "2024-01-01T00:00:01Z"),
+        ];
+        let result = earliest_claim(&comments);
+        // First in input order wins the tie.
+        assert_eq!(result, Some(("2024-01-01T00:00:01Z", "run-first")));
+    }
+
+    #[test]
+    fn earliest_claim_single_claim_comment() {
+        let comments = vec![make_comment("looper-claim:only-run", "2024-01-01T00:00:01Z")];
+        let result = earliest_claim(&comments);
+        assert_eq!(result, Some(("2024-01-01T00:00:01Z", "only-run")));
+    }
+
+    // ── decide_winner ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn verify_wins_when_our_run_id_is_earliest() {
+        let comments = vec![
+            make_comment("looper-claim:ours-first", "2024-01-01T00:00:01Z"),
+            make_comment("looper-claim:theirs-second", "2024-01-01T00:00:02Z"),
+        ];
+        let decision = decide_winner(&comments, "ours-first");
+        assert_eq!(decision, Decision::Won);
+    }
+
+    #[test]
+    fn verify_loses_when_another_run_id_is_earliest() {
+        let comments = vec![
+            make_comment("looper-claim:theirs-first", "2024-01-01T00:00:01Z"),
+            make_comment("looper-claim:ours-second", "2024-01-01T00:00:02Z"),
+        ];
+        let decision = decide_winner(&comments, "ours-second");
+        assert_eq!(
+            decision,
+            Decision::Lost {
+                winner: "theirs-first".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn verify_loses_when_no_claim_comments_present() {
+        // Unexpected state (our comment should exist); safe default is Lost.
+        let comments = vec![make_comment("regular comment", "2024-01-01T00:00:01Z")];
+        let decision = decide_winner(&comments, "our-run-id");
+        assert_eq!(
+            decision,
+            Decision::Lost {
+                winner: String::new()
+            }
+        );
+    }
+
+    #[test]
+    fn verify_wins_with_single_own_claim_comment() {
+        let comments = vec![make_comment("looper-claim:our-only", "2024-01-01T00:00:01Z")];
+        let decision = decide_winner(&comments, "our-only");
+        assert_eq!(decision, Decision::Won);
+    }
+
+    #[test]
+    fn verify_loses_with_single_other_claim_comment() {
+        let comments = vec![make_comment("looper-claim:their-only", "2024-01-01T00:00:01Z")];
+        let decision = decide_winner(&comments, "our-run-id");
+        assert_eq!(
+            decision,
+            Decision::Lost {
+                winner: "their-only".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn verify_loses_when_empty_run_id_comment_exists() {
+        // "looper-claim:" (empty run_id) never matches our non-empty run_id → Lost.
+        let comments = vec![make_comment("looper-claim:", "2024-01-01T00:00:01Z")];
+        let decision = decide_winner(&comments, "our-real-run-id");
+        assert_eq!(
+            decision,
+            Decision::Lost {
+                winner: String::new()
+            }
+        );
+    }
+
+    // ── local lock ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn local_lock_create_new_succeeds() {
+        let locks_dir = tmp_locks_dir();
+        let result = try_local_lock(&locks_dir, "test.lock", "run-id-abc");
+        assert!(result.is_ok(), "first lock creation should succeed");
+        let lock_path = result.unwrap();
+        assert!(lock_path.exists(), "lock file should exist on disk");
+        let contents = std::fs::read_to_string(&lock_path).unwrap();
+        assert_eq!(contents, "run-id-abc", "lock file should contain the run_id");
+        let _ = std::fs::remove_file(lock_path);
+    }
+
+    #[test]
+    fn local_lock_fails_when_already_exists() {
+        let locks_dir = tmp_locks_dir();
+        // Pre-create the lock file
+        std::fs::write(locks_dir.join("test.lock"), "existing-run").unwrap();
+        let result = try_local_lock(&locks_dir, "test.lock", "new-run-id");
+        assert!(
+            matches!(result, Err(ClaimError::LocalLockHeld)),
+            "second attempt should return LocalLockHeld"
+        );
+    }
+
+    #[test]
+    fn claim_guard_drop_removes_local_lockfile() {
+        let locks_dir = tmp_locks_dir();
+        let lock_path = try_local_lock(&locks_dir, "drop-test.lock", "run-id")
+            .expect("should acquire lock");
+        assert!(lock_path.exists(), "lock file should exist before drop");
+
+        // Create a ClaimGuard that owns this lock_path
+        let guard = ClaimGuard {
+            lock_path: lock_path.clone(),
+            run_id: "run-id".to_string(),
+            repo: "owner/repo".to_string(),
+            issue_number: 1,
+        };
+
+        drop(guard);
+
+        assert!(
+            !lock_path.exists(),
+            "lock file should be removed after ClaimGuard is dropped"
+        );
+    }
+
+    // ── sanitize_repo ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn sanitize_repo_replaces_slash_with_dash() {
+        assert_eq!(sanitize_repo("owner/repo"), "owner-repo");
+    }
+
+    #[test]
+    fn sanitize_repo_no_slash_unchanged() {
+        assert_eq!(sanitize_repo("noslash"), "noslash");
+    }
+
+    #[test]
+    fn sanitize_repo_multiple_slashes() {
+        assert_eq!(sanitize_repo("org/team/repo"), "org-team-repo");
+    }
+
+    // ── generate_run_id ───────────────────────────────────────────────────────
+
+    #[test]
+    fn run_id_format_has_three_dash_separated_parts() {
+        // Format: <hostname>-<pid>-<uuid>
+        // The uuid itself contains 4 dashes, so total dashes >= 2.
+        // We assert: contains at least 2 '-' characters and ends with a UUID-like
+        // 36-character suffix.
+        let run_id = generate_run_id();
+        let dash_count = run_id.chars().filter(|&c| c == '-').count();
+        assert!(
+            dash_count >= 2,
+            "run_id should have at least 2 '-' separators, got: {run_id}"
+        );
+        // UUID v4 is 36 chars (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+        // The last segment after the hostname-pid prefix should be the UUID.
+        // We verify the run_id is non-empty and has reasonable length.
+        assert!(
+            run_id.len() > 10,
+            "run_id should be reasonably long, got: {run_id}"
+        );
+    }
+
+    // ── error path cleanup ────────────────────────────────────────────────────
+
+    #[test]
+    fn delete_if_exists_removes_existing_file() {
+        // Verify that removing a freshly created lock cleans it up.
+        // This models the cleanup done in try_claim on gh failure.
+        let locks_dir = tmp_locks_dir();
+        let lock_path = try_local_lock(&locks_dir, "cleanup.lock", "run-cleanup").unwrap();
+        assert!(lock_path.exists());
+        let _ = std::fs::remove_file(&lock_path);
+        assert!(!lock_path.exists(), "lock should be removed after cleanup");
+    }
+}

--- a/crates/looper-watch/src/claim.rs
+++ b/crates/looper-watch/src/claim.rs
@@ -35,6 +35,7 @@
 /// is best-effort and the claim is NOT aborted on label error.
 ///
 /// `LABEL_IS_BEST_EFFORT = true` — see `try_claim` implementation.
+#[allow(dead_code)]
 pub const LABEL_IS_BEST_EFFORT: bool = true;
 
 use std::fs::OpenOptions;
@@ -52,7 +53,9 @@ use serde::Deserialize;
 pub struct ClaimGuard {
     lock_path: PathBuf,
     pub run_id: String,
+    #[allow(dead_code)]
     pub repo: String,
+    #[allow(dead_code)]
     pub issue_number: u64,
 }
 
@@ -143,12 +146,10 @@ pub fn parse_claim_body(body: &str) -> Option<&str> {
 /// smallest `createdAt` timestamp string (RFC3339 lexicographic comparison).
 /// Ties on identical `createdAt` are broken by input order (first in slice).
 /// Returns `None` if no claim comments are present.
-pub fn earliest_claim<'a>(comments: &'a [Comment]) -> Option<(&'a str, &'a str)> {
+pub fn earliest_claim(comments: &[Comment]) -> Option<(&str, &str)> {
     comments
         .iter()
-        .filter_map(|c| {
-            parse_claim_body(&c.body).map(|run_id| (c.created_at.as_str(), run_id))
-        })
+        .filter_map(|c| parse_claim_body(&c.body).map(|run_id| (c.created_at.as_str(), run_id)))
         .min_by(|a, b| a.0.cmp(b.0))
 }
 
@@ -210,7 +211,11 @@ pub fn generate_run_id() -> String {
 /// - `Ok(lock_path)` — lock acquired, caller is responsible for deleting it.
 /// - `Err(ClaimError::LocalLockHeld)` — another process holds the lock.
 /// - `Err(ClaimError::Io(...))` — unexpected I/O error.
-pub fn try_local_lock(locks_dir: &Path, lock_name: &str, run_id: &str) -> Result<PathBuf, ClaimError> {
+pub fn try_local_lock(
+    locks_dir: &Path,
+    lock_name: &str,
+    run_id: &str,
+) -> Result<PathBuf, ClaimError> {
     std::fs::create_dir_all(locks_dir)
         .map_err(|e| ClaimError::Io(format!("create_dir_all failed: {e}")))?;
     let lock_path = locks_dir.join(lock_name);
@@ -308,9 +313,7 @@ pub async fn try_claim(
         Ok(o) => {
             let _ = std::fs::remove_file(&lock_path);
             let stderr = String::from_utf8_lossy(&o.stderr);
-            return Err(ClaimError::GhFailure(format!(
-                "comment failed: {stderr}"
-            )));
+            return Err(ClaimError::GhFailure(format!("comment failed: {stderr}")));
         }
         Err(e) => {
             let _ = std::fs::remove_file(&lock_path);
@@ -496,7 +499,10 @@ mod tests {
 
     #[test]
     fn earliest_claim_single_claim_comment() {
-        let comments = vec![make_comment("looper-claim:only-run", "2024-01-01T00:00:01Z")];
+        let comments = vec![make_comment(
+            "looper-claim:only-run",
+            "2024-01-01T00:00:01Z",
+        )];
         let result = earliest_claim(&comments);
         assert_eq!(result, Some(("2024-01-01T00:00:01Z", "only-run")));
     }
@@ -543,14 +549,20 @@ mod tests {
 
     #[test]
     fn verify_wins_with_single_own_claim_comment() {
-        let comments = vec![make_comment("looper-claim:our-only", "2024-01-01T00:00:01Z")];
+        let comments = vec![make_comment(
+            "looper-claim:our-only",
+            "2024-01-01T00:00:01Z",
+        )];
         let decision = decide_winner(&comments, "our-only");
         assert_eq!(decision, Decision::Won);
     }
 
     #[test]
     fn verify_loses_with_single_other_claim_comment() {
-        let comments = vec![make_comment("looper-claim:their-only", "2024-01-01T00:00:01Z")];
+        let comments = vec![make_comment(
+            "looper-claim:their-only",
+            "2024-01-01T00:00:01Z",
+        )];
         let decision = decide_winner(&comments, "our-run-id");
         assert_eq!(
             decision,
@@ -583,7 +595,10 @@ mod tests {
         let lock_path = result.unwrap();
         assert!(lock_path.exists(), "lock file should exist on disk");
         let contents = std::fs::read_to_string(&lock_path).unwrap();
-        assert_eq!(contents, "run-id-abc", "lock file should contain the run_id");
+        assert_eq!(
+            contents, "run-id-abc",
+            "lock file should contain the run_id"
+        );
         let _ = std::fs::remove_file(lock_path);
     }
 
@@ -602,8 +617,8 @@ mod tests {
     #[test]
     fn claim_guard_drop_removes_local_lockfile() {
         let locks_dir = tmp_locks_dir();
-        let lock_path = try_local_lock(&locks_dir, "drop-test.lock", "run-id")
-            .expect("should acquire lock");
+        let lock_path =
+            try_local_lock(&locks_dir, "drop-test.lock", "run-id").expect("should acquire lock");
         assert!(lock_path.exists(), "lock file should exist before drop");
 
         // Create a ClaimGuard that owns this lock_path

--- a/crates/looper-watch/src/github.rs
+++ b/crates/looper-watch/src/github.rs
@@ -51,6 +51,8 @@ pub async fn fetch_open_unassigned(repo: &str, retries: u32) -> Result<Vec<Issue
 }
 
 /// Assign an issue to the current user (@me).
+/// Kept for potential direct use; claim::try_claim is the preferred entry point.
+#[allow(dead_code)]
 pub async fn assign_to_me(repo: &str, issue_number: u64, retries: u32) -> Result<(), String> {
     retry(retries, || async {
         let output = Command::new("gh")

--- a/crates/looper-watch/src/main.rs
+++ b/crates/looper-watch/src/main.rs
@@ -1,3 +1,4 @@
+mod claim;
 mod github;
 mod lock;
 mod state;

--- a/crates/looper-watch/src/worker.rs
+++ b/crates/looper-watch/src/worker.rs
@@ -6,6 +6,7 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, Notify};
 
 use crate::Cli;
+use crate::claim;
 use crate::github;
 use crate::state::{self, Entry, Outcome, OutcomeField, State};
 
@@ -148,7 +149,6 @@ pub async fn poll_once(cli: &Cli, state_path: &Path, app: &AppState) {
         .iter()
         .map(|issue| {
             let repo = cli.repo.clone();
-            let retries = cli.retries;
             let app_clone = app.clone();
             let state_path_clone = state_path.to_path_buf();
             let issue_number = issue.number;
@@ -168,16 +168,35 @@ pub async fn poll_once(cli: &Cli, state_path: &Path, app: &AppState) {
                     return;
                 }
 
-                // Assign with retries — skip this issue if it fails
-                if let Err(e) = github::assign_to_me(&repo, issue_number, retries).await {
-                    app_clone
-                        .log(&format!("#{issue_number}: assign failed: {e}"))
-                        .await;
-                    return;
-                }
-                app_clone
-                    .log(&format!("#{issue_number}: assigned to @me"))
-                    .await;
+                // Claim with write-then-verify protocol (local lock + remote
+                // claim comment + settle + verify earliest-comment-wins).
+                let cfg = claim::ClaimConfig::default_for(&repo);
+                let guard = match claim::try_claim(&repo, issue_number, &cfg).await {
+                    Ok(g) => {
+                        app_clone
+                            .log(&format!("#{issue_number}: claimed (run_id={})", g.run_id))
+                            .await;
+                        g
+                    }
+                    Err(claim::ClaimError::LocalLockHeld) => {
+                        app_clone
+                            .log(&format!("#{issue_number}: skipping (local lock held)"))
+                            .await;
+                        return;
+                    }
+                    Err(claim::ClaimError::LostRace { winner }) => {
+                        app_clone
+                            .log(&format!("#{issue_number}: lost race to {winner}"))
+                            .await;
+                        return;
+                    }
+                    Err(e) => {
+                        app_clone
+                            .log(&format!("#{issue_number}: claim error: {e}"))
+                            .await;
+                        return;
+                    }
+                };
 
                 // Remove from open issues list immediately so TUI reflects assignment
                 app_clone
@@ -186,8 +205,12 @@ pub async fn poll_once(cli: &Cli, state_path: &Path, app: &AppState) {
                     .await
                     .retain(|i| i.number != issue_number);
 
-                // Spawn claude in tmux as a background task
+                // Spawn claude in tmux as a background task.
+                // Move the guard into the spawned task so it lives for the
+                // full duration of the claude session; Drop removes the local
+                // lockfile when the session finishes.
                 tokio::spawn(async move {
+                    let _guard = guard;
                     run_claude(
                         &repo,
                         issue_number,

--- a/plugins/looper/skills/looper-issue/SKILL.md
+++ b/plugins/looper/skills/looper-issue/SKILL.md
@@ -76,17 +76,73 @@ or `- [ ] #N`), and "Blocked by #N" references. Exit 0 means not blocked.
 
 Store the selected issue's number as `NUMBER` and its title as `TITLE`.
 
-### 1d. Assign issue immediately
+### 1d. Generate run id
 
 ```bash
-gh issue edit $NUMBER --add-assignee @me
+RUN_ID="$(hostname)-$$-$(uuidgen)"
 ```
 
-- **Success:** Log:
-  > "Assigned issue #`$NUMBER` to current user."
-- **Failure:** Warn:
-  > "Could not assign issue #`$NUMBER`. Continuing anyway."
-  Do NOT abort — proceed regardless.
+### 1e. Local lock
+
+```bash
+LOCK_DIR=".looper/locks"
+mkdir -p "$LOCK_DIR"
+LOCK_FILE="$LOCK_DIR/${NUMBER}.lock"
+# O_EXCL via noclobber — atomic, no TOCTOU race
+if ! (set -o noclobber; echo "$RUN_ID" > "$LOCK_FILE") 2>/dev/null; then
+    echo "Issue #$NUMBER is locked locally by another process. Skipping."
+    exit 0
+fi
+trap 'rm -f "$LOCK_FILE"' EXIT
+```
+
+The EXIT trap keeps the lock file in place for the lifetime of this shell
+session (which encompasses the `/looper` invocation). The lockfile is
+automatically removed when the session exits.
+
+### 1f. Remote claim
+
+```bash
+# Label creation is best-effort — the assignee + comment are the
+# load-bearing parts of the claim protocol.
+gh label create looper-claimed --force 2>/dev/null || true
+
+gh issue edit "$NUMBER" --add-assignee @me --add-label looper-claimed || {
+    rm -f "$LOCK_FILE"
+    echo "Failed to claim issue #$NUMBER; skipping."
+    exit 0
+}
+
+gh issue comment "$NUMBER" -b "looper-claim:$RUN_ID" || {
+    rm -f "$LOCK_FILE"
+    echo "Failed to post claim comment for #$NUMBER; skipping."
+    exit 0
+}
+```
+
+### 1g. Settle and verify (earliest-comment-wins)
+
+```bash
+sleep 3
+
+WINNER=$(gh issue view "$NUMBER" --json comments \
+  --jq '[.comments[] | select(.body | startswith("looper-claim:"))] | sort_by(.createdAt) | .[0].body' \
+  | sed 's/^looper-claim://')
+
+if [ "$WINNER" != "$RUN_ID" ]; then
+    echo "Lost race to $WINNER; ceding issue #$NUMBER."
+    gh issue edit "$NUMBER" --remove-assignee @me --remove-label looper-claimed 2>/dev/null || true
+    rm -f "$LOCK_FILE"
+    exit 0
+fi
+
+echo "Won claim for issue #$NUMBER (run_id=$RUN_ID)."
+```
+
+Both instances evaluate the same GitHub-ordered comment list, so they always
+agree on the winner without a central lock. A 3-second settle window is well
+above observed GitHub comment replication lag. See `crates/looper-watch/src/claim.rs`
+for the equivalent Rust implementation and detailed commentary on edge cases.
 
 ---
 


### PR DESCRIPTION
## Problem / Task

Closes #64. When multiple Claude instances run `looper-watch` against the same repo, two instances could pick up and start working on the same unassigned issue. GitHub has no atomic claim primitive — `--add-assignee` and labels are multi-writer, so a naive check-then-assign races.

**Current behavior:** Two watchers can both claim and start working the same issue, wasting effort and creating conflicting PRs.
**Expected behavior:** Only one instance wins the claim; losers cede cleanly without starting work.

## Existing Architecture

`worker::poll_once` calls `github::assign_to_me` directly and immediately spawns the claude session — no fencing.

```mermaid
flowchart TD
    A([poll_once]) --> B[github::assign_to_me]
    B --> C[spawn tmux claude session]
    C --> D[(GitHub)]
    style B fill:#f66,stroke:#333
```

Both the shell `looper-issue` skill and the Rust watcher use check-then-assign, giving a race window.

## Proposed Architecture

New `claim` module implements: local O_EXCL lockfile fast-path → `gh` assign + label + claim comment → 3s settle → fetch comments and keep only the earliest `looper-claim:` comment — if it is ours, we win; otherwise we cede (remove assignee/label, drop lockfile). `ClaimGuard` holds the lockfile for the lifetime of the spawned task.

```mermaid
flowchart TD
    A([poll_once]) --> L{local O_EXCL lock}
    L -- held --> S1[skip]
    L -- acquired --> E[gh edit assign+label]
    E --> CM[gh comment claim:runid]
    CM --> W[sleep 3s settle]
    W --> V[gh view comments]
    V --> D{earliest claim == ours?}
    D -- yes --> OK[spawn claude + keep ClaimGuard]
    D -- no --> R[cede: unassign, unlabel, drop lock]
    style L fill:#69f,stroke:#333
    style V fill:#69f,stroke:#333
    style OK fill:#6f6,stroke:#333
```

Same protocol mirrored in `plugins/looper/skills/looper-issue/SKILL.md` phases 1d–1g for the shell skill path.

## Key Changes

- **`crates/looper-watch/src/claim.rs` (new, 692 lines):** `try_claim`, `ClaimGuard`, pure helpers `parse_claim_body`, `earliest_claim`, `decide_winner`, `try_local_lock`, `sanitize_repo`, `generate_run_id`. 24 unit tests covering parsing, ordering, tie-breaking, lock semantics, and guard drop.
- **`crates/looper-watch/src/worker.rs`:** `poll_once` now calls `claim::try_claim`; `ClaimGuard` moved into the spawned tokio task so the lockfile persists for the session lifetime. `LocalLockHeld`/`LostRace` skip cleanly.
- **`crates/looper-watch/src/main.rs`:** registers `mod claim;`.
- **`crates/looper-watch/Cargo.toml`:** adds `uuid` with `v4` feature.
- **`plugins/looper/skills/looper-issue/SKILL.md`:** phases 1d–1g rewritten with `set -o noclobber` local lock, `gh` claim, 3s settle, and `jq`-sorted earliest-comment verify.

Run ID format: `<hostname>-<pid>-<uuid>`. Claim comment body: `looper-claim:<run_id>`. Label: `looper-claimed` (best-effort).

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 97 passed (24 new in claim.rs) |
| Clippy | ✅ | clean |
| Rustfmt | ✅ | clean |
| ShellCheck | ✅ | clean |

---