### PR TITLE
refactor(sandbox): extract run-sandboxed backends into pluggable adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Lint all bash scripts
         run: |
           for script in plugins/looper/skills/looper/scripts/*; do
+            [ -d "$script" ] && continue
+            shellcheck "$script"
+          done
+          for script in plugins/looper/skills/looper/scripts/backends/*.sh; do
             shellcheck "$script"
           done
 
@@ -38,6 +42,13 @@ jobs:
         run: |
           status=0
           for script in plugins/looper/skills/looper/scripts/*; do
+            [ -d "$script" ] && continue
+            if [ ! -x "$script" ]; then
+              echo "ERROR: $script is not executable"
+              status=1
+            fi
+          done
+          for script in plugins/looper/skills/looper/scripts/backends/*.sh; do
             if [ ! -x "$script" ]; then
               echo "ERROR: $script is not executable"
               status=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.46.1"
+version = "0.47.0"
 dependencies = [
  "chrono",
  "clap",

--- a/plugins/looper/skills/looper/scripts/backends/README.md
+++ b/plugins/looper/skills/looper/scripts/backends/README.md
@@ -1,0 +1,73 @@
+# Sandbox Backend Adapters
+
+This directory contains pluggable backend scripts for `run-sandboxed`. Each
+file `<name>.sh` is a self-contained adapter that the dispatcher selects via
+`LOOPER_SANDBOX_BACKEND=<name>`.
+
+## Backend contract
+
+### Environment variables (guaranteed set by the dispatcher before `exec`)
+
+| Variable | Description |
+|---|---|
+| `LOOPER_SANDBOX_TASK` | Full task string from `$*`, spaces preserved |
+| `LOOPER_SANDBOX_NAME` | Unique per invocation: `loop-$(date +%s)-$$` |
+| `LOOPER_SANDBOX_BACKEND` | Resolved backend name (always set explicitly) |
+| `LOOPER_SANDBOX_IMAGE` | Container image ref (default: `ghcr.io/code-salad/looper-sandbox:latest`) |
+| `LOOPER_SANDBOX_POLICY` | Isolation policy (default: `balanced`; used by sbx only) |
+| `ANTHROPIC_API_KEY` | Required; already validated by the dispatcher |
+| `GITHUB_TOKEN` | May be empty string (warn-only; dispatcher emits the warning) |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Inner command succeeded |
+| `127` | Required backend CLI is not installed on PATH |
+| `*` | Inner command exit code passed through verbatim |
+
+### Each backend MUST
+
+- Check its required CLI is present; exit 127 with an install hint if not.
+- Install a cleanup trap on `INT`/`TERM`/`EXIT` that removes its own resources
+  (container, sandbox, worktree) — the trap must be idempotent.
+- Stream `stdout`/`stderr` from the inner `claude` invocation through unmodified.
+- Exit with the inner command's exit code.
+
+### Each backend MUST NOT
+
+- Read positional arguments — everything arrives via environment variables.
+- Touch files outside `$(pwd)` or its own scratch area.
+- Print banner or progress output on `stderr` that would clobber the loop's own output.
+- Redefine `LOOPER_SANDBOX_*` or `ANTHROPIC_API_KEY` — treat them as read-only.
+
+## Backends shipped in v1
+
+| File | Backend name | Notes |
+|---|---|---|
+| `docker.sh` | `docker` | Default; DooD via `/var/run/docker.sock` |
+| `sbx.sh` | `sbx` | microVM via `sbx` CLI; requires KVM |
+| `null.sh` | `null` | Runs `claude -p` directly on the host; reference implementation |
+
+The `null` backend is intentionally not exposed through the
+`/looper:looper-sandboxed` skill (which gates on `docker|sbx` in Phase 1).
+It is reachable only via direct `run-sandboxed` invocation, making it useful
+for CI test harnesses and local development without a container runtime.
+
+## How to add a backend
+
+1. Create `backends/<name>.sh` with `#!/usr/bin/env bash` and `set -euo pipefail`.
+2. Read `LOOPER_SANDBOX_TASK`, `LOOPER_SANDBOX_NAME`, and any other contract
+   variables you need from the environment — do not accept positional args.
+3. Check that your required CLI is on PATH; emit an install hint and exit 127
+   if it is not.
+4. Install a cleanup trap (EXIT INT TERM) that removes any resources your
+   backend creates, keyed on `LOOPER_SANDBOX_NAME` so parallel runs stay
+   isolated.
+5. Run `claude -p "/looper:loop $LOOPER_SANDBOX_TASK"` (or equivalent) inside
+   your isolation environment, forwarding `ANTHROPIC_API_KEY` and
+   `GITHUB_TOKEN`.
+6. Exit with the inner command's exit code.
+7. Make the script executable (`chmod +x`) and run `shellcheck` on it — CI
+   enforces both.
+8. Add a row to the table above in this README.

--- a/plugins/looper/skills/looper/scripts/backends/docker.sh
+++ b/plugins/looper/skills/looper/scripts/backends/docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: 'docker' is not installed (LOOPER_SANDBOX_BACKEND=docker).
+Install docker from https://docs.docker.com/engine/install/
+and ensure your user has access to /var/run/docker.sock.
+EOF
+    exit 127
+fi
+
+trap 'docker kill "$LOOPER_SANDBOX_NAME" >/dev/null 2>&1 || true' INT TERM
+
+RUN_EXIT=0
+docker run --rm --name "$LOOPER_SANDBOX_NAME" \
+    -v "$(pwd)":/repo \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -w /repo \
+    -e ANTHROPIC_API_KEY \
+    -e GITHUB_TOKEN \
+    -e LOOPER_SANDBOX_BACKEND=docker \
+    "$LOOPER_SANDBOX_IMAGE" \
+    claude -p "/looper:loop $LOOPER_SANDBOX_TASK" \
+      --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
+    || RUN_EXIT=$?
+exit "$RUN_EXIT"

--- a/plugins/looper/skills/looper/scripts/backends/null.sh
+++ b/plugins/looper/skills/looper/scripts/backends/null.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+    echo "Error: claude CLI is not installed (LOOPER_SANDBOX_BACKEND=null)." >&2
+    echo "Install: https://docs.anthropic.com/en/docs/claude-code" >&2
+    exit 127
+fi
+
+exec claude -p "/looper:loop $LOOPER_SANDBOX_TASK" \
+    --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill

--- a/plugins/looper/skills/looper/scripts/backends/sbx.sh
+++ b/plugins/looper/skills/looper/scripts/backends/sbx.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v sbx >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: `sbx` (Docker Sandboxes) is not installed.
+
+Install it with:
+    curl -fsSL https://sbx.sh/install | bash
+
+Or see: https://github.com/docker/sandbox
+
+Then re-run /looper:looper-sandboxed.
+EOF
+    exit 127
+fi
+
+sbx secret set ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" >/dev/null
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    sbx secret set GITHUB_TOKEN "$GITHUB_TOKEN" >/dev/null
+fi
+
+cleanup() {
+    local exit_code=$?
+    if sbx ls 2>/dev/null | grep -q "^${LOOPER_SANDBOX_NAME}"; then
+        sbx rm "$LOOPER_SANDBOX_NAME" >/dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+RUN_EXIT=0
+sbx run "$LOOPER_SANDBOX_NAME" \
+    --image "$LOOPER_SANDBOX_IMAGE" \
+    --branch \
+    --policy "$LOOPER_SANDBOX_POLICY" \
+    -- claude -p "/looper:loop $LOOPER_SANDBOX_TASK" \
+       --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
+    || RUN_EXIT=$?
+
+if [ "$RUN_EXIT" -ne 0 ]; then
+    echo "Error: inner claude -p exited with status $RUN_EXIT. Sandbox will be removed; branch is preserved under .sbx/${LOOPER_SANDBOX_NAME}/ for inspection." >&2
+    exit "$RUN_EXIT"
+fi
+
+SBX_WORKTREE=".sbx/$LOOPER_SANDBOX_NAME"
+if [ -d "$SBX_WORKTREE/.git" ] || [ -f "$SBX_WORKTREE/.git" ]; then
+    (
+        cd "$SBX_WORKTREE"
+        git push origin HEAD
+    )
+else
+    echo "Warning: expected worktree at $SBX_WORKTREE but none found. Skipping push." >&2
+fi

--- a/plugins/looper/skills/looper/scripts/run-sandboxed
+++ b/plugins/looper/skills/looper/scripts/run-sandboxed
@@ -1,39 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# run-sandboxed — Run the PDC loop inside an isolated sandbox.
-#
-# Supports two backends selected via LOOPER_SANDBOX_BACKEND (default: docker):
-#
-#   docker (default)
-#     Runs `docker run --rm` with the project directory bind-mounted as /repo
-#     and /var/run/docker.sock bind-mounted for nested Docker (DooD). Compose
-#     services spawned inside the sandbox appear as sibling containers on the
-#     host daemon. Works on Hyper-V, WSL2, and cloud VMs without KVM. Requires
-#     the docker CLI and a running daemon accessible via /var/run/docker.sock.
-#
-#   sbx (opt-in)
-#     Runs `sbx run --branch --policy <POLICY>` for stronger isolation via a
-#     microVM with a host-side secret proxy. Requires the sbx CLI and KVM.
-#     Branch worktree is mounted at .sbx/<name>/ and pushed on success.
-#
-# LOOPER_SANDBOX_BACKEND is case-sensitive; an empty value collapses to docker.
-# Values other than "docker" or "sbx" cause exit 4.
-#
-# Exit codes:
-#   0   Inner loop succeeded.
-#   2   No task argument supplied.
-#   3   ANTHROPIC_API_KEY is unset (checked BEFORE backend switch).
-#   4   Unknown LOOPER_SANDBOX_BACKEND value.
-#   127 Selected backend binary missing on PATH.
-#   *   Inner claude -p (or docker run) exit code surfaced verbatim.
-#
-# Environment variables:
-#   ANTHROPIC_API_KEY      (required) — forwarded into the sandbox.
-#   GITHUB_TOKEN           (optional) — falls back to `gh auth token`.
-#   LOOPER_SANDBOX_BACKEND (optional) — backend to use (default: docker).
-#   LOOPER_SANDBOX_IMAGE   (optional) — container image (default below).
-#   LOOPER_SANDBOX_POLICY  (optional) — sbx policy only (default: balanced).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKENDS_DIR="$SCRIPT_DIR/backends"
 
 if [ "$#" -eq 0 ]; then
     echo "Usage: run-sandboxed <task description>" >&2
@@ -44,8 +13,6 @@ TASK="$*"
 BACKEND="${LOOPER_SANDBOX_BACKEND:-docker}"
 IMAGE="${LOOPER_SANDBOX_IMAGE:-ghcr.io/code-salad/looper-sandbox:latest}"
 POLICY="${LOOPER_SANDBOX_POLICY:-balanced}"
-
-# --- SHARED PRE-FLIGHT (runs before the backend switch) -----------------------
 
 if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
     echo "Error: ANTHROPIC_API_KEY is not set. Export it before invoking looper-sandboxed." >&2
@@ -64,102 +31,22 @@ fi
 
 SANDBOX_NAME="loop-$(date +%s)-$$"
 
-# --- Backend switch -----------------------------------------------------------
-
-case "$BACKEND" in
-  docker)
-    if ! command -v docker >/dev/null 2>&1; then
-        cat >&2 <<'EOF'
-Error: 'docker' is not installed (LOOPER_SANDBOX_BACKEND=docker).
-Install docker from https://docs.docker.com/engine/install/
-and ensure your user has access to /var/run/docker.sock.
-EOF
-        exit 127
-    fi
-
-    trap 'docker kill "$SANDBOX_NAME" >/dev/null 2>&1 || true' INT TERM
-
-    export GITHUB_TOKEN="$GH_TOKEN"
-
-    RUN_EXIT=0
-    docker run --rm --name "$SANDBOX_NAME" \
-        -v "$(pwd)":/repo \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        -w /repo \
-        -e ANTHROPIC_API_KEY \
-        -e GITHUB_TOKEN \
-        -e LOOPER_SANDBOX_BACKEND=docker \
-        "$IMAGE" \
-        claude -p "/looper:loop $TASK" \
-          --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
-        || RUN_EXIT=$?
-    exit "$RUN_EXIT"
-    ;;
-
-  sbx)
-    if ! command -v sbx >/dev/null 2>&1; then
-        cat >&2 <<'EOF'
-Error: `sbx` (Docker Sandboxes) is not installed.
-
-Install it with:
-    curl -fsSL https://sbx.sh/install | bash
-
-Or see: https://github.com/docker/sandbox
-
-Then re-run /looper:looper-sandboxed.
-EOF
-        exit 127
-    fi
-
-    # Inject secrets via sbx (host-side proxy; plaintext never enters the box).
-    sbx secret set ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" >/dev/null
-    if [ -n "$GH_TOKEN" ]; then
-        sbx secret set GITHUB_TOKEN "$GH_TOKEN" >/dev/null
-    fi
-
-    # Cleanup trap: always remove the sandbox, even on failure.
-    cleanup() {
-        local exit_code=$?
-        if sbx ls 2>/dev/null | grep -q "^${SANDBOX_NAME}"; then
-            sbx rm "$SANDBOX_NAME" >/dev/null 2>&1 || true
-        fi
-        exit "$exit_code"
-    }
-    trap cleanup EXIT INT TERM
-
-    # `--branch` creates a git worktree at .sbx/<name>/ on the host, mounted
-    # into the sandbox. This means the inner `/looper:loop` still runs against
-    # a normal worktree from its own perspective.
-    RUN_EXIT=0
-    sbx run "$SANDBOX_NAME" \
-        --image "$IMAGE" \
-        --branch \
-        --policy "$POLICY" \
-        -- claude -p "/looper:loop $TASK" \
-           --allowed-tools Bash,Read,Write,Edit,Grep,Glob,Agent,Skill \
-        || RUN_EXIT=$?
-
-    if [ "$RUN_EXIT" -ne 0 ]; then
-        echo "Error: inner claude -p exited with status $RUN_EXIT. Sandbox will be removed; branch is preserved under .sbx/${SANDBOX_NAME}/ for inspection." >&2
-        exit "$RUN_EXIT"
-    fi
-
-    # On success: push the branch from the sandbox worktree.
-    SBX_WORKTREE=".sbx/$SANDBOX_NAME"
-    if [ -d "$SBX_WORKTREE/.git" ] || [ -f "$SBX_WORKTREE/.git" ]; then
-        (
-            cd "$SBX_WORKTREE"
-            git push origin HEAD
-        )
-    else
-        echo "Warning: expected worktree at $SBX_WORKTREE but none found. Skipping push." >&2
-    fi
-
-    # Cleanup handled by trap.
-    ;;
-
-  *)
-    echo "Error: unknown LOOPER_SANDBOX_BACKEND: '$BACKEND' (expected: docker | sbx)" >&2
+BACKEND_SCRIPT="$BACKENDS_DIR/${BACKEND}.sh"
+if [ ! -f "$BACKEND_SCRIPT" ]; then
+    echo "Error: unknown LOOPER_SANDBOX_BACKEND: '${BACKEND}'" >&2
+    echo "Available backends:" >&2
+    for f in "$BACKENDS_DIR"/*.sh; do
+        [ -e "$f" ] && echo "  - $(basename "$f" .sh)" >&2
+    done
     exit 4
-    ;;
-esac
+fi
+
+export LOOPER_SANDBOX_TASK="$TASK"
+export LOOPER_SANDBOX_NAME="$SANDBOX_NAME"
+export LOOPER_SANDBOX_BACKEND="$BACKEND"
+export LOOPER_SANDBOX_IMAGE="$IMAGE"
+export LOOPER_SANDBOX_POLICY="$POLICY"
+export ANTHROPIC_API_KEY
+export GITHUB_TOKEN="$GH_TOKEN"
+
+exec bash "$BACKEND_SCRIPT"

--- a/plugins/looper/tests/test-run-sandboxed-dispatcher.sh
+++ b/plugins/looper/tests/test-run-sandboxed-dispatcher.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-run-sandboxed-dispatcher.sh — Smoke-test the run-sandboxed dispatcher contract.
+# Does NOT test real docker or sbx runtimes; uses a claude shim for the null backend.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/skills/looper/scripts"
+BACKENDS_DIR="$SCRIPTS_DIR/backends"
+DISPATCHER="$SCRIPTS_DIR/run-sandboxed"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local result="$2"
+
+    if [ "$result" = "true" ]; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Write a claude shim that logs its environment and args, then exits 0.
+cat > "$TMPDIR/claude" << 'SHIM'
+#!/usr/bin/env bash
+LOG="${TMPDIR:-/tmp}/claude.log"
+{
+    echo "ARGS=$*"
+    echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}"
+    echo "LOOPER_SANDBOX_TASK=${LOOPER_SANDBOX_TASK:-}"
+    echo "LOOPER_SANDBOX_BACKEND=${LOOPER_SANDBOX_BACKEND:-}"
+    echo "LOOPER_SANDBOX_NAME=${LOOPER_SANDBOX_NAME:-}"
+} >> "$LOG"
+exit 0
+SHIM
+chmod +x "$TMPDIR/claude"
+
+# Write a gh shim that suppresses auth-status side-effects.
+cat > "$TMPDIR/gh" << 'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+chmod +x "$TMPDIR/gh"
+
+# --- Case 1: No args -> exit 2, stderr contains "Usage:" ---
+
+stderr_out=$("$DISPATCHER" 2>&1 >/dev/null || true)
+exit_code=$(ANTHROPIC_API_KEY=k "$DISPATCHER" 2>&1 >/dev/null; echo $?) || true
+# Use a subshell to capture exit code properly
+set +e
+output=$(ANTHROPIC_API_KEY=k "$DISPATCHER" 2>&1); code=$?
+set -e
+check "no args: exit code is 2" "$([ "$code" -eq 2 ] && echo true || echo false)"
+check "no args: stderr contains Usage:" "$(echo "$output" | grep -q 'Usage:' && echo true || echo false)"
+
+# --- Case 2: ANTHROPIC_API_KEY unset, LOOPER_SANDBOX_BACKEND=null, task provided -> exit 3 ---
+
+set +e
+output=$(PATH="$TMPDIR:$PATH" LOOPER_SANDBOX_BACKEND=null unset_ANTHROPIC_API_KEY=1 \
+    env -u ANTHROPIC_API_KEY "$DISPATCHER" "some task" 2>&1); code=$?
+set -e
+check "no ANTHROPIC_API_KEY: exit code is 3" "$([ "$code" -eq 3 ] && echo true || echo false)"
+
+# --- Case 3: Unknown backend -> exit 4, stderr lists docker, sbx, null ---
+
+set +e
+output=$(ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=frobnicate \
+    PATH="$TMPDIR:$PATH" "$DISPATCHER" "some task" 2>&1); code=$?
+set -e
+check "unknown backend: exit code is 4" "$([ "$code" -eq 4 ] && echo true || echo false)"
+check "unknown backend: stderr lists docker" "$(echo "$output" | grep -q 'docker' && echo true || echo false)"
+check "unknown backend: stderr lists sbx" "$(echo "$output" | grep -q 'sbx' && echo true || echo false)"
+check "unknown backend: stderr lists null" "$(echo "$output" | grep -q 'null' && echo true || echo false)"
+
+# --- Case 4: null backend with claude shim, task "add logging" -> exit 0, claude.log correct ---
+
+rm -f "$TMPDIR/claude.log"
+set +e
+TMPDIR="$TMPDIR" PATH="$TMPDIR:$PATH" ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=null \
+    "$DISPATCHER" "add logging" >/dev/null 2>&1; code=$?
+set -e
+check "null backend shim: exit code is 0" "$([ "$code" -eq 0 ] && echo true || echo false)"
+check "null backend shim: claude.log has /looper:loop add logging" \
+    "$(grep -q '/looper:loop add logging' "$TMPDIR/claude.log" && echo true || echo false)"
+check "null backend shim: claude.log has ANTHROPIC_API_KEY=k" \
+    "$(grep -q 'ANTHROPIC_API_KEY=k' "$TMPDIR/claude.log" && echo true || echo false)"
+check "null backend shim: claude.log has LOOPER_SANDBOX_BACKEND=null" \
+    "$(grep -q 'LOOPER_SANDBOX_BACKEND=null' "$TMPDIR/claude.log" && echo true || echo false)"
+check "null backend shim: LOOPER_SANDBOX_NAME starts with loop-" \
+    "$(grep 'LOOPER_SANDBOX_NAME=' "$TMPDIR/claude.log" | grep -q 'LOOPER_SANDBOX_NAME=loop-' && echo true || echo false)"
+
+# --- Case 5: Multi-word task "add logging and tracing" -> claude.log preserves full string ---
+
+rm -f "$TMPDIR/claude.log"
+set +e
+TMPDIR="$TMPDIR" PATH="$TMPDIR:$PATH" ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=null \
+    "$DISPATCHER" "add logging and tracing" >/dev/null 2>&1; code=$?
+set -e
+check "multi-word task: claude.log contains full string" \
+    "$(grep -q '/looper:loop add logging and tracing' "$TMPDIR/claude.log" && echo true || echo false)"
+
+# --- Case 6: Default backend (docker) with no docker on PATH -> exit 127 ---
+
+CLEAN_PATH="$TMPDIR"
+set +e
+output=$(ANTHROPIC_API_KEY=k PATH="$CLEAN_PATH" \
+    env -u LOOPER_SANDBOX_BACKEND "$DISPATCHER" "some task" 2>&1); code=$?
+set -e
+check "default docker, no docker on PATH: exit code is 127" "$([ "$code" -eq 127 ] && echo true || echo false)"
+check "default docker, no docker on PATH: stderr mentions docker" \
+    "$(echo "$output" | grep -q 'docker' && echo true || echo false)"
+
+# --- Case 7: Grep-based extraction-fidelity assertions ---
+
+# docker.sh must use contract variable names, not old bare names
+check "docker.sh uses LOOPER_SANDBOX_TASK" \
+    "$(grep -q 'LOOPER_SANDBOX_TASK' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does not use bare \$TASK (unquoted)" \
+    "$(! grep -qE '"\$TASK"' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh uses LOOPER_SANDBOX_NAME" \
+    "$(grep -q 'LOOPER_SANDBOX_NAME' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does not use bare \$SANDBOX_NAME" \
+    "$(! grep -q '\$SANDBOX_NAME' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh uses LOOPER_SANDBOX_IMAGE" \
+    "$(grep -q 'LOOPER_SANDBOX_IMAGE' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does not use bare \$IMAGE" \
+    "$(! grep -qE '"\$IMAGE"' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh retains socket mount" \
+    "$(grep -q '/var/run/docker.sock:/var/run/docker.sock' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh retains --allowed-tools" \
+    "$(grep -q '\-\-allowed-tools' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does NOT contain dropped GH_TOKEN export" \
+    "$(! grep -q 'export GITHUB_TOKEN=.*GH_TOKEN' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+
+check "sbx.sh uses LOOPER_SANDBOX_POLICY" \
+    "$(grep -q 'LOOPER_SANDBOX_POLICY' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+check "sbx.sh does not use bare \$POLICY" \
+    "$(! grep -qE '"\$POLICY"' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+check "sbx.sh retains --branch" \
+    "$(grep -q '\-\-branch' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+check "sbx.sh retains sbx secret set ANTHROPIC_API_KEY" \
+    "$(grep -q 'sbx secret set ANTHROPIC_API_KEY' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+check "sbx.sh retains push-on-success path .sbx/\$LOOPER_SANDBOX_NAME" \
+    "$(grep -q '\.sbx/\$LOOPER_SANDBOX_NAME' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+
+# --- Case 8: backends/README.md exists and contains "How to add a backend" ---
+
+check "backends/README.md exists" \
+    "$([ -f "$BACKENDS_DIR/README.md" ] && echo true || echo false)"
+check "backends/README.md contains 'How to add a backend'" \
+    "$(grep -qi 'how to add a backend' "$BACKENDS_DIR/README.md" && echo true || echo false)"
+
+# --- Summary ---
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/plugins/looper/tests/test-run-sandboxed-dispatcher.sh
+++ b/plugins/looper/tests/test-run-sandboxed-dispatcher.sh
@@ -52,9 +52,6 @@ chmod +x "$TMPDIR/gh"
 
 # --- Case 1: No args -> exit 2, stderr contains "Usage:" ---
 
-stderr_out=$("$DISPATCHER" 2>&1 >/dev/null || true)
-exit_code=$(ANTHROPIC_API_KEY=k "$DISPATCHER" 2>&1 >/dev/null; echo $?) || true
-# Use a subshell to capture exit code properly
 set +e
 output=$(ANTHROPIC_API_KEY=k "$DISPATCHER" 2>&1); code=$?
 set -e
@@ -84,7 +81,7 @@ check "unknown backend: stderr lists null" "$(echo "$output" | grep -q 'null' &&
 
 rm -f "$TMPDIR/claude.log"
 set +e
-TMPDIR="$TMPDIR" PATH="$TMPDIR:$PATH" ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=null \
+env TMPDIR="$TMPDIR" PATH="$TMPDIR:$PATH" ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=null \
     "$DISPATCHER" "add logging" >/dev/null 2>&1; code=$?
 set -e
 check "null backend shim: exit code is 0" "$([ "$code" -eq 0 ] && echo true || echo false)"
@@ -101,17 +98,25 @@ check "null backend shim: LOOPER_SANDBOX_NAME starts with loop-" \
 
 rm -f "$TMPDIR/claude.log"
 set +e
-TMPDIR="$TMPDIR" PATH="$TMPDIR:$PATH" ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=null \
+env TMPDIR="$TMPDIR" PATH="$TMPDIR:$PATH" ANTHROPIC_API_KEY=k LOOPER_SANDBOX_BACKEND=null \
     "$DISPATCHER" "add logging and tracing" >/dev/null 2>&1; code=$?
 set -e
 check "multi-word task: claude.log contains full string" \
     "$(grep -q '/looper:loop add logging and tracing' "$TMPDIR/claude.log" && echo true || echo false)"
 
 # --- Case 6: Default backend (docker) with no docker on PATH -> exit 127 ---
+# Build a minimal PATH containing only essential tools (not docker) by creating
+# symlinks to needed binaries in a scratch directory.
 
-CLEAN_PATH="$TMPDIR"
+NODOCK_DIR="$TMPDIR/nodock"
+mkdir -p "$NODOCK_DIR"
+for tool in bash sh env date grep sed awk basename dirname pwd mktemp cat; do
+    src=$(command -v "$tool" 2>/dev/null || true)
+    [ -n "$src" ] && ln -sf "$src" "$NODOCK_DIR/$tool"
+done
+# Include the gh shim (already in $TMPDIR) to suppress auth warnings.
 set +e
-output=$(ANTHROPIC_API_KEY=k PATH="$CLEAN_PATH" \
+output=$(ANTHROPIC_API_KEY=k PATH="$NODOCK_DIR:$TMPDIR" \
     env -u LOOPER_SANDBOX_BACKEND "$DISPATCHER" "some task" 2>&1); code=$?
 set -e
 check "default docker, no docker on PATH: exit code is 127" "$([ "$code" -eq 127 ] && echo true || echo false)"
@@ -119,37 +124,49 @@ check "default docker, no docker on PATH: stderr mentions docker" \
     "$(echo "$output" | grep -q 'docker' && echo true || echo false)"
 
 # --- Case 7: Grep-based extraction-fidelity assertions ---
+# Patterns below contain literal $ for grepping shell variable references.
+# The grep patterns are stored in variables first to avoid SC2016 false positives
+# in check() invocations. SC2016 disabled for the pattern variable assignments.
+# shellcheck disable=SC2016
+BARE_TASK='"$TASK"'
+# shellcheck disable=SC2016
+BARE_SANDBOX_NAME='$SANDBOX_NAME'
+# shellcheck disable=SC2016
+BARE_IMAGE='"$IMAGE"'
+# shellcheck disable=SC2016
+BARE_POLICY='"$POLICY"'
+# shellcheck disable=SC2016
+SBX_WORKTREE_PATH='\.sbx/\$LOOPER_SANDBOX_NAME'
 
-# docker.sh must use contract variable names, not old bare names
 check "docker.sh uses LOOPER_SANDBOX_TASK" \
     "$(grep -q 'LOOPER_SANDBOX_TASK' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
-check "docker.sh does not use bare \$TASK (unquoted)" \
-    "$(! grep -qE '"\$TASK"' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does not use bare dollar-TASK" \
+    "$(! grep -qE "$BARE_TASK" "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
 check "docker.sh uses LOOPER_SANDBOX_NAME" \
     "$(grep -q 'LOOPER_SANDBOX_NAME' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
-check "docker.sh does not use bare \$SANDBOX_NAME" \
-    "$(! grep -q '\$SANDBOX_NAME' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does not use bare dollar-SANDBOX_NAME" \
+    "$(! grep -q "$BARE_SANDBOX_NAME" "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
 check "docker.sh uses LOOPER_SANDBOX_IMAGE" \
     "$(grep -q 'LOOPER_SANDBOX_IMAGE' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
-check "docker.sh does not use bare \$IMAGE" \
-    "$(! grep -qE '"\$IMAGE"' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+check "docker.sh does not use bare dollar-IMAGE" \
+    "$(! grep -qE "$BARE_IMAGE" "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
 check "docker.sh retains socket mount" \
     "$(grep -q '/var/run/docker.sock:/var/run/docker.sock' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
 check "docker.sh retains --allowed-tools" \
-    "$(grep -q '\-\-allowed-tools' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
+    "$(grep -q -- '--allowed-tools' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
 check "docker.sh does NOT contain dropped GH_TOKEN export" \
     "$(! grep -q 'export GITHUB_TOKEN=.*GH_TOKEN' "$BACKENDS_DIR/docker.sh" && echo true || echo false)"
 
 check "sbx.sh uses LOOPER_SANDBOX_POLICY" \
     "$(grep -q 'LOOPER_SANDBOX_POLICY' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
-check "sbx.sh does not use bare \$POLICY" \
-    "$(! grep -qE '"\$POLICY"' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+check "sbx.sh does not use bare dollar-POLICY" \
+    "$(! grep -qE "$BARE_POLICY" "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
 check "sbx.sh retains --branch" \
-    "$(grep -q '\-\-branch' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+    "$(grep -q -- '--branch' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
 check "sbx.sh retains sbx secret set ANTHROPIC_API_KEY" \
     "$(grep -q 'sbx secret set ANTHROPIC_API_KEY' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
-check "sbx.sh retains push-on-success path .sbx/\$LOOPER_SANDBOX_NAME" \
-    "$(grep -q '\.sbx/\$LOOPER_SANDBOX_NAME' "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
+check "sbx.sh retains push-on-success path .sbx/LOOPER_SANDBOX_NAME" \
+    "$(grep -qE "$SBX_WORKTREE_PATH" "$BACKENDS_DIR/sbx.sh" && echo true || echo false)"
 
 # --- Case 8: backends/README.md exists and contains "How to add a backend" ---
 


### PR DESCRIPTION
## Problem / Task

Closes #74. The `plugins/looper/skills/looper/scripts/run-sandboxed` script was a 165-line monolith with a single `case "$BACKEND" in docker) ... sbx) ... esac` mixing shared pre-flight with backend-specific exec, cleanup, and push behavior. Every new backend (E2B, Runloop, Modal, Managed Agents, a "null" host mode) would force another arm of that case block, making the file progressively harder to change and blocking isolated smoke-testing of a single backend.

**Current behavior:** Two hardcoded backends (`docker`, `sbx`) live inline in one script; adding a third means editing the same file and risks breaking the other two. There is no way to test one backend without the others on hand.

**Expected behavior:** A thin dispatcher under `run-sandboxed` validates shared pre-flight (task arg, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `SANDBOX_NAME`), resolves `backends/${BACKEND}.sh`, and `exec`s it with a contract-defined env. Each backend is a self-contained script. Unknown backends exit 4 with a dynamic listing. A new `null` backend runs `claude -p /looper:loop` on the host for CI/test harnesses.

## Existing Architecture

One script owned both the shared pre-flight and the backend-specific runtime. All three responsibilities (validation, docker-case, sbx-case) were interleaved, and any backend change touched the same file.

```mermaid
graph TD
    Skill([/looper:looper-sandboxed]) --> RS[run-sandboxed<br/>165 lines]
    RS --> Validate[pre-flight<br/>task, API key, GH_TOKEN, SANDBOX_NAME]
    Validate --> Case{case $BACKEND}
    Case -->|docker| DockerCase[docker run +<br/>bind mounts + socket +<br/>--allowed-tools + trap]
    Case -->|sbx| SbxCase[sbx init + secret +<br/>--branch + --policy +<br/>cleanup trap +<br/>push-on-success]
    Case -->|other| Err[unhandled]
    style RS fill:#f66,stroke:#333
    style Case fill:#f66,stroke:#333
```

## Proposed Architecture

`run-sandboxed` is now a 52-line dispatcher that exports a contract env (`LOOPER_SANDBOX_TASK`, `LOOPER_SANDBOX_NAME`, `LOOPER_SANDBOX_BACKEND`, `LOOPER_SANDBOX_IMAGE`, `LOOPER_SANDBOX_POLICY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`) and `exec`s `backends/${BACKEND}.sh`. The three backends each own their own CLI check, cleanup trap, and exit semantics — adding a fourth is a single new file in `backends/`.

```mermaid
graph TD
    Skill([/looper:looper-sandboxed]) --> RS[run-sandboxed<br/>52-line dispatcher]
    RS --> Validate[pre-flight<br/>task, API key, GH_TOKEN, SANDBOX_NAME]
    Validate --> Resolve{resolve<br/>backends/$BACKEND.sh}
    Resolve -->|docker| Docker[backends/docker.sh<br/>27 lines]
    Resolve -->|sbx| Sbx[backends/sbx.sh<br/>54 lines]
    Resolve -->|null| Null[backends/null.sh<br/>11 lines — new]
    Resolve -->|unknown| Exit4[exit 4 + list]
    Contract[backends/README.md<br/>contract + how-to-add] -.-> Docker
    Contract -.-> Sbx
    Contract -.-> Null
    style RS fill:#69f,stroke:#333
    style Docker fill:#6f6,stroke:#333
    style Sbx fill:#6f6,stroke:#333
    style Null fill:#6f6,stroke:#333
    style Contract fill:#6f6,stroke:#333
```

## Key Changes

- **Dispatcher (`run-sandboxed`):** Rewritten as 52 lines. Uses `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` so it resolves `backends/` from any CWD. Preserves exit codes 2 (missing task) and 3 (missing `ANTHROPIC_API_KEY`). Adds exit 4 for unknown backends with a dynamic listing from `backends/*.sh`. Uses `exec` (not subshell) so signals propagate cleanly.
- **`backends/docker.sh`:** Byte-for-byte extraction of the docker `case` arm with renames (`$TASK → $LOOPER_SANDBOX_TASK`, `$SANDBOX_NAME → $LOOPER_SANDBOX_NAME`, `$IMAGE → $LOOPER_SANDBOX_IMAGE`). Dropped redundant `export GITHUB_TOKEN="$GH_TOKEN"` since the dispatcher already exports it. Retains socket mount, bind mounts, `--allowed-tools`, and the INT/TERM trap.
- **`backends/sbx.sh`:** Extraction of the sbx arm with the same renames plus `$GH_TOKEN → $GITHUB_TOKEN` (guarded with `[ -n "${GITHUB_TOKEN:-}" ]`). Retains `--branch`, `--policy`, secret-set, full EXIT/INT/TERM cleanup trap, and push-on-success.
- **`backends/null.sh`:** New. Checks `claude` is on `PATH` (exit 127 with install hint if not), then `exec`s `claude -p "/looper:loop $LOOPER_SANDBOX_TASK"` with the same `--allowed-tools` list as the sandboxed backends. Serves as the reference implementation of the contract.
- **`backends/README.md`:** Documents the contract (env vars guaranteed by the dispatcher, MUST/MUST-NOT rules for backends, exit-code conventions) plus a one-paragraph how-to-add-a-backend section.
- **`plugins/looper/tests/test-run-sandboxed-dispatcher.sh`:** 31-case smoke test covering the three cases the issue mandates (unknown backend → exit 4 + listing; missing `ANTHROPIC_API_KEY` → exit 3; null backend with fake `claude` shim receives expected env+args) plus extraction-fidelity grep checks so any future edit that regresses the var-rename invariant fails loudly.
- **`.github/workflows/ci.yml`:** ShellCheck and executable-check loops now skip directories (`[ -d "$script" ] && continue`) and a second loop lints `backends/*.sh` directly.

The out-of-scope items called out in the issue (E2B, Runloop, Modal, Managed Agents) are intentionally not implemented — this PR ships only the abstraction.

## Tests & Checks

All tests and checks run locally against this branch.

| Check | Status | Details |
|-------|--------|---------|
| `shellcheck` on dispatcher + all 3 backends + test script | ✅ | clean (exit 0) |
| `bash plugins/looper/tests/test-run-sandboxed-dispatcher.sh` | ✅ | 31 passed, 0 failed |
| `shellcheck plugins/looper/tests/*.sh` | ✅ | exits 0 (pre-existing SC2034 warning in `test-integration-ci.sh` is unrelated) |
| `.github/workflows/ci.yml` YAML syntax | ✅ | parses clean |
| SKILL.md (`/looper:looper-sandboxed`) | ✅ | unchanged — external interface preserved |
| Dispatcher line count | ✅ | 52 lines (target 50–80) |
| Executable bits on new `.sh` files | ✅ | all owner-exec set |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)