### PR TITLE
feat(looper): sandboxed loop variant with pluggable docker/sbx backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,43 @@ jobs:
           path: fallback-agent-x86_64-linux.tar.gz
           if-no-files-found: error
 
+  build-sandbox-image:
+    name: Build + Push Sandbox Image
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: plugins/looper/sandbox
+          file: plugins/looper/sandbox/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/code-salad/looper-sandbox:latest
+            ghcr.io/code-salad/looper-sandbox:${{ steps.version.outputs.tag }}
+          build-args: |
+            LOOPER_REF=${{ steps.version.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   release:
     name: Create Release
     needs: [detect, build-looper-watch, build-fallback-agent]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.42.3"
+version = "0.46.1"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ flowchart TD
     PR --> CI["Wait for CI"]
 ```
 
+### Modes
+
+Looper supports two execution modes. Pick one per invocation.
+
+| Mode | Command | Isolation | Use when |
+|------|---------|-----------|----------|
+| **Worktree** (default) | `/looper:loop "<task>"` | Git worktree at `.worktrees/<name>/`. Host env, host network, host creds. | Single-developer, single-task, trusted environment. |
+| **Sandboxed** (opt-in) | `/looper:looper-sandboxed "<task>"` | Docker sandbox via [`sbx`](https://github.com/docker/sandbox). Branch worktree mounted into container. Secrets injected via `sbx secret set` (plaintext never enters the box). | Concurrent loops, defense-in-depth, or preparing for remote fleet execution. |
+
+Both modes run the same PDC loop — only the execution environment differs.
+Sandboxed mode requires Docker and `sbx` on the host.
+
 ### State Management
 
 All state is stored in git commits with structured trailers:
@@ -255,6 +267,7 @@ Each plugin lives under `plugins/<name>/` and can be installed independently.
 | Looper EE | `/looper:looper-ee <issue_url>` | Work on a GitHub issue from an external repo |
 | Looper Issue | `/looper:looper-issue` | Auto-pick an open GitHub issue and work on it |
 | Looper Watch | `/looper:looper-watch <owner/repo> [interval]` | Poll a GitHub repo and work issues automatically |
+| Looper Sandboxed | `/looper:looper-sandboxed "task"` | Run the PDC loop inside a local Docker sandbox (`sbx`) |
 
 ### Utility Scripts
 

--- a/README.md
+++ b/README.md
@@ -177,10 +177,41 @@ Looper supports two execution modes. Pick one per invocation.
 | Mode | Command | Isolation | Use when |
 |------|---------|-----------|----------|
 | **Worktree** (default) | `/looper:loop "<task>"` | Git worktree at `.worktrees/<name>/`. Host env, host network, host creds. | Single-developer, single-task, trusted environment. |
-| **Sandboxed** (opt-in) | `/looper:looper-sandboxed "<task>"` | Docker sandbox via [`sbx`](https://github.com/docker/sandbox). Branch worktree mounted into container. Secrets injected via `sbx secret set` (plaintext never enters the box). | Concurrent loops, defense-in-depth, or preparing for remote fleet execution. |
+| **Sandboxed** (opt-in) | `/looper:looper-sandboxed "<task>"` | `docker` backend (default): `docker run` + bind-mount + `/var/run/docker.sock` for nested Docker. `sbx` backend (opt-in): microVM + host-side secret proxy. | Concurrent loops, defense-in-depth, or preparing for remote fleet execution. |
 
 Both modes run the same PDC loop — only the execution environment differs.
-Sandboxed mode requires Docker and `sbx` on the host.
+Sandboxed mode requires the selected backend (see Backends below).
+
+### Backends
+
+The sandboxed mode supports a pluggable backend via the
+`LOOPER_SANDBOX_BACKEND` env var.
+
+| Backend | Command | When to use | Security tradeoff |
+|---------|---------|-------------|-------------------|
+| `docker` (default) | `docker run` + bind-mount + `/var/run/docker.sock` | Hyper-V, WSL2, cloud VMs without KVM. Any host that can run Docker. | **DooD:** the sandbox has full access to the host Docker daemon via the socket mount — trivial container escape. Acceptable for single-user local use; not for untrusted agents. |
+| `sbx` (opt-in) | `sbx run --branch --policy balanced` | Hosts with KVM; want stronger isolation. | microVM + host-side secret proxy. Per-sandbox daemon — no socket mount, no host-exposure tradeoff. |
+| Future (`e2b`, `runloop`, ...) | TBD | Remote fleet execution. | TBD. |
+
+Select the backend per-invocation:
+
+```bash
+# Default
+/looper:looper-sandboxed "add input validation"
+
+# Opt in to sbx
+LOOPER_SANDBOX_BACKEND=sbx /looper:looper-sandboxed "add input validation"
+```
+
+Why nested Docker? Looper's integration-test helpers (`compose-isolate`,
+`compose-lifecycle`) run `docker compose up/down`. The sandbox must reach
+a Docker daemon.
+- `docker` backend: DooD via socket mount — compose services spawn as
+  *siblings* on the host.
+- `sbx` backend: native nested Docker — each sandbox has its own daemon.
+
+Rejected alternatives: `--privileged` DinD (security-hostile, slow) and
+rootless Docker-inside-sandbox (parked for a future hardened mode).
 
 ### State Management
 
@@ -267,7 +298,7 @@ Each plugin lives under `plugins/<name>/` and can be installed independently.
 | Looper EE | `/looper:looper-ee <issue_url>` | Work on a GitHub issue from an external repo |
 | Looper Issue | `/looper:looper-issue` | Auto-pick an open GitHub issue and work on it |
 | Looper Watch | `/looper:looper-watch <owner/repo> [interval]` | Poll a GitHub repo and work issues automatically |
-| Looper Sandboxed | `/looper:looper-sandboxed "task"` | Run the PDC loop inside a local Docker sandbox (`sbx`) |
+| Looper Sandboxed | `/looper:looper-sandboxed "task"` | Run the PDC loop inside a sandbox (`docker` default via DooD; `sbx` opt-in via `LOOPER_SANDBOX_BACKEND=sbx`) |
 
 ### Utility Scripts
 

--- a/plugins/looper/sandbox/.dockerignore
+++ b/plugins/looper/sandbox/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.worktrees
+.sbx
+target
+crates/*/target
+node_modules
+plugins/*/node_modules
+*.log
+.env
+.env.*

--- a/plugins/looper/sandbox/Dockerfile
+++ b/plugins/looper/sandbox/Dockerfile
@@ -37,6 +37,17 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
         sh -s -- -y --default-toolchain stable --profile minimal \
     && /root/.cargo/bin/rustup component add clippy rustfmt
 
+# Docker CLI (client only — no daemon).
+# The container talks to the HOST daemon via a bind-mounted
+# /var/run/docker.sock (DooD). This lets compose-isolate /
+# compose-lifecycle spawn sibling containers from inside the sandbox.
+# No daemon ever runs in this image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         docker.io \
+         docker-compose-v2 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Claude Code CLI (official install script).
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
@@ -60,6 +71,7 @@ RUN command -v git \
     && command -v claude \
     && command -v node \
     && command -v python3 \
-    && command -v cargo
+    && command -v cargo \
+    && command -v docker
 
 CMD ["/bin/bash"]

--- a/plugins/looper/sandbox/Dockerfile
+++ b/plugins/looper/sandbox/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+
+# Base: Ubuntu 24.04 LTS (matches CI runners: blacksmith-*-ubuntu-2404).
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH="/root/.cargo/bin:/root/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Core OS packages — pinned to apt (stable, reproducible per Ubuntu release).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        gh \
+        jq \
+        curl \
+        ca-certificates \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        python3 \
+        python3-pip \
+        python3-venv \
+        unzip \
+        xz-utils \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js LTS (20.x) via NodeSource — the current Ubuntu 24.04 apt Node is 18.x.
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g npm@latest pnpm yarn
+
+# Rust stable via rustup (non-interactive).
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain stable --profile minimal \
+    && /root/.cargo/bin/rustup component add clippy rustfmt
+
+# Claude Code CLI (official install script).
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Pre-install the looper plugin at the well-known path.
+# ARG LOOPER_REF=alpha allows the release workflow to pass LOOPER_REF=v<version>
+# so the baked plugin matches the release tag.
+ARG LOOPER_REF=alpha
+RUN mkdir -p /root/.claude/plugins \
+    && git clone --depth 1 --branch "${LOOPER_REF}" \
+        https://github.com/code-salad/looper.git /tmp/looper \
+    && cp -r /tmp/looper/plugins/looper /root/.claude/plugins/looper \
+    && chmod -R +x /root/.claude/plugins/looper/skills/looper/scripts \
+    && rm -rf /tmp/looper
+
+WORKDIR /workspace
+
+# Sanity check — all critical binaries resolve.
+RUN command -v git \
+    && command -v gh \
+    && command -v jq \
+    && command -v claude \
+    && command -v node \
+    && command -v python3 \
+    && command -v cargo
+
+CMD ["/bin/bash"]

--- a/plugins/looper/skills/looper-sandboxed/SKILL.md
+++ b/plugins/looper/skills/looper-sandboxed/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: looper-sandboxed
+description: >-
+  Use this skill when the user wants to run the Plan-Do-Check loop inside a
+  local Docker sandbox (`sbx`) instead of directly on the host. Injects
+  ANTHROPIC_API_KEY and GITHUB_TOKEN via sbx's host-side secret proxy so the
+  agent inside the sandbox never sees plaintext credentials. Triggered by
+  "/looper:looper-sandboxed <task>".
+tools: Bash, Read
+---
+
+# Looper Sandboxed Skill
+
+Thin wrapper around the main `looper` skill that runs the entire PDC loop
+inside a containerised sandbox. The existing `/looper:loop` flow is unchanged
+— users opt in per-invocation by running `/looper:looper-sandboxed` instead.
+
+## Prerequisites
+
+- Docker + `sbx` CLI installed on the host.
+- `ANTHROPIC_API_KEY` exported in the current shell.
+- `gh` authenticated (preferred) or `GITHUB_TOKEN` exported.
+
+## Phase 0: Validate argument
+
+If `$ARGUMENTS` is empty, print:
+
+> Usage: /looper:looper-sandboxed <task description>
+
+and exit.
+
+## Phase 1: Verify `sbx` is installed
+
+```bash
+if ! command -v sbx >/dev/null 2>&1; then
+    echo "Error: \`sbx\` is not installed." >&2
+    echo "Install with: curl -fsSL https://sbx.sh/install | bash" >&2
+    exit 127
+fi
+```
+
+## Phase 2: Delegate to `run-sandboxed`
+
+```bash
+SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/plugins/looper}/skills/looper/scripts"
+"$SCRIPTS_DIR/run-sandboxed" "$ARGUMENTS"
+```
+
+The wrapper script handles secret injection, sandbox lifecycle, and branch
+push on success.
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| `sbx` missing | Abort with install hint (exit 127). |
+| Empty argument | Print usage and exit. |
+| `ANTHROPIC_API_KEY` unset | `run-sandboxed` exits 3 with a clear message. |
+| Neither `GITHUB_TOKEN` nor `gh auth` available | Warn and continue (PR creation inside will fail but loop can run). |
+| Inner `claude -p` exits non-zero | Wrapper surfaces the exit code; sandbox is removed; `.sbx/<name>/` worktree is preserved for inspection. |
+
+## How this differs from `/looper:loop`
+
+- `/looper:loop` — runs in the user's shell, creates a host worktree under
+  `.worktrees/<name>/`, has full host network + env access.
+- `/looper:looper-sandboxed` — runs inside a container with `sbx`'s network
+  policy and sandboxed filesystem. The inner PDC loop is byte-identical; only
+  the execution environment changes.

--- a/plugins/looper/skills/looper-sandboxed/SKILL.md
+++ b/plugins/looper/skills/looper-sandboxed/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: looper-sandboxed
 description: >-
-  Use this skill when the user wants to run the Plan-Do-Check loop inside a
-  local Docker sandbox (`sbx`) instead of directly on the host. Injects
-  ANTHROPIC_API_KEY and GITHUB_TOKEN via sbx's host-side secret proxy so the
-  agent inside the sandbox never sees plaintext credentials. Triggered by
+  Use this skill when the user wants to run the Plan-Do-Check loop inside
+  an isolated sandbox instead of directly on the host. Defaults to the
+  `docker` backend (plain `docker run` with a bind-mounted worktree and a
+  bind-mounted /var/run/docker.sock for nested Docker); opt in to the
+  `sbx` backend (microVM + host-side secret proxy) via
+  `LOOPER_SANDBOX_BACKEND=sbx`. Triggered by
   "/looper:looper-sandboxed <task>".
 tools: Bash, Read
 ---
@@ -12,12 +14,18 @@ tools: Bash, Read
 # Looper Sandboxed Skill
 
 Thin wrapper around the main `looper` skill that runs the entire PDC loop
-inside a containerised sandbox. The existing `/looper:loop` flow is unchanged
-— users opt in per-invocation by running `/looper:looper-sandboxed` instead.
+inside an isolated sandbox. Supports two backends: `docker` (default, DooD via
+socket mount) and `sbx` (microVM, opt-in). The existing `/looper:loop` flow is
+unchanged — users opt in per-invocation by running `/looper:looper-sandboxed`
+instead.
 
 ## Prerequisites
 
-- Docker + `sbx` CLI installed on the host.
+- Selected backend installed on the host:
+  - `docker` (default) — `docker` CLI + running daemon accessible via
+    `/var/run/docker.sock`. Works on Hyper-V, WSL2, and cloud VMs
+    without KVM.
+  - `sbx` (opt-in) — `sbx` CLI + KVM.
 - `ANTHROPIC_API_KEY` exported in the current shell.
 - `gh` authenticated (preferred) or `GITHUB_TOKEN` exported.
 
@@ -29,14 +37,30 @@ If `$ARGUMENTS` is empty, print:
 
 and exit.
 
-## Phase 1: Verify `sbx` is installed
+## Phase 1: Verify selected backend
 
 ```bash
-if ! command -v sbx >/dev/null 2>&1; then
-    echo "Error: \`sbx\` is not installed." >&2
-    echo "Install with: curl -fsSL https://sbx.sh/install | bash" >&2
-    exit 127
-fi
+BACKEND="${LOOPER_SANDBOX_BACKEND:-docker}"
+case "$BACKEND" in
+  docker)
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Error: 'docker' is not installed (LOOPER_SANDBOX_BACKEND=docker)." >&2
+        echo "Install: https://docs.docker.com/engine/install/" >&2
+        exit 127
+    fi
+    ;;
+  sbx)
+    if ! command -v sbx >/dev/null 2>&1; then
+        echo "Error: 'sbx' is not installed (LOOPER_SANDBOX_BACKEND=sbx)." >&2
+        echo "Install: curl -fsSL https://sbx.sh/install | bash" >&2
+        exit 127
+    fi
+    ;;
+  *)
+    echo "Error: unknown LOOPER_SANDBOX_BACKEND: '$BACKEND' (expected: docker | sbx)" >&2
+    exit 4
+    ;;
+esac
 ```
 
 ## Phase 2: Delegate to `run-sandboxed`
@@ -46,23 +70,29 @@ SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/plugins/loop
 "$SCRIPTS_DIR/run-sandboxed" "$ARGUMENTS"
 ```
 
-The wrapper script handles secret injection, sandbox lifecycle, and branch
-push on success.
+The wrapper script handles secret injection, sandbox lifecycle, and (for sbx)
+branch push on success.
 
 ## Error Handling
 
 | Scenario | Action |
 |----------|--------|
-| `sbx` missing | Abort with install hint (exit 127). |
-| Empty argument | Print usage and exit. |
-| `ANTHROPIC_API_KEY` unset | `run-sandboxed` exits 3 with a clear message. |
-| Neither `GITHUB_TOKEN` nor `gh auth` available | Warn and continue (PR creation inside will fail but loop can run). |
-| Inner `claude -p` exits non-zero | Wrapper surfaces the exit code; sandbox is removed; `.sbx/<name>/` worktree is preserved for inspection. |
+| Selected backend binary missing | Abort with install hint (exit 127). |
+| Unknown `LOOPER_SANDBOX_BACKEND` | Exit 4 with "expected docker or sbx". |
+| Empty argument | Print usage and exit 2. |
+| `ANTHROPIC_API_KEY` unset | `run-sandboxed` exits 3. |
+| Neither `GITHUB_TOKEN` nor `gh auth` available | Warn and continue. |
+| Inner `claude -p` / `docker run` exits non-zero | Wrapper surfaces the exit code. |
 
 ## How this differs from `/looper:loop`
 
 - `/looper:loop` — runs in the user's shell, creates a host worktree under
   `.worktrees/<name>/`, has full host network + env access.
-- `/looper:looper-sandboxed` — runs inside a container with `sbx`'s network
-  policy and sandboxed filesystem. The inner PDC loop is byte-identical; only
-  the execution environment changes.
+- `/looper:looper-sandboxed` — runs inside a container. The inner PDC loop is
+  byte-identical; only the execution environment changes.
+
+**Backend-specific differences:**
+- `docker` backend — bind-mount (no separate push needed); compose services
+  spawn as siblings on the host daemon via DooD socket mount.
+- `sbx` backend — `--branch` + `.sbx/<name>/` worktree; push required on
+  success; per-sandbox daemon (no socket mount, no host-exposure tradeoff).

--- a/plugins/looper/skills/looper/scripts/run-sandboxed
+++ b/plugins/looper/skills/looper/scripts/run-sandboxed
@@ -1,16 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# run-sandboxed — Run the PDC loop inside a local Docker sandbox via `sbx`.
-# Usage: run-sandboxed <task description>
-# Environment:
-#   ANTHROPIC_API_KEY (required) — forwarded to the sandbox via `sbx secret set`.
-#   GITHUB_TOKEN (optional)      — if unset, falls back to `gh auth token`.
-#   LOOPER_SANDBOX_IMAGE (optional) — override the default image reference.
-#   LOOPER_SANDBOX_POLICY (optional) — override sbx policy (default: balanced).
-
-DEFAULT_IMAGE="ghcr.io/code-salad/looper-sandbox:latest"
-DEFAULT_POLICY="balanced"
+# run-sandboxed — Run the PDC loop inside an isolated sandbox.
+#
+# Supports two backends selected via LOOPER_SANDBOX_BACKEND (default: docker):
+#
+#   docker (default)
+#     Runs `docker run --rm` with the project directory bind-mounted as /repo
+#     and /var/run/docker.sock bind-mounted for nested Docker (DooD). Compose
+#     services spawned inside the sandbox appear as sibling containers on the
+#     host daemon. Works on Hyper-V, WSL2, and cloud VMs without KVM. Requires
+#     the docker CLI and a running daemon accessible via /var/run/docker.sock.
+#
+#   sbx (opt-in)
+#     Runs `sbx run --branch --policy <POLICY>` for stronger isolation via a
+#     microVM with a host-side secret proxy. Requires the sbx CLI and KVM.
+#     Branch worktree is mounted at .sbx/<name>/ and pushed on success.
+#
+# LOOPER_SANDBOX_BACKEND is case-sensitive; an empty value collapses to docker.
+# Values other than "docker" or "sbx" cause exit 4.
+#
+# Exit codes:
+#   0   Inner loop succeeded.
+#   2   No task argument supplied.
+#   3   ANTHROPIC_API_KEY is unset (checked BEFORE backend switch).
+#   4   Unknown LOOPER_SANDBOX_BACKEND value.
+#   127 Selected backend binary missing on PATH.
+#   *   Inner claude -p (or docker run) exit code surfaced verbatim.
+#
+# Environment variables:
+#   ANTHROPIC_API_KEY      (required) — forwarded into the sandbox.
+#   GITHUB_TOKEN           (optional) — falls back to `gh auth token`.
+#   LOOPER_SANDBOX_BACKEND (optional) — backend to use (default: docker).
+#   LOOPER_SANDBOX_IMAGE   (optional) — container image (default below).
+#   LOOPER_SANDBOX_POLICY  (optional) — sbx policy only (default: balanced).
 
 if [ "$#" -eq 0 ]; then
     echo "Usage: run-sandboxed <task description>" >&2
@@ -18,12 +41,64 @@ if [ "$#" -eq 0 ]; then
 fi
 
 TASK="$*"
-IMAGE="${LOOPER_SANDBOX_IMAGE:-$DEFAULT_IMAGE}"
-POLICY="${LOOPER_SANDBOX_POLICY:-$DEFAULT_POLICY}"
+BACKEND="${LOOPER_SANDBOX_BACKEND:-docker}"
+IMAGE="${LOOPER_SANDBOX_IMAGE:-ghcr.io/code-salad/looper-sandbox:latest}"
+POLICY="${LOOPER_SANDBOX_POLICY:-balanced}"
 
-# --- Pre-flight: verify `sbx` is installed ------------------------------------
-if ! command -v sbx >/dev/null 2>&1; then
-    cat >&2 <<'EOF'
+# --- SHARED PRE-FLIGHT (runs before the backend switch) -----------------------
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "Error: ANTHROPIC_API_KEY is not set. Export it before invoking looper-sandboxed." >&2
+    exit 3
+fi
+
+GH_TOKEN="${GITHUB_TOKEN:-}"
+if [ -z "$GH_TOKEN" ]; then
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+    fi
+fi
+if [ -z "$GH_TOKEN" ]; then
+    echo "Warning: No GITHUB_TOKEN available (neither env nor \`gh auth token\`). PR creation inside the sandbox may fail." >&2
+fi
+
+SANDBOX_NAME="loop-$(date +%s)-$$"
+
+# --- Backend switch -----------------------------------------------------------
+
+case "$BACKEND" in
+  docker)
+    if ! command -v docker >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
+Error: 'docker' is not installed (LOOPER_SANDBOX_BACKEND=docker).
+Install docker from https://docs.docker.com/engine/install/
+and ensure your user has access to /var/run/docker.sock.
+EOF
+        exit 127
+    fi
+
+    trap 'docker kill "$SANDBOX_NAME" >/dev/null 2>&1 || true' INT TERM
+
+    export GITHUB_TOKEN="$GH_TOKEN"
+
+    RUN_EXIT=0
+    docker run --rm --name "$SANDBOX_NAME" \
+        -v "$(pwd)":/repo \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -w /repo \
+        -e ANTHROPIC_API_KEY \
+        -e GITHUB_TOKEN \
+        -e LOOPER_SANDBOX_BACKEND=docker \
+        "$IMAGE" \
+        claude -p "/looper:loop $TASK" \
+          --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
+        || RUN_EXIT=$?
+    exit "$RUN_EXIT"
+    ;;
+
+  sbx)
+    if ! command -v sbx >/dev/null 2>&1; then
+        cat >&2 <<'EOF'
 Error: `sbx` (Docker Sandboxes) is not installed.
 
 Install it with:
@@ -33,72 +108,58 @@ Or see: https://github.com/docker/sandbox
 
 Then re-run /looper:looper-sandboxed.
 EOF
-    exit 127
-fi
-
-# --- Pre-flight: ANTHROPIC_API_KEY --------------------------------------------
-if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "Error: ANTHROPIC_API_KEY is not set. Export it before invoking looper-sandboxed." >&2
-    exit 3
-fi
-
-# --- Pre-flight: GITHUB_TOKEN (fallback to `gh auth token`) -------------------
-GH_TOKEN="${GITHUB_TOKEN:-}"
-if [ -z "$GH_TOKEN" ]; then
-    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-        GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+        exit 127
     fi
-fi
-if [ -z "$GH_TOKEN" ]; then
-    echo "Warning: No GITHUB_TOKEN available (neither env nor \`gh auth token\`). PR creation inside the sandbox will fail." >&2
-fi
 
-# --- Derive a unique sandbox name ---------------------------------------------
-SANDBOX_NAME="loop-$(date +%s)-$$"
-
-# --- Inject secrets via sbx (host-side proxy; plaintext never enters the box) -
-sbx secret set ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" >/dev/null
-if [ -n "$GH_TOKEN" ]; then
-    sbx secret set GITHUB_TOKEN "$GH_TOKEN" >/dev/null
-fi
-
-# --- Cleanup trap: always remove the sandbox, even on failure -----------------
-cleanup() {
-    local exit_code=$?
-    if sbx ls 2>/dev/null | grep -q "^${SANDBOX_NAME}"; then
-        sbx rm "$SANDBOX_NAME" >/dev/null 2>&1 || true
+    # Inject secrets via sbx (host-side proxy; plaintext never enters the box).
+    sbx secret set ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" >/dev/null
+    if [ -n "$GH_TOKEN" ]; then
+        sbx secret set GITHUB_TOKEN "$GH_TOKEN" >/dev/null
     fi
-    exit "$exit_code"
-}
-trap cleanup EXIT INT TERM
 
-# --- Run the inner loop -------------------------------------------------------
-# `--branch` creates a git worktree at .sbx/<name>/ on the host, mounted into
-# the sandbox. This means the inner `/looper:loop` still runs against a normal
-# worktree from its own perspective.
-RUN_EXIT=0
-sbx run "$SANDBOX_NAME" \
-    --image "$IMAGE" \
-    --branch \
-    --policy "$POLICY" \
-    -- claude -p "/looper:loop $TASK" \
-       --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
-    || RUN_EXIT=$?
+    # Cleanup trap: always remove the sandbox, even on failure.
+    cleanup() {
+        local exit_code=$?
+        if sbx ls 2>/dev/null | grep -q "^${SANDBOX_NAME}"; then
+            sbx rm "$SANDBOX_NAME" >/dev/null 2>&1 || true
+        fi
+        exit "$exit_code"
+    }
+    trap cleanup EXIT INT TERM
 
-if [ "$RUN_EXIT" -ne 0 ]; then
-    echo "Error: inner claude -p exited with status $RUN_EXIT. Sandbox will be removed; branch is preserved under .sbx/${SANDBOX_NAME}/ for inspection." >&2
-    exit "$RUN_EXIT"
-fi
+    # `--branch` creates a git worktree at .sbx/<name>/ on the host, mounted
+    # into the sandbox. This means the inner `/looper:loop` still runs against
+    # a normal worktree from its own perspective.
+    RUN_EXIT=0
+    sbx run "$SANDBOX_NAME" \
+        --image "$IMAGE" \
+        --branch \
+        --policy "$POLICY" \
+        -- claude -p "/looper:loop $TASK" \
+           --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
+        || RUN_EXIT=$?
 
-# --- On success: push the branch from the sandbox worktree --------------------
-SBX_WORKTREE=".sbx/$SANDBOX_NAME"
-if [ -d "$SBX_WORKTREE/.git" ] || [ -f "$SBX_WORKTREE/.git" ]; then
-    (
-        cd "$SBX_WORKTREE"
-        git push origin HEAD
-    )
-else
-    echo "Warning: expected worktree at $SBX_WORKTREE but none found. Skipping push." >&2
-fi
+    if [ "$RUN_EXIT" -ne 0 ]; then
+        echo "Error: inner claude -p exited with status $RUN_EXIT. Sandbox will be removed; branch is preserved under .sbx/${SANDBOX_NAME}/ for inspection." >&2
+        exit "$RUN_EXIT"
+    fi
 
-# Cleanup handled by trap.
+    # On success: push the branch from the sandbox worktree.
+    SBX_WORKTREE=".sbx/$SANDBOX_NAME"
+    if [ -d "$SBX_WORKTREE/.git" ] || [ -f "$SBX_WORKTREE/.git" ]; then
+        (
+            cd "$SBX_WORKTREE"
+            git push origin HEAD
+        )
+    else
+        echo "Warning: expected worktree at $SBX_WORKTREE but none found. Skipping push." >&2
+    fi
+
+    # Cleanup handled by trap.
+    ;;
+
+  *)
+    echo "Error: unknown LOOPER_SANDBOX_BACKEND: '$BACKEND' (expected: docker | sbx)" >&2
+    exit 4
+    ;;
+esac

--- a/plugins/looper/skills/looper/scripts/run-sandboxed
+++ b/plugins/looper/skills/looper/scripts/run-sandboxed
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# run-sandboxed — Run the PDC loop inside a local Docker sandbox via `sbx`.
+# Usage: run-sandboxed <task description>
+# Environment:
+#   ANTHROPIC_API_KEY (required) — forwarded to the sandbox via `sbx secret set`.
+#   GITHUB_TOKEN (optional)      — if unset, falls back to `gh auth token`.
+#   LOOPER_SANDBOX_IMAGE (optional) — override the default image reference.
+#   LOOPER_SANDBOX_POLICY (optional) — override sbx policy (default: balanced).
+
+DEFAULT_IMAGE="ghcr.io/code-salad/looper-sandbox:latest"
+DEFAULT_POLICY="balanced"
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: run-sandboxed <task description>" >&2
+    exit 2
+fi
+
+TASK="$*"
+IMAGE="${LOOPER_SANDBOX_IMAGE:-$DEFAULT_IMAGE}"
+POLICY="${LOOPER_SANDBOX_POLICY:-$DEFAULT_POLICY}"
+
+# --- Pre-flight: verify `sbx` is installed ------------------------------------
+if ! command -v sbx >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: `sbx` (Docker Sandboxes) is not installed.
+
+Install it with:
+    curl -fsSL https://sbx.sh/install | bash
+
+Or see: https://github.com/docker/sandbox
+
+Then re-run /looper:looper-sandboxed.
+EOF
+    exit 127
+fi
+
+# --- Pre-flight: ANTHROPIC_API_KEY --------------------------------------------
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "Error: ANTHROPIC_API_KEY is not set. Export it before invoking looper-sandboxed." >&2
+    exit 3
+fi
+
+# --- Pre-flight: GITHUB_TOKEN (fallback to `gh auth token`) -------------------
+GH_TOKEN="${GITHUB_TOKEN:-}"
+if [ -z "$GH_TOKEN" ]; then
+    if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+        GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+    fi
+fi
+if [ -z "$GH_TOKEN" ]; then
+    echo "Warning: No GITHUB_TOKEN available (neither env nor \`gh auth token\`). PR creation inside the sandbox will fail." >&2
+fi
+
+# --- Derive a unique sandbox name ---------------------------------------------
+SANDBOX_NAME="loop-$(date +%s)-$$"
+
+# --- Inject secrets via sbx (host-side proxy; plaintext never enters the box) -
+sbx secret set ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" >/dev/null
+if [ -n "$GH_TOKEN" ]; then
+    sbx secret set GITHUB_TOKEN "$GH_TOKEN" >/dev/null
+fi
+
+# --- Cleanup trap: always remove the sandbox, even on failure -----------------
+cleanup() {
+    local exit_code=$?
+    if sbx ls 2>/dev/null | grep -q "^${SANDBOX_NAME}"; then
+        sbx rm "$SANDBOX_NAME" >/dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+# --- Run the inner loop -------------------------------------------------------
+# `--branch` creates a git worktree at .sbx/<name>/ on the host, mounted into
+# the sandbox. This means the inner `/looper:loop` still runs against a normal
+# worktree from its own perspective.
+RUN_EXIT=0
+sbx run "$SANDBOX_NAME" \
+    --image "$IMAGE" \
+    --branch \
+    --policy "$POLICY" \
+    -- claude -p "/looper:loop $TASK" \
+       --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
+    || RUN_EXIT=$?
+
+if [ "$RUN_EXIT" -ne 0 ]; then
+    echo "Error: inner claude -p exited with status $RUN_EXIT. Sandbox will be removed; branch is preserved under .sbx/${SANDBOX_NAME}/ for inspection." >&2
+    exit "$RUN_EXIT"
+fi
+
+# --- On success: push the branch from the sandbox worktree --------------------
+SBX_WORKTREE=".sbx/$SANDBOX_NAME"
+if [ -d "$SBX_WORKTREE/.git" ] || [ -f "$SBX_WORKTREE/.git" ]; then
+    (
+        cd "$SBX_WORKTREE"
+        git push origin HEAD
+    )
+else
+    echo "Warning: expected worktree at $SBX_WORKTREE but none found. Skipping push." >&2
+fi
+
+# Cleanup handled by trap.


### PR DESCRIPTION
Closes #72.

## Problem / Task

The current `/looper:loop` runs inside the user's active Claude session with full access to `$HOME`, SSH keys, secrets, and the host network. This breaks down for concurrent loops (port collisions on `localhost:3000`, shared test DBs, `node_modules` cache contention), defense-in-depth (a misbehaving Doer can reach outside the worktree), and the fleet trajectory (remote execution needs to assume it runs in a box).

**Current behavior:** `/looper:loop` runs directly on the host. A worktree isolates files + branches but nothing else.
**Expected behavior:** An opt-in `/looper:looper-sandboxed` that wraps the entire PDC loop in a local container with a pluggable backend (`docker` default, `sbx` opt-in), nested-Docker support (DooD), and the existing loop code untouched.

## Existing Architecture

Before this PR the loop runs directly on the host — the worktree gives file/branch isolation, but process, network, and secret visibility all stay host-level.

```mermaid
graph TD
    U([User]) --> L[/looper:loop/]
    L --> WT[worktree .worktrees/NAME]
    WT --> HST[Host shell]
    HST --> ENV[(ANTHROPIC_API_KEY / GITHUB_TOKEN in env)]
    HST --> NET[(Host network — collidable localhost ports)]
    HST --> DK[[Docker daemon — host]]
    style HST fill:#f66,stroke:#333
    style ENV fill:#f66,stroke:#333
    style NET fill:#f66,stroke:#333
```

## Proposed Architecture

A new thin skill `/looper:looper-sandboxed` delegates to `run-sandboxed`, which selects a backend via `LOOPER_SANDBOX_BACKEND` (default `docker`) and wraps the whole PDC loop inside a container. The `docker` arm mounts `/var/run/docker.sock` (DooD) so the inner loop's `compose-isolate` / `compose-lifecycle` scripts can still spawn sibling containers. The `sbx` arm (opt-in) keeps the microVM + host-side secret proxy pattern.

```mermaid
graph TD
    U([User]) --> LS[/looper:looper-sandboxed/]
    LS --> SK[SKILL.md — verifies selected backend]
    SK --> RS[run-sandboxed script]
    RS --> CASE{LOOPER_SANDBOX_BACKEND}
    CASE -->|docker default| DR[docker run --rm]
    CASE -->|sbx opt-in| SX[sbx run --branch --policy]
    CASE -->|unknown| ER[exit 4]
    DR --> IMG[[ghcr.io/code-salad/looper-sandbox:latest]]
    SX --> IMG
    IMG --> LOOP[Inner claude -p /looper:loop TASK]
    DR -.-> SOCK[/var/run/docker.sock mount → DooD/]
    SOCK --> HDK[[Host Docker daemon]]
    LOOP --> PDC[PDC loop — untouched]
    style LS fill:#6f6,stroke:#333
    style SK fill:#6f6,stroke:#333
    style RS fill:#6f6,stroke:#333
    style IMG fill:#6f6,stroke:#333
    style SOCK fill:#69f,stroke:#333
```

## Key Changes

### New wrapper script — `plugins/looper/skills/looper/scripts/run-sandboxed`

- Reads `LOOPER_SANDBOX_BACKEND` (default `docker`, strict lowercase) and `LOOPER_SANDBOX_IMAGE` / `LOOPER_SANDBOX_POLICY` env vars.
- Shared pre-flight (runs **before** the backend switch): validates `ANTHROPIC_API_KEY` (exit 3), resolves `GITHUB_TOKEN` from env or `gh auth token` (warn-only), generates a unique `SANDBOX_NAME`.
- `docker)` arm: `command -v docker` (exit 127) → `trap 'docker kill … ' INT TERM` → `docker run --rm --name $NAME -v "$(pwd)":/repo -v /var/run/docker.sock:/var/run/docker.sock -w /repo -e ANTHROPIC_API_KEY -e GITHUB_TOKEN -e LOOPER_SANDBOX_BACKEND=docker <IMAGE> claude -p "/looper:loop $TASK" --allowed-tools …`. No post-run push (bind mount lands commits on host).
- `sbx)` arm: preserves the iter-1 pattern — `sbx secret set` for both tokens, EXIT/INT/TERM trap → `sbx rm`, `sbx run --branch --policy balanced`, post-success `git push origin HEAD` from `.sbx/$NAME/`.
- `*)` arm: exits **4** before any side effects (secrets, containers) with an `expected: docker | sbx` message.
- Exit-code table documented in the script header: `0` success, `2` no task, `3` no API key, `4` unknown backend, `127` backend binary missing, other = inner command's exit.

### Sandbox image — `plugins/looper/sandbox/Dockerfile`

- Ubuntu 24.04 base + `git`, `gh`, `jq`, `curl`, `build-essential`, Node 20 (NodeSource), Rust stable (rustup), Python 3, Claude CLI.
- **`docker.io` + `docker-compose-v2`** (client only, no daemon) — sandbox talks to the host daemon via mounted socket. Comment block explains DooD and why no daemon runs in the image.
- `ARG LOOPER_REF=alpha` pre-installs the looper plugin under `/root/.claude/plugins/looper`.
- Final `RUN command -v …` sanity check for every critical binary including `docker`.

### Thin skill — `plugins/looper/skills/looper-sandboxed/SKILL.md`

YAML frontmatter (`name`, `description`, `tools: Bash, Read`). Phase 1 reads `LOOPER_SANDBOX_BACKEND`, runs a `case` switch that `command -v`s the selected binary (exit 127 on missing, exit 4 on unknown value), emits an install hint. Phase 2 delegates to `run-sandboxed`. Prerequisites enumerates both backends.

### Release workflow — `.github/workflows/release.yml`

New `build-sandbox-image` job on `push: tags: v*`. Uses `docker/setup-buildx-action@v3` + `docker/login-action@v3` (GHCR via `${{ secrets.GITHUB_TOKEN }}`) + `docker/build-push-action@v5`. Tags `:latest` and `:${{ github.ref_name }}`. `permissions: contents: read, packages: write`. Independent of the existing `release` job (not in `needs:`) — image build failures don't block binary releases.

### README

New `### Modes` subsection comparing worktree-only vs. sandboxed. New `### Backends` subsection with a `docker` vs. `sbx` vs. future (`e2b`/`runloop`) comparison table, `LOOPER_SANDBOX_BACKEND` docs, invocation examples, an explicit DooD security caveat ("socket mount = trivial container escape — acceptable for single-user local use, not for untrusted agents"), and the rejected alternatives (`--privileged` DinD / rootless-in-sandbox). Skills table row added for `/looper:looper-sandboxed`.

## PDC loop notes

This PR is the output of 2 PDC-loop iterations. The issue body was updated twice mid-loop:

1. **Iter 1** (FAIL): scaffolded the sbx-only variant per the original issue text. Before the Checker ran, the issue was expanded to require a pluggable backend with `docker` as default; the Checker correctly failed iter 1 for missing that requirement.
2. **Iter 2** (PASS): added the `LOOPER_SANDBOX_BACKEND` switch, the `docker` arm, DooD socket mount, docker CLI in the image, backend-aware skill Phase 1, and the Backends README section. 22/22 planned verification commands pass (tests 8 and 21 required `PATH=/nonexistent` instead of `/usr/bin:/bin` because `docker` lives in `/usr/bin` on the dev host — logic correctness confirmed by the parallel `sbx` arm test).

## Tests & Checks

Scaffolding PR — no runtime `docker run` or `sbx run` invocation. Acceptance gate is static (shellcheck + exec bit + JSON/YAML validation + corner-case exit codes).

| Check | Status | Details |
|-------|--------|---------|
| ShellCheck | ✅ | clean across all `plugins/looper/skills/looper/scripts/*` |
| Executable bits | ✅ | `run-sandboxed` has `+x` |
| JSON validation | ✅ | `plugin.json`, `marketplace.json` parse |
| YAML validation | ✅ | `release.yml`, `ci.yml` parse |
| Cargo Test | ✅ | 97 passed, 0 failed |
| Corner-case exits | ✅ | `2` (no args), `3` (no API key), `4` (unknown backend), `127` (backend missing) — all verified |
| pre-check | ✅ | `ALL_CHECKS_PASSED` |

## Out of scope

- Live `sbx run` / `docker run` validation (requires the image to be published first).
- Rootless Docker inside the sandbox (parked as a future hardened mode).
- Remote backends (`e2b`, `runloop`, `modal`) — same adapter, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)