### PR TITLE
fix(looper-watch): use GitHub GraphQL sub-issue/dependency graph instead of body-text parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.47.0"
+version = "0.47.3"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/looper-watch/src/github.rs
+++ b/crates/looper-watch/src/github.rs
@@ -91,24 +91,26 @@ pub fn parse_dependencies_json(json: &str) -> Result<Vec<Dependency>, String> {
         Some(i) => i,
         None => return Ok(Vec::new()),
     };
-    let mut deps = Vec::new();
-    for n in issue.blocked_by.into_iter().flat_map(|c| c.nodes) {
-        deps.push(Dependency {
-            number: n.number,
-            repo: n.repository.name_with_owner,
-            state: parse_state(&n.state),
-            source: DepSource::BlockedBy,
-        });
+    let blocked_by = issue
+        .blocked_by
+        .into_iter()
+        .flat_map(|c| c.nodes)
+        .map(|n| node_to_dep(n, DepSource::BlockedBy));
+    let sub_issues = issue
+        .sub_issues
+        .into_iter()
+        .flat_map(|c| c.nodes)
+        .map(|n| node_to_dep(n, DepSource::SubIssue));
+    Ok(blocked_by.chain(sub_issues).collect())
+}
+
+fn node_to_dep(n: GqlDepNode, source: DepSource) -> Dependency {
+    Dependency {
+        number: n.number,
+        repo: n.repository.name_with_owner,
+        state: parse_state(&n.state),
+        source,
     }
-    for n in issue.sub_issues.into_iter().flat_map(|c| c.nodes) {
-        deps.push(Dependency {
-            number: n.number,
-            repo: n.repository.name_with_owner,
-            state: parse_state(&n.state),
-            source: DepSource::SubIssue,
-        });
-    }
-    Ok(deps)
 }
 
 fn parse_state(s: &str) -> DepState {
@@ -123,13 +125,10 @@ fn parse_state(s: &str) -> DepState {
 /// blocked via manual override (label names containing "blocked" or
 /// "dependencies", case-insensitive).
 pub fn label_blocks(issue: &Issue) -> Option<String> {
-    for label in &issue.labels {
+    issue.labels.iter().find_map(|label| {
         let lower = label.name.to_lowercase();
-        if lower.contains("blocked") || lower.contains("dependencies") {
-            return Some(label.name.clone());
-        }
-    }
-    None
+        (lower.contains("blocked") || lower.contains("dependencies")).then(|| label.name.clone())
+    })
 }
 
 /// Returns true if any dependency in the list is currently OPEN.

--- a/crates/looper-watch/src/github.rs
+++ b/crates/looper-watch/src/github.rs
@@ -7,6 +7,8 @@ pub struct Issue {
     pub number: u64,
     pub title: String,
     pub labels: Vec<Label>,
+    // body is fetched from GitHub but not read by is_blocked (kept for future TUI use)
+    #[allow(dead_code)]
     pub body: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
@@ -27,14 +29,12 @@ pub struct Dependency {
     pub source: DepSource,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DepState {
     Open,
     Closed,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DepSource {
     BlockedBy,
@@ -42,23 +42,19 @@ pub enum DepSource {
 }
 
 // Private Serde helpers for GraphQL JSON decoding.
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlResp {
     data: Option<GqlData>,
     errors: Option<serde_json::Value>,
 }
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlData {
     repository: Option<GqlRepo>,
 }
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlRepo {
     issue: Option<GqlIssue>,
 }
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlIssue {
     #[serde(rename = "blockedBy")]
@@ -66,53 +62,134 @@ struct GqlIssue {
     #[serde(rename = "subIssues")]
     sub_issues: Option<GqlConn>,
 }
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlConn {
     nodes: Vec<GqlDepNode>,
 }
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlDepNode {
     number: u64,
     state: String,
     repository: GqlDepRepo,
 }
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct GqlDepRepo {
     #[serde(rename = "nameWithOwner")]
     name_with_owner: String,
 }
 
-/// Stub: parse_dependencies_json — NOT YET IMPLEMENTED (RED phase stub)
-#[allow(dead_code)]
-pub fn parse_dependencies_json(_json: &str) -> Result<Vec<Dependency>, String> {
-    panic!("not implemented")
+/// Parse a GraphQL response body into a flat Dependency list.
+/// Empty response (missing repo/issue, or dep graph feature disabled)
+/// returns `Ok(vec![])` — callers fall through to label-based blocking.
+pub fn parse_dependencies_json(json: &str) -> Result<Vec<Dependency>, String> {
+    let resp: GqlResp =
+        serde_json::from_str(json).map_err(|e| format!("graphql parse error: {e}"))?;
+    if let Some(errs) = resp.errors {
+        return Err(format!("graphql errors: {errs}"));
+    }
+    let issue = match resp.data.and_then(|d| d.repository).and_then(|r| r.issue) {
+        Some(i) => i,
+        None => return Ok(Vec::new()),
+    };
+    let mut deps = Vec::new();
+    for n in issue.blocked_by.into_iter().flat_map(|c| c.nodes) {
+        deps.push(Dependency {
+            number: n.number,
+            repo: n.repository.name_with_owner,
+            state: parse_state(&n.state),
+            source: DepSource::BlockedBy,
+        });
+    }
+    for n in issue.sub_issues.into_iter().flat_map(|c| c.nodes) {
+        deps.push(Dependency {
+            number: n.number,
+            repo: n.repository.name_with_owner,
+            state: parse_state(&n.state),
+            source: DepSource::SubIssue,
+        });
+    }
+    Ok(deps)
 }
 
-/// Stub: label_blocks — NOT YET IMPLEMENTED (RED phase stub)
-#[allow(dead_code)]
-pub fn label_blocks(_issue: &Issue) -> Option<String> {
-    panic!("not implemented")
+fn parse_state(s: &str) -> DepState {
+    if s.eq_ignore_ascii_case("OPEN") {
+        DepState::Open
+    } else {
+        DepState::Closed
+    }
 }
 
-/// Stub: any_open — NOT YET IMPLEMENTED (RED phase stub)
-#[allow(dead_code)]
-pub fn any_open(_deps: &[Dependency]) -> bool {
-    panic!("not implemented")
+/// Returns the matching label name if any label indicates this issue is
+/// blocked via manual override (label names containing "blocked" or
+/// "dependencies", case-insensitive).
+pub fn label_blocks(issue: &Issue) -> Option<String> {
+    for label in &issue.labels {
+        let lower = label.name.to_lowercase();
+        if lower.contains("blocked") || lower.contains("dependencies") {
+            return Some(label.name.clone());
+        }
+    }
+    None
 }
 
-/// Stub: format_deps_summary — NOT YET IMPLEMENTED (RED phase stub)
-#[allow(dead_code)]
-pub fn format_deps_summary(_deps: &[Dependency]) -> String {
-    panic!("not implemented")
+/// Returns true if any dependency in the list is currently OPEN.
+pub fn any_open(deps: &[Dependency]) -> bool {
+    deps.iter().any(|d| d.state == DepState::Open)
 }
 
-/// Stub: fetch_dependencies — NOT YET IMPLEMENTED (RED phase stub)
-#[allow(dead_code)]
-pub async fn fetch_dependencies(_repo: &str, _number: u64) -> Result<Vec<Dependency>, String> {
-    panic!("not implemented")
+/// Render a Dependency list for the log line — includes source so the reader
+/// can distinguish native "Depends on" edges from sub-issue edges.
+///   []                                                         when empty
+///   [blocked-by owner/repo#5(open), sub-issue owner/repo#9(closed)]
+pub fn format_deps_summary(deps: &[Dependency]) -> String {
+    if deps.is_empty() {
+        return "[]".to_string();
+    }
+    let parts: Vec<String> = deps
+        .iter()
+        .map(|d| {
+            let src = match d.source {
+                DepSource::BlockedBy => "blocked-by",
+                DepSource::SubIssue => "sub-issue",
+            };
+            let state = match d.state {
+                DepState::Open => "open",
+                DepState::Closed => "closed",
+            };
+            format!("{} {}#{}({})", src, d.repo, d.number, state)
+        })
+        .collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// Fetch tracked dependencies for an issue via GitHub GraphQL.
+///
+/// * Empty vec → issue has no deps, or the repo/org does not expose the
+///   dep-graph feature (caller treats as "not blocked by deps").
+/// * Err → gh invocation failure or GraphQL-level errors.
+///
+/// Note: we cap each connection at `first: 50`. Issues with more than 50
+/// direct deps are pathological for a dev-workflow watcher; add pagination
+/// later if this becomes a problem.
+pub async fn fetch_dependencies(repo: &str, number: u64) -> Result<Vec<Dependency>, String> {
+    let (owner, name) = match repo.split_once('/') {
+        Some((o, n)) if !o.is_empty() && !n.is_empty() => (o, n),
+        _ => return Err(format!("invalid repo format: {repo}")),
+    };
+    let query = format!(
+        r#"query {{ repository(owner: "{owner}", name: "{name}") {{ issue(number: {number}) {{ blockedBy(first: 50) {{ nodes {{ number state repository {{ nameWithOwner }} }} }} subIssues(first: 50) {{ nodes {{ number state repository {{ nameWithOwner }} }} }} }} }} }}"#
+    );
+    let output = Command::new("gh")
+        .args(["api", "graphql", "-f", &format!("query={query}")])
+        .output()
+        .await
+        .map_err(|e| format!("failed to run gh: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh api graphql failed: {stderr}"));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_dependencies_json(&stdout)
 }
 
 /// Fetch open unassigned issues from a GitHub repo.
@@ -177,83 +254,36 @@ pub async fn assign_to_me(repo: &str, issue_number: u64, retries: u32) -> Result
     .await
 }
 
-/// Check if a specific issue is open.
-pub async fn is_issue_open(repo: &str, number: u64) -> bool {
-    let output = Command::new("gh")
-        .args([
-            "issue",
-            "view",
-            &number.to_string(),
-            "--repo",
-            repo,
-            "--json",
-            "state",
-            "--jq",
-            ".state",
-        ])
-        .output()
-        .await;
-
-    match output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim() == "OPEN",
-        _ => false,
-    }
-}
-
-/// Check if an issue is blocked by labels or body references.
+/// Check if an issue is blocked by labels (manual override) or by any open
+/// GitHub-tracked dependency (`blockedBy` + `subIssues`).
 pub async fn is_blocked(issue: &Issue, repo: &str) -> bool {
-    // Label-based blocking
-    for label in &issue.labels {
-        let name = label.name.to_lowercase();
-        if name.contains("blocked") || name.contains("dependencies") {
-            return true;
-        }
+    // 1. Label-based manual override (single source of truth: label_blocks).
+    if let Some(name) = label_blocks(issue) {
+        eprintln!("#{}: blocked by label '{}'", issue.number, name);
+        return true;
     }
 
-    let body = match &issue.body {
-        Some(b) => b,
-        None => return false,
-    };
-
-    // Check for dependency references
-    for line in body.lines() {
-        let is_dep_line = line.contains("- [ ] Depends on #")
-            || line.contains("- [ ] depends on #")
-            || line.starts_with("- [ ] #")
-            || line.to_lowercase().contains("blocked by #");
-
-        if is_dep_line {
-            for num in extract_issue_numbers(line) {
-                if is_issue_open(repo, num).await {
-                    return true;
-                }
-            }
+    // 2. Native GitHub dependency graph.
+    match fetch_dependencies(repo, issue.number).await {
+        Ok(deps) => {
+            let summary = format_deps_summary(&deps);
+            let blocked = any_open(&deps);
+            eprintln!(
+                "#{}: deps={} -> {}",
+                issue.number,
+                summary,
+                if blocked { "blocked" } else { "not blocked" }
+            );
+            blocked
+        }
+        Err(e) => {
+            eprintln!(
+                "#{}: dep-graph query failed ({}); treating as not blocked",
+                issue.number, e
+            );
+            false
         }
     }
-
-    false
-}
-
-fn extract_issue_numbers(line: &str) -> Vec<u64> {
-    let mut numbers = Vec::new();
-    let mut chars = line.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '#' {
-            let mut num_str = String::new();
-            while let Some(&d) = chars.peek() {
-                if d.is_ascii_digit() {
-                    num_str.push(d);
-                    chars.next();
-                } else {
-                    break;
-                }
-            }
-            if let Ok(n) = num_str.parse::<u64>() {
-                numbers.push(n);
-            }
-        }
-    }
-    numbers
 }
 
 /// Retry an async operation with exponential backoff.
@@ -289,29 +319,6 @@ where
 mod tests {
     use super::*;
 
-    /// Extract just the label-based blocking decision (no network needed).
-    fn is_blocked_by_labels(issue: &Issue) -> bool {
-        issue.labels.iter().any(|l| {
-            let name = l.name.to_lowercase();
-            name.contains("blocked") || name.contains("dependencies")
-        })
-    }
-
-    /// Check if the body contains dependency reference lines (without resolving them).
-    fn dependency_refs_in_body(body: &str) -> Vec<u64> {
-        let mut refs = Vec::new();
-        for line in body.lines() {
-            let is_dep_line = line.contains("- [ ] Depends on #")
-                || line.contains("- [ ] depends on #")
-                || line.starts_with("- [ ] #")
-                || line.to_lowercase().contains("blocked by #");
-            if is_dep_line {
-                refs.extend(extract_issue_numbers(line));
-            }
-        }
-        refs
-    }
-
     fn make_issue_with_labels(labels: &[&str]) -> Issue {
         Issue {
             number: 1,
@@ -325,111 +332,6 @@ mod tests {
             body: None,
             created_at: "2024-01-01T00:00:00Z".to_string(),
         }
-    }
-
-    // ── extract_issue_numbers ────────────────────────────────────────
-
-    #[test]
-    fn extract_single_issue_number() {
-        assert_eq!(extract_issue_numbers("Depends on #42"), vec![42]);
-    }
-
-    #[test]
-    fn extract_multiple_issue_numbers() {
-        assert_eq!(
-            extract_issue_numbers("- [ ] #10 and #20 and #30"),
-            vec![10, 20, 30]
-        );
-    }
-
-    #[test]
-    fn extract_no_issue_numbers_from_plain_text() {
-        assert!(extract_issue_numbers("no issues here").is_empty());
-    }
-
-    #[test]
-    fn extract_ignores_hash_without_digits() {
-        assert!(extract_issue_numbers("# Heading").is_empty());
-    }
-
-    #[test]
-    fn extract_handles_hash_at_end_of_line() {
-        assert!(extract_issue_numbers("trailing #").is_empty());
-    }
-
-    #[test]
-    fn extract_adjacent_hashes() {
-        assert_eq!(extract_issue_numbers("#1#2#3"), vec![1, 2, 3]);
-    }
-
-    // ── label-based blocking ─────────────────────────────────────────
-
-    #[test]
-    fn blocked_by_label_containing_blocked() {
-        let issue = make_issue_with_labels(&["blocked"]);
-        assert!(is_blocked_by_labels(&issue));
-    }
-
-    #[test]
-    fn blocked_by_label_containing_dependencies() {
-        let issue = make_issue_with_labels(&["dependencies"]);
-        assert!(is_blocked_by_labels(&issue));
-    }
-
-    #[test]
-    fn not_blocked_by_unrelated_labels() {
-        let issue = make_issue_with_labels(&["bug", "enhancement", "priority:high"]);
-        assert!(!is_blocked_by_labels(&issue));
-    }
-
-    #[test]
-    fn blocked_label_is_case_insensitive() {
-        let issue = make_issue_with_labels(&["BLOCKED"]);
-        assert!(is_blocked_by_labels(&issue));
-    }
-
-    #[test]
-    fn not_blocked_when_no_labels() {
-        let issue = make_issue_with_labels(&[]);
-        assert!(!is_blocked_by_labels(&issue));
-    }
-
-    // ── dependency reference detection ───────────────────────────────
-
-    #[test]
-    fn detects_depends_on_syntax() {
-        let body = "Some context\n- [ ] Depends on #15\n- [x] Done";
-        assert_eq!(dependency_refs_in_body(body), vec![15]);
-    }
-
-    #[test]
-    fn detects_lowercase_depends_on() {
-        let body = "- [ ] depends on #7";
-        assert_eq!(dependency_refs_in_body(body), vec![7]);
-    }
-
-    #[test]
-    fn detects_blocked_by_syntax() {
-        let body = "Blocked by #3 and #4";
-        assert_eq!(dependency_refs_in_body(body), vec![3, 4]);
-    }
-
-    #[test]
-    fn detects_checkbox_issue_ref() {
-        let body = "- [ ] #100\n- [x] #200";
-        // Only unchecked checkboxes starting with "- [ ] #" are dependency lines
-        assert_eq!(dependency_refs_in_body(body), vec![100]);
-    }
-
-    #[test]
-    fn no_refs_in_plain_body() {
-        let body = "This is a normal issue body with no dependencies.";
-        assert!(dependency_refs_in_body(body).is_empty());
-    }
-
-    #[test]
-    fn no_refs_when_body_empty() {
-        assert!(dependency_refs_in_body("").is_empty());
     }
 
     // ── parse_dependencies_json ──────────────────────────────────────

--- a/crates/looper-watch/src/github.rs
+++ b/crates/looper-watch/src/github.rs
@@ -17,6 +17,104 @@ pub struct Label {
     pub name: String,
 }
 
+/// A dependency relationship surfaced by GitHub's native issue graph
+/// (either a `blockedBy` edge or a `subIssues` edge).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dependency {
+    pub number: u64,
+    pub repo: String,
+    pub state: DepState,
+    pub source: DepSource,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepState {
+    Open,
+    Closed,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepSource {
+    BlockedBy,
+    SubIssue,
+}
+
+// Private Serde helpers for GraphQL JSON decoding.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlResp {
+    data: Option<GqlData>,
+    errors: Option<serde_json::Value>,
+}
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlData {
+    repository: Option<GqlRepo>,
+}
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlRepo {
+    issue: Option<GqlIssue>,
+}
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlIssue {
+    #[serde(rename = "blockedBy")]
+    blocked_by: Option<GqlConn>,
+    #[serde(rename = "subIssues")]
+    sub_issues: Option<GqlConn>,
+}
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlConn {
+    nodes: Vec<GqlDepNode>,
+}
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlDepNode {
+    number: u64,
+    state: String,
+    repository: GqlDepRepo,
+}
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct GqlDepRepo {
+    #[serde(rename = "nameWithOwner")]
+    name_with_owner: String,
+}
+
+/// Stub: parse_dependencies_json — NOT YET IMPLEMENTED (RED phase stub)
+#[allow(dead_code)]
+pub fn parse_dependencies_json(_json: &str) -> Result<Vec<Dependency>, String> {
+    panic!("not implemented")
+}
+
+/// Stub: label_blocks — NOT YET IMPLEMENTED (RED phase stub)
+#[allow(dead_code)]
+pub fn label_blocks(_issue: &Issue) -> Option<String> {
+    panic!("not implemented")
+}
+
+/// Stub: any_open — NOT YET IMPLEMENTED (RED phase stub)
+#[allow(dead_code)]
+pub fn any_open(_deps: &[Dependency]) -> bool {
+    panic!("not implemented")
+}
+
+/// Stub: format_deps_summary — NOT YET IMPLEMENTED (RED phase stub)
+#[allow(dead_code)]
+pub fn format_deps_summary(_deps: &[Dependency]) -> String {
+    panic!("not implemented")
+}
+
+/// Stub: fetch_dependencies — NOT YET IMPLEMENTED (RED phase stub)
+#[allow(dead_code)]
+pub async fn fetch_dependencies(_repo: &str, _number: u64) -> Result<Vec<Dependency>, String> {
+    panic!("not implemented")
+}
+
 /// Fetch open unassigned issues from a GitHub repo.
 pub async fn fetch_open_unassigned(repo: &str, retries: u32) -> Result<Vec<Issue>, String> {
     retry(retries, || async {
@@ -332,6 +430,326 @@ mod tests {
     #[test]
     fn no_refs_when_body_empty() {
         assert!(dependency_refs_in_body("").is_empty());
+    }
+
+    // ── parse_dependencies_json ──────────────────────────────────────
+
+    #[test]
+    fn parse_dependencies_json_empty_response() {
+        let json = r#"{"data":{"repository":{"issue":{"blockedBy":{"nodes":[]},"subIssues":{"nodes":[]}}}}}"#;
+        let deps = parse_dependencies_json(json).expect("should parse ok");
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn parse_dependencies_json_blocked_by_open() {
+        let json = r#"{
+            "data": {
+                "repository": {
+                    "issue": {
+                        "blockedBy": {
+                            "nodes": [
+                                {
+                                    "number": 5,
+                                    "state": "OPEN",
+                                    "repository": { "nameWithOwner": "code-salad/looper" }
+                                }
+                            ]
+                        },
+                        "subIssues": { "nodes": [] }
+                    }
+                }
+            }
+        }"#;
+        let deps = parse_dependencies_json(json).expect("should parse ok");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].number, 5);
+        assert_eq!(deps[0].repo, "code-salad/looper");
+        assert_eq!(deps[0].state, DepState::Open);
+        assert_eq!(deps[0].source, DepSource::BlockedBy);
+    }
+
+    #[test]
+    fn parse_dependencies_json_sub_issue_closed() {
+        let json = r#"{
+            "data": {
+                "repository": {
+                    "issue": {
+                        "blockedBy": { "nodes": [] },
+                        "subIssues": {
+                            "nodes": [
+                                {
+                                    "number": 9,
+                                    "state": "CLOSED",
+                                    "repository": { "nameWithOwner": "owner/repo" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let deps = parse_dependencies_json(json).expect("should parse ok");
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].number, 9);
+        assert_eq!(deps[0].state, DepState::Closed);
+        assert_eq!(deps[0].source, DepSource::SubIssue);
+    }
+
+    #[test]
+    fn parse_dependencies_json_mixed_sources_and_cross_repo() {
+        let json = r#"{
+            "data": {
+                "repository": {
+                    "issue": {
+                        "blockedBy": {
+                            "nodes": [
+                                {
+                                    "number": 1,
+                                    "state": "OPEN",
+                                    "repository": { "nameWithOwner": "owner/a" }
+                                },
+                                {
+                                    "number": 2,
+                                    "state": "CLOSED",
+                                    "repository": { "nameWithOwner": "owner/b" }
+                                }
+                            ]
+                        },
+                        "subIssues": {
+                            "nodes": [
+                                {
+                                    "number": 3,
+                                    "state": "OPEN",
+                                    "repository": { "nameWithOwner": "other/c" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let deps = parse_dependencies_json(json).expect("should parse ok");
+        assert_eq!(deps.len(), 3);
+        assert_eq!(deps[0].repo, "owner/a");
+        assert_eq!(deps[0].source, DepSource::BlockedBy);
+        assert_eq!(deps[1].repo, "owner/b");
+        assert_eq!(deps[1].source, DepSource::BlockedBy);
+        assert_eq!(deps[2].repo, "other/c");
+        assert_eq!(deps[2].source, DepSource::SubIssue);
+    }
+
+    #[test]
+    fn parse_dependencies_json_graphql_errors_returns_err() {
+        let json = r#"{"errors":[{"message":"bad"}]}"#;
+        let result = parse_dependencies_json(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("graphql errors"),
+            "expected 'graphql errors' in: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_dependencies_json_missing_repo_returns_empty() {
+        let json = r#"{"data":{"repository":null}}"#;
+        let deps = parse_dependencies_json(json).expect("should return ok");
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn parse_dependencies_json_malformed_json_returns_err() {
+        let result = parse_dependencies_json("not json");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("graphql parse error"),
+            "expected 'graphql parse error' in: {err}"
+        );
+    }
+
+    /// Regression test for the reported bug: GitHub's native sub-issue UI renders
+    /// list items as `- [ ] [#123](https://...) Title`, which the old body-text
+    /// parser missed because `[` before `#` breaks the prefix match.
+    /// The new GraphQL-based approach doesn't parse body text at all — it reads
+    /// the structured `subIssues` connection, so any sub-issue linked via the UI
+    /// is correctly detected.
+    #[test]
+    fn parse_dependencies_json_native_sub_issue_ui_link_is_detected() {
+        // This JSON represents what GitHub returns for a native sub-issue link
+        // (the `- [ ] [#123](...) Title` rendered in the UI body)
+        let json = r#"{
+            "data": {
+                "repository": {
+                    "issue": {
+                        "blockedBy": { "nodes": [] },
+                        "subIssues": {
+                            "nodes": [
+                                {
+                                    "number": 123,
+                                    "state": "OPEN",
+                                    "repository": { "nameWithOwner": "code-salad/looper" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"#;
+        let deps = parse_dependencies_json(json).expect("should parse ok");
+        assert_eq!(deps.len(), 1, "native sub-issue UI link should be detected");
+        assert_eq!(deps[0].number, 123);
+        assert_eq!(deps[0].state, DepState::Open);
+        assert!(
+            any_open(&deps),
+            "issue with open native sub-issue link should be detected as blocked"
+        );
+    }
+
+    // ── format_deps_summary ──────────────────────────────────────────
+
+    #[test]
+    fn format_deps_summary_empty_is_brackets() {
+        assert_eq!(format_deps_summary(&[]), "[]");
+    }
+
+    #[test]
+    fn format_deps_summary_renders_source_repo_number_state() {
+        let deps = vec![
+            Dependency {
+                number: 5,
+                repo: "owner/a".to_string(),
+                state: DepState::Open,
+                source: DepSource::BlockedBy,
+            },
+            Dependency {
+                number: 9,
+                repo: "owner/b".to_string(),
+                state: DepState::Closed,
+                source: DepSource::SubIssue,
+            },
+        ];
+        let summary = format_deps_summary(&deps);
+        assert!(
+            summary.contains("blocked-by owner/a#5(open)"),
+            "expected blocked-by entry in: {summary}"
+        );
+        assert!(
+            summary.contains("sub-issue owner/b#9(closed)"),
+            "expected sub-issue entry in: {summary}"
+        );
+    }
+
+    // ── any_open ─────────────────────────────────────────────────────
+
+    #[test]
+    fn any_open_true_when_any_open() {
+        let deps = vec![
+            Dependency {
+                number: 1,
+                repo: "r/r".to_string(),
+                state: DepState::Closed,
+                source: DepSource::BlockedBy,
+            },
+            Dependency {
+                number: 2,
+                repo: "r/r".to_string(),
+                state: DepState::Closed,
+                source: DepSource::BlockedBy,
+            },
+            Dependency {
+                number: 3,
+                repo: "r/r".to_string(),
+                state: DepState::Open,
+                source: DepSource::BlockedBy,
+            },
+        ];
+        assert!(any_open(&deps));
+    }
+
+    #[test]
+    fn any_open_false_when_all_closed() {
+        let deps = vec![
+            Dependency {
+                number: 1,
+                repo: "r/r".to_string(),
+                state: DepState::Closed,
+                source: DepSource::BlockedBy,
+            },
+            Dependency {
+                number: 2,
+                repo: "r/r".to_string(),
+                state: DepState::Closed,
+                source: DepSource::BlockedBy,
+            },
+            Dependency {
+                number: 3,
+                repo: "r/r".to_string(),
+                state: DepState::Closed,
+                source: DepSource::BlockedBy,
+            },
+        ];
+        assert!(!any_open(&deps));
+    }
+
+    #[test]
+    fn any_open_false_when_empty() {
+        assert!(!any_open(&[]));
+    }
+
+    // ── label_blocks ─────────────────────────────────────────────────
+
+    #[test]
+    fn label_blocks_detects_blocked() {
+        let issue = make_issue_with_labels(&["blocked"]);
+        assert_eq!(label_blocks(&issue), Some("blocked".to_string()));
+    }
+
+    #[test]
+    fn label_blocks_detects_dependencies() {
+        let issue = make_issue_with_labels(&["dependencies"]);
+        assert_eq!(label_blocks(&issue), Some("dependencies".to_string()));
+    }
+
+    #[test]
+    fn label_blocks_is_case_insensitive() {
+        let issue = make_issue_with_labels(&["BLOCKED"]);
+        // Returns the original un-lowercased label name
+        assert_eq!(label_blocks(&issue), Some("BLOCKED".to_string()));
+    }
+
+    #[test]
+    fn label_blocks_returns_none_for_unrelated() {
+        let issue = make_issue_with_labels(&["bug", "enhancement", "priority:high"]);
+        assert_eq!(label_blocks(&issue), None);
+    }
+
+    #[test]
+    fn label_blocks_returns_none_when_empty() {
+        let issue = make_issue_with_labels(&[]);
+        assert_eq!(label_blocks(&issue), None);
+    }
+
+    // ── fetch_dependencies pre-spawn validation ──────────────────────
+
+    #[tokio::test]
+    async fn fetch_dependencies_rejects_malformed_repo() {
+        let result = fetch_dependencies("badrepo", 1).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("invalid repo format"),
+            "expected 'invalid repo format' in: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_dependencies_rejects_empty_owner_or_name() {
+        let result = fetch_dependencies("/foo", 1).await;
+        assert!(result.is_err(), "empty owner should be rejected");
+        let result2 = fetch_dependencies("foo/", 1).await;
+        assert!(result2.is_err(), "empty name should be rejected");
     }
 
     // ── retry utility ────────────────────────────────────────────────

--- a/tests/test-looper-watch-smoke.sh
+++ b/tests/test-looper-watch-smoke.sh
@@ -203,8 +203,8 @@ assert_exit_zero "kanban categorization tests" "$rc"
 echo ""
 echo "=== Test: github parsing via Rust tests ==="
 rc=0
-cargo test -p looper-watch extract_ --quiet 2>&1 || rc=$?
-assert_exit_zero "github extract_issue_numbers tests" "$rc"
+cargo test -p looper-watch parse_dependencies_json_ --quiet 2>&1 || rc=$?
+assert_exit_zero "github parse_dependencies_json tests" "$rc"
 
 # ──────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Closes #78.

## Problem / Task

`crates/looper-watch/src/github.rs::is_blocked` determined whether an issue was blocked by scanning the raw issue body for a handful of hard-coded text patterns. This was fragile and silently dropped real dependencies in multiple scenarios: non-standard phrasings (`Requires #5`, `After #5 lands`), GitHub's native sub-issue UI (which renders as `- [ ] [#123](...) Title` — the link wrapping broke the `- [ ] #` prefix match), cross-repo references (always queried the current repo), and inverse phrasing on the dependency side.

**Current behavior (before):** Only exact text patterns matched; `looper-watch` silently picked up issues whose dependencies were still open, with no visibility into what it parsed.
**Expected behavior (after):** Dependencies are read from GitHub's structured dependency graph (`blockedBy` + `subIssues`), works regardless of phrasing or UI, resolves cross-repo correctly, and every evaluation logs the parsed dep set and the resulting decision.

## Existing Architecture

`is_blocked` lived entirely inside `github.rs` and made its decision from `issue.body` via regex-like prefix matching plus a per-dep `gh issue view` call to check state. Label-based blocking was mixed into the same body-scan helpers.

```mermaid
flowchart TD
    W[worker.rs::is_blocked caller] --> B[is_blocked]
    B --> L[is_blocked_by_labels - body-adjacent]
    B --> R[dependency_refs_in_body - body regex]
    R --> E[extract_issue_numbers]
    E --> O[is_issue_open - spawns gh issue view per dep]
    O --> G[(GitHub REST)]
    style R fill:#f66,stroke:#333
    style E fill:#f66,stroke:#333
    style O fill:#f66,stroke:#333
```

## Proposed Architecture

Body parsing is gone. `is_blocked` first consults `label_blocks` (the single source of truth for manual-override labels), then calls `fetch_dependencies`, which issues one `gh api graphql` query returning both `blockedBy` and `subIssues` edges (each capped at 50, including `repository.nameWithOwner` for cross-repo). The response is decoded by the pure `parse_dependencies_json`; pure predicates `any_open` and `format_deps_summary` feed the final decision and the log line.

```mermaid
flowchart TD
    W[worker.rs::is_blocked caller] --> B[is_blocked]
    B --> L[label_blocks - single source of truth]
    B -->|no label match| F[fetch_dependencies]
    F --> P[parse_dependencies_json]
    F --> G[(GitHub GraphQL<br/>blockedBy + subIssues)]
    P --> AO[any_open]
    P --> FS[format_deps_summary]
    AO --> D{blocked?}
    FS --> LOG[eprintln! one line per evaluation]
    style L fill:#69f,stroke:#333
    style F fill:#6f6,stroke:#333
    style P fill:#6f6,stroke:#333
    style AO fill:#6f6,stroke:#333
    style FS fill:#6f6,stroke:#333
```

## Key Changes

- **`crates/looper-watch/src/github.rs`**
  - New types: `Dependency`, `DepState` (`Open`/`Closed`), `DepSource` (`BlockedBy`/`SubIssue`), plus private Serde types for the GraphQL envelope.
  - New pure functions: `parse_dependencies_json` (handles missing repo/issue and feature-disabled repos by returning `Ok(vec![])`; returns `Err` on GraphQL errors or malformed JSON), `label_blocks` (returns the matching label name for tests/logging), `any_open`, `format_deps_summary`.
  - New async `fetch_dependencies` — validates `owner/name` pre-spawn, invokes `gh api graphql`, delegates parsing.
  - `is_blocked` rewritten: label short-circuit via `label_blocks`, then `fetch_dependencies`, with one `eprintln!` per decision (`#N: blocked by label '...'` / `#N: deps=[...] -> blocked|not blocked` / `#N: dep-graph query failed (...); treating as not blocked`). `Issue.body` is no longer read by the blocking logic (kept with `#[allow(dead_code)]` for future TUI use).
  - Removed: `is_issue_open`, `extract_issue_numbers`, `dependency_refs_in_body`, `is_blocked_by_labels`, and 12 obsolete body-parser tests. `worker.rs:117` compiles unchanged — `is_blocked` signature preserved.
- **`tests/test-looper-watch-smoke.sh`**: the Rust-test filter in the smoke script updated from `extract_` → `parse_dependencies_json_` so it keeps exercising a real test after the old helpers were removed.
- **`Cargo.lock`**: `looper-watch` version bump only — no new dependencies.

Trade-offs: the tests exercise the decision logic via pure-function seams (`parse_dependencies_json`, `label_blocks`, `any_open`, `format_deps_summary`) rather than mocking the `gh` subprocess; this gives complete coverage of the response → verdict mapping without a mock-server dependency. GraphQL errors fail open (treat as "not blocked") so a transient API hiccup doesn't stall the watcher — label-based blocking remains the reliable manual override.

## Tests & Checks

22 new tests were added (then 20 landed after consolidating duplicates): 8 for `parse_dependencies_json` (empty response, only `blockedBy`, only `subIssues`, mixed, cross-repo, GraphQL errors, malformed JSON, and a regression test named `parse_dependencies_json_native_sub_issue_ui_link_is_detected` that replays the exact shape of GitHub's native sub-issue UI payload — the reported bug). 5 for `label_blocks`, 3 for `any_open`, 2 for `format_deps_summary`, 2 for `fetch_dependencies` repo-format validation. The retry infra tests remain.

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 100 passed, 0 failed (`cargo test -p looper-watch`) |
| Lint (clippy) | ✅ | `cargo clippy -p looper-watch -- -D warnings` clean |
| Format | ✅ | `cargo fmt --check` clean |
| Build | ✅ | `cargo build -p looper-watch` succeeds; `--help` exits 0 |
| Smoke tests | ✅ | 13/13 (filter updated to `parse_dependencies_json_`) |

---