### PR TITLE
perf(looper): trim per-role loop context + drop redundant reads

### DIFF
--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -37,8 +37,11 @@ modify any project files — only commit a plan as a git commit message.
 
 2. **Gather context and explore in parallel** — Launch all four tracks as
    separate tool calls in a single message:
-   - **Track A (Bash):** Run `$SCRIPTS_DIR/git-loop-context` and
-     `$SCRIPTS_DIR/detect-stack` as two parallel Bash calls
+   - **Track A (Bash):** Run `$SCRIPTS_DIR/detect-stack` to identify the
+     project tech stack. (The prior loop context is already pre-injected
+     upstream in the `## Prior Loop Context` section of this prompt — do
+     NOT re-fetch it manually; that duplicates input tokens in the same
+     agent turn.)
    - **Track B (Glob):** Map project structure — top-level files, primary
      source directory, test directory
    - **Track C:** If iteration > 1, spawn an Explore subagent to
@@ -240,6 +243,7 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
 - `detect-compose` — Detect docker-compose and extract service port mappings
 - `compose-lifecycle` — Start/stop docker-compose services (`up --task`, `down`)
 - `git-loop-context` — Read prior loop iterations from git log
+  (pre-injected as `## Prior Loop Context`; do not call manually)
 - `git-commit-loop` — Create commits with loop trailers
 
 The `$SCRIPTS_DIR` path is injected as a task variable in your dynamic context.

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -164,11 +164,10 @@ MAX_ITERATIONS="${LOOPER_MAX_ITERATIONS:-10}"
 
 For each iteration from `START_ITERATION` to `MAX_ITERATIONS`:
 
-#### 7a. Get loop context
+#### 7a. Get loop context (per-role, inside `build-agent-context`)
 
-```bash
-LOOP_CONTEXT=$($SCRIPTS_DIR/git-loop-context --task "$TASK_NAME" --iteration $ITERATION)
-```
+Loop context is fetched per-role inside `build-agent-context` in step 7c.
+No upstream shared fetch is needed.
 
 #### 7b. Generate isolated dev port
 
@@ -231,7 +230,7 @@ CTX_COMMON=(
     --task-prompt "$TASK_PROMPT" --scripts-dir "$SCRIPTS_DIR"
     --worktree-dir "$WORKTREE_DIR" --dev-port "$LOOPER_DEV_PORT"
     --compose "${HAS_COMPOSE:-false}" --compose-services "${COMPOSE_SERVICES:-none}"
-    --issue-body "$ISSUE_BODY" --loop-context "$LOOP_CONTEXT"
+    --issue-body "$ISSUE_BODY"
 )
 
 PLANNER_CONTEXT=$($SCRIPTS_DIR/build-agent-context --role planner "${CTX_COMMON[@]}")

--- a/plugins/looper/skills/looper/scripts/build-agent-context
+++ b/plugins/looper/skills/looper/scripts/build-agent-context
@@ -79,6 +79,16 @@ case "$ROLE" in
         ;;
 esac
 
+# If caller didn't pass --loop-context and we're past iter 1, fetch the loop
+# context scoped to the role. Preserve legacy passthrough: if --loop-context
+# is non-empty (even if just "placeholder"), use it verbatim.
+if [ -z "$LOOP_CONTEXT" ] && [ "$ITERATION" -gt 1 ]; then
+    LOOP_CONTEXT=$("$SCRIPTS_DIR/git-loop-context" \
+        --task "$TASK_NAME" \
+        --iteration "$ITERATION" \
+        --role "$ROLE")
+fi
+
 # --- Helper: read file if it exists, empty string otherwise ---
 read_file_if_exists() {
     local path="$1"
@@ -171,97 +181,101 @@ CARGO_TOML_CONTENT=$(read_file_if_exists "$CARGO_TOML_FILE")
 # --- Build role-specific PROJECT_CONTEXT ---
 PROJECT_CONTEXT=""
 
-case "$ROLE" in
-    planner)
-        # Full context: all docs + all build configs
-        if [ -n "$CONTRIBUTING_FULL" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md" "$CONTRIBUTING_FULL")"
-        fi
-        if [ -n "$README_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "README.md" "$README_CONTENT")"
-        fi
-        if [ -n "$AGENTS_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "AGENTS.md" "$AGENTS_CONTENT")"
-        fi
-        if [ -n "$PR_TEMPLATE_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".github/PULL_REQUEST_TEMPLATE.md" "$PR_TEMPLATE_CONTENT")"
-        fi
-        if [ -n "$EDITORCONFIG_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".editorconfig" "$EDITORCONFIG_CONTENT")"
-        fi
-        if [ -n "$PACKAGE_JSON_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json" "$PACKAGE_JSON_CONTENT")"
-        fi
-        if [ -n "$MAKEFILE_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
-        fi
-        if [ -n "$PYPROJECT_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
-        fi
-        if [ -n "$CARGO_TOML_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
-        fi
-        ;;
+if [ "$ITERATION" -eq 1 ]; then
+    case "$ROLE" in
+        planner)
+            # Full context: all docs + all build configs
+            if [ -n "$CONTRIBUTING_FULL" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md" "$CONTRIBUTING_FULL")"
+            fi
+            if [ -n "$README_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "README.md" "$README_CONTENT")"
+            fi
+            if [ -n "$AGENTS_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "AGENTS.md" "$AGENTS_CONTENT")"
+            fi
+            if [ -n "$PR_TEMPLATE_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".github/PULL_REQUEST_TEMPLATE.md" "$PR_TEMPLATE_CONTENT")"
+            fi
+            if [ -n "$EDITORCONFIG_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".editorconfig" "$EDITORCONFIG_CONTENT")"
+            fi
+            if [ -n "$PACKAGE_JSON_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json" "$PACKAGE_JSON_CONTENT")"
+            fi
+            if [ -n "$MAKEFILE_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
+            fi
+            if [ -n "$PYPROJECT_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
+            fi
+            if [ -n "$CARGO_TOML_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
+            fi
+            ;;
 
-    doer)
-        # Focused: Code Style section + .editorconfig + build config scripts only
-        CODE_STYLE_CONTENT=""
-        if [ -n "$CONTRIBUTING_CODE_STYLE" ]; then
-            CODE_STYLE_CONTENT="## Code Style
+        doer)
+            # Focused: Code Style section + .editorconfig + build config scripts only
+            CODE_STYLE_CONTENT=""
+            if [ -n "$CONTRIBUTING_CODE_STYLE" ]; then
+                CODE_STYLE_CONTENT="## Code Style
 
 $CONTRIBUTING_CODE_STYLE"
-        fi
-        if [ -n "$CODE_STYLE_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md (Code Style)" "$CODE_STYLE_CONTENT")"
-        fi
-        if [ -n "$EDITORCONFIG_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".editorconfig" "$EDITORCONFIG_CONTENT")"
-        fi
-        if [ -n "$PACKAGE_JSON_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json (scripts)" "$PACKAGE_JSON_CONTENT")"
-        fi
-        if [ -n "$MAKEFILE_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
-        fi
-        if [ -n "$PYPROJECT_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
-        fi
-        if [ -n "$CARGO_TOML_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
-        fi
-        ;;
+            fi
+            if [ -n "$CODE_STYLE_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md (Code Style)" "$CODE_STYLE_CONTENT")"
+            fi
+            if [ -n "$EDITORCONFIG_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section ".editorconfig" "$EDITORCONFIG_CONTENT")"
+            fi
+            if [ -n "$PACKAGE_JSON_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json (scripts)" "$PACKAGE_JSON_CONTENT")"
+            fi
+            if [ -n "$MAKEFILE_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
+            fi
+            if [ -n "$PYPROJECT_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
+            fi
+            if [ -n "$CARGO_TOML_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
+            fi
+            ;;
 
-    checker)
-        # Minimal: Code Style + Testing sections + test/lint/build commands
-        CHECKER_CONTRIBUTING=""
-        if [ -n "$CONTRIBUTING_CODE_STYLE" ]; then
-            CHECKER_CONTRIBUTING="${CHECKER_CONTRIBUTING}## Code Style
+        checker)
+            # Minimal: Code Style + Testing sections + test/lint/build commands
+            CHECKER_CONTRIBUTING=""
+            if [ -n "$CONTRIBUTING_CODE_STYLE" ]; then
+                CHECKER_CONTRIBUTING="${CHECKER_CONTRIBUTING}## Code Style
 
 $CONTRIBUTING_CODE_STYLE
 "
-        fi
-        if [ -n "$CONTRIBUTING_TESTING" ]; then
-            CHECKER_CONTRIBUTING="${CHECKER_CONTRIBUTING}## Testing and CI
+            fi
+            if [ -n "$CONTRIBUTING_TESTING" ]; then
+                CHECKER_CONTRIBUTING="${CHECKER_CONTRIBUTING}## Testing and CI
 
 $CONTRIBUTING_TESTING"
-        fi
-        if [ -n "$CHECKER_CONTRIBUTING" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md (Code Style + Testing)" "$CHECKER_CONTRIBUTING")"
-        fi
-        if [ -n "$PACKAGE_JSON_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json (scripts)" "$PACKAGE_JSON_CONTENT")"
-        fi
-        if [ -n "$MAKEFILE_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
-        fi
-        if [ -n "$PYPROJECT_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
-        fi
-        if [ -n "$CARGO_TOML_CONTENT" ]; then
-            PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
-        fi
-        ;;
-esac
+            fi
+            if [ -n "$CHECKER_CONTRIBUTING" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "CONTRIBUTING.md (Code Style + Testing)" "$CHECKER_CONTRIBUTING")"
+            fi
+            if [ -n "$PACKAGE_JSON_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "package.json (scripts)" "$PACKAGE_JSON_CONTENT")"
+            fi
+            if [ -n "$MAKEFILE_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Makefile (targets)" "$MAKEFILE_CONTENT")"
+            fi
+            if [ -n "$PYPROJECT_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "pyproject.toml" "$PYPROJECT_CONTENT")"
+            fi
+            if [ -n "$CARGO_TOML_CONTENT" ]; then
+                PROJECT_CONTEXT="${PROJECT_CONTEXT}$(format_file_section "Cargo.toml" "$CARGO_TOML_CONTENT")"
+            fi
+            ;;
+    esac
+else
+    PROJECT_CONTEXT="See Planner commit from iteration 1 — project context unchanged."
+fi
 
 # --- Assemble issue context ---
 if [ -z "$ISSUE_BODY" ]; then
@@ -325,13 +339,3 @@ cat << LOOP_EOF
 
 ${LOOP_CONTEXT:-This is the first iteration. No prior context available.}
 LOOP_EOF
-
-# Planner iteration > 1: add pruning note
-if [ "$ROLE" = "planner" ] && [ "$ITERATION" -gt 1 ]; then
-    cat << PRUNE_EOF
-
-NOTE: This is iteration ${ITERATION}. Project context is the same as iteration 1.
-Spawn Explore subagents ONLY for the areas the Checker flagged — do not
-re-explore the entire codebase. The action items above are your focus.
-PRUNE_EOF
-fi

--- a/plugins/looper/skills/looper/scripts/git-loop-context
+++ b/plugins/looper/skills/looper/scripts/git-loop-context
@@ -2,26 +2,44 @@
 set -euo pipefail
 
 # git-loop-context — Read loop history from git log
-# Usage: git-loop-context --task <name> --iteration <N>
+# Usage: git-loop-context --task <name> --iteration <N> [--role planner|doer|checker]
 # Outputs structured markdown with progressive compression:
 #   - Last iteration (N-1):  full plan + changes + file stats + verdict
 #   - Recent iterations (N-2, N-3): plan first line + verdict action items
 #   - Older iterations: one-line summary (verdict + first line)
+#
+# --role planner  : emit only plan body + verdict body per iteration
+# --role doer     : emit only one-line summary per iteration (### Iteration N — VERDICT)
+# --role checker  : emit only verdict body per iteration
+# --role ""       : same as no --role (legacy full output)
 
 TASK=""
 ITERATION=""
+ROLE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --task) TASK="$2"; shift 2 ;;
         --iteration) ITERATION="$2"; shift 2 ;;
+        --role) ROLE="$2"; shift 2 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
 
 if [ -z "$TASK" ] || [ -z "$ITERATION" ]; then
-    echo "Usage: git-loop-context --task <name> --iteration <N>" >&2
+    echo "Usage: git-loop-context --task <name> --iteration <N> [--role planner|doer|checker]" >&2
     exit 1
+fi
+
+# Validate role if non-empty
+if [ -n "$ROLE" ]; then
+    case "$ROLE" in
+        planner|doer|checker) ;;
+        *)
+            echo "Unknown role: $ROLE (must be planner, doer, or checker)" >&2
+            exit 1
+            ;;
+    esac
 fi
 
 echo "## Loop Context: ${TASK}, Iteration ${ITERATION}"
@@ -106,7 +124,51 @@ for (( i=1; i<ITERATION; i++ )); do
     verdict_body=$(_extract_body "check" "$i")
     verdict=$(echo "$verdict_body" | grep -oE 'Loop-Verdict: (PASS|FAIL)' | head -1 | sed 's/Loop-Verdict: //' || echo "UNKNOWN")
 
-    # Calculate detail level (verdict-adaptive)
+    # --- Role-scoped output (when --role is set) ---
+    if [ -n "$ROLE" ]; then
+        case "$ROLE" in
+            planner)
+                # Plan body + verdict body; skip all do-* commits
+                echo "### Iteration ${i}"
+                echo ""
+                if [ -n "$plan_body" ]; then
+                    echo "#### Plan"
+                    echo ""
+                    echo "$plan_body" | _strip_trailers
+                    echo ""
+                fi
+                if [ -n "$verdict_body" ]; then
+                    echo "#### Verdict: ${verdict}"
+                    echo ""
+                    echo "$verdict_body" | _strip_trailers
+                    echo ""
+                fi
+                echo "---"
+                echo ""
+                ;;
+            doer)
+                # One-line summary per prior iteration; no bodies
+                echo "### Iteration ${i} — ${verdict}"
+                echo ""
+                ;;
+            checker)
+                # Verdict body only; skip plan and do-* commits
+                echo "### Iteration ${i}"
+                echo ""
+                if [ -n "$verdict_body" ]; then
+                    echo "#### Verdict: ${verdict}"
+                    echo ""
+                    echo "$verdict_body" | _strip_trailers
+                    echo ""
+                fi
+                echo "---"
+                echo ""
+                ;;
+        esac
+        continue
+    fi
+
+    # Calculate detail level (verdict-adaptive) — legacy full output
     if [ "$i" -eq "$LAST" ]; then
         detail="full"
     elif [ "$verdict" = "PASS" ]; then

--- a/plugins/looper/tests/test-loop-context-trim.sh
+++ b/plugins/looper/tests/test-loop-context-trim.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-loop-context-trim.sh — Verify role-scoped loop context, project-context
+# pruning on iter > 1, internal per-role fetch, planner.md Track A cleanup,
+# and SKILL.md upstream-fetch removal.
+#
+# Runs standalone: bash plugins/looper/tests/test-loop-context-trim.sh
+# Exit 0 = all assertions PASS.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills/looper/scripts" && pwd)"
+AGENTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../agents" && pwd)"
+SKILL_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills/looper" && pwd)/SKILL.md"
+
+GLC="$SCRIPTS_DIR/git-loop-context"
+BAC="$SCRIPTS_DIR/build-agent-context"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; echo "  $2"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Group A — git-loop-context --role flag
+# ---------------------------------------------------------------------------
+echo "=== Group A: git-loop-context --role flag ==="
+
+TMPDIR_A=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_A"' EXIT
+
+# Set up seeded repo for Group A
+git -C "$TMPDIR_A" init -b main >/dev/null 2>&1
+git -C "$TMPDIR_A" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -m "seed" >/dev/null 2>&1
+
+git -C "$TMPDIR_A" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+chore: plan commit
+
+PLAN_MARKER_BODY
+Loop-Phase: plan
+Loop-Iteration: 1
+MSG
+
+git -C "$TMPDIR_A" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+test: do-red commit
+
+DO_RED_MARKER_BODY
+Loop-Phase: do-red
+Loop-Iteration: 1
+MSG
+
+git -C "$TMPDIR_A" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+feat: do-green commit
+
+DO_GREEN_MARKER_BODY
+Loop-Phase: do-green
+Loop-Iteration: 1
+MSG
+
+git -C "$TMPDIR_A" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+test: check commit
+
+VERDICT_MARKER_BODY
+Loop-Phase: check
+Loop-Iteration: 1
+Loop-Verdict: FAIL
+MSG
+
+printf 'CONTRIB_A\n\n## Code Style\n\nFoo.\n' > "$TMPDIR_A/CONTRIBUTING.md"
+
+SAVED_DIR="$PWD"
+
+cd "$TMPDIR_A"
+
+# A1: planner role — plan + verdict, NOT do-red or do-green
+out=$("$GLC" --task demo --iteration 2 --role planner 2>&1 || true)
+if echo "$out" | grep -q "PLAN_MARKER_BODY" && \
+   echo "$out" | grep -q "VERDICT_MARKER_BODY" && \
+   ! echo "$out" | grep -q "DO_RED_MARKER_BODY" && \
+   ! echo "$out" | grep -q "DO_GREEN_MARKER_BODY"; then
+    pass "A1: planner role shows plan+verdict, hides do-red/do-green"
+else
+    fail "A1: planner role shows plan+verdict, hides do-red/do-green" \
+        "output: $out"
+fi
+
+# A2: doer role — only one-line summary per iteration, NO marker bodies
+out=$("$GLC" --task demo --iteration 2 --role doer 2>&1 || true)
+if ! echo "$out" | grep -q "PLAN_MARKER_BODY" && \
+   ! echo "$out" | grep -q "DO_RED_MARKER_BODY" && \
+   ! echo "$out" | grep -q "DO_GREEN_MARKER_BODY" && \
+   ! echo "$out" | grep -q "VERDICT_MARKER_BODY" && \
+   echo "$out" | grep -q "### Iteration 1 — FAIL"; then
+    pass "A2: doer role emits one-line summary, no marker bodies"
+else
+    fail "A2: doer role emits one-line summary, no marker bodies" \
+        "output: $out"
+fi
+
+# A3: checker role — only verdict body, NOT plan or do-* bodies
+out=$("$GLC" --task demo --iteration 2 --role checker 2>&1 || true)
+if echo "$out" | grep -q "VERDICT_MARKER_BODY" && \
+   ! echo "$out" | grep -q "PLAN_MARKER_BODY" && \
+   ! echo "$out" | grep -q "DO_RED_MARKER_BODY" && \
+   ! echo "$out" | grep -q "DO_GREEN_MARKER_BODY"; then
+    pass "A3: checker role shows verdict only"
+else
+    fail "A3: checker role shows verdict only" \
+        "output: $out"
+fi
+
+# A4: iteration 1 with any role → first-iteration banner
+out=$("$GLC" --task demo --iteration 1 --role planner 2>&1 || true)
+if echo "$out" | grep -q "This is the first iteration. No prior context available."; then
+    pass "A4: iteration 1 with role prints first-iteration banner"
+else
+    fail "A4: iteration 1 with role prints first-iteration banner" \
+        "output: $out"
+fi
+
+# A5: no --role → legacy full output (backward compat)
+out=$("$GLC" --task demo --iteration 2 2>&1 || true)
+if echo "$out" | grep -q "PLAN_MARKER_BODY" && \
+   echo "$out" | grep -q "DO_RED_MARKER_BODY" && \
+   echo "$out" | grep -q "DO_GREEN_MARKER_BODY" && \
+   echo "$out" | grep -q "VERDICT_MARKER_BODY"; then
+    pass "A5: no --role emits legacy full output"
+else
+    fail "A5: no --role emits legacy full output" \
+        "output: $out"
+fi
+
+# A6: invalid role → non-zero exit + stderr contains 'role'
+err_a6=$("$GLC" --task demo --iteration 2 --role bogus 2>&1 || true)
+if ! "$GLC" --task demo --iteration 2 --role bogus >/dev/null 2>/dev/null; then
+    if echo "$err_a6" | grep -qi "role"; then
+        pass "A6: --role bogus exits non-zero with 'role' in stderr"
+    else
+        fail "A6: --role bogus exits non-zero with 'role' in stderr" \
+            "combined output: $err_a6"
+    fi
+else
+    fail "A6: --role bogus should exit non-zero" "exited 0"
+fi
+
+# A7: empty role string → legacy full output (additive behavior)
+out=$("$GLC" --task demo --iteration 2 --role "" 2>&1 || true)
+if echo "$out" | grep -q "PLAN_MARKER_BODY" && \
+   echo "$out" | grep -q "DO_RED_MARKER_BODY" && \
+   echo "$out" | grep -q "DO_GREEN_MARKER_BODY" && \
+   echo "$out" | grep -q "VERDICT_MARKER_BODY"; then
+    pass "A7: --role '' treated as legacy (full output)"
+else
+    fail "A7: --role '' treated as legacy (full output)" \
+        "output: $out"
+fi
+
+cd "$SAVED_DIR"
+rm -rf "$TMPDIR_A"
+trap '' EXIT
+
+# ---------------------------------------------------------------------------
+# Group B — build-agent-context project-context pruning
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Group B: build-agent-context project-context pruning ==="
+
+TMPDIR_B=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_B"' EXIT
+
+git -C "$TMPDIR_B" init -b main >/dev/null 2>&1
+git -C "$TMPDIR_B" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -m "seed" >/dev/null 2>&1
+
+printf 'CONTRIB_MARKER_XYZ\n\n## Code Style\n\nFoo.\n\n## Testing and CI\n\nBar.\n' \
+    > "$TMPDIR_B/CONTRIBUTING.md"
+
+cd "$TMPDIR_B"
+
+BAC_COMMON=(
+    --task test --task-prompt "test prompt"
+    --scripts-dir "$SCRIPTS_DIR"
+    --dev-port 9999
+    --compose false --compose-services none
+    --worktree-dir "$TMPDIR_B"
+)
+
+# B1: iter 1, planner role — CONTRIB_MARKER_XYZ present
+out=$("$BAC" --role planner --iteration 1 "${BAC_COMMON[@]}" \
+    --loop-context "placeholder" 2>&1 || true)
+if echo "$out" | grep -q "CONTRIB_MARKER_XYZ"; then
+    pass "B1: iter 1 planner includes full project-context (CONTRIB_MARKER_XYZ present)"
+else
+    fail "B1: iter 1 planner includes full project-context (CONTRIB_MARKER_XYZ present)" \
+        "CONTRIB_MARKER_XYZ not found in output"
+fi
+
+# B2: iter 2, planner role — CONTRIB_MARKER_XYZ absent, pointer present
+out=$("$BAC" --role planner --iteration 2 "${BAC_COMMON[@]}" \
+    --loop-context "placeholder" 2>&1 || true)
+if ! echo "$out" | grep -q "CONTRIB_MARKER_XYZ" && \
+   echo "$out" | grep -q "project context unchanged"; then
+    pass "B2: iter 2 planner omits CONTRIB and has pointer"
+else
+    fail "B2: iter 2 planner omits CONTRIB and has pointer" \
+        "has_contrib=$(echo "$out" | grep -c CONTRIB_MARKER_XYZ 2>/dev/null || echo 0), has_pointer=$(echo "$out" | grep -c 'project context unchanged' 2>/dev/null || echo 0)"
+fi
+
+# B3: iter 2, doer role
+out=$("$BAC" --role doer --iteration 2 "${BAC_COMMON[@]}" \
+    --loop-context "placeholder" 2>&1 || true)
+if ! echo "$out" | grep -q "CONTRIB_MARKER_XYZ" && \
+   echo "$out" | grep -q "project context unchanged"; then
+    pass "B3: iter 2 doer omits CONTRIB and has pointer"
+else
+    fail "B3: iter 2 doer omits CONTRIB and has pointer" \
+        "has_contrib=$(echo "$out" | grep -c CONTRIB_MARKER_XYZ 2>/dev/null || echo 0)"
+fi
+
+# B4: iter 2, checker role
+out=$("$BAC" --role checker --iteration 2 "${BAC_COMMON[@]}" \
+    --loop-context "placeholder" 2>&1 || true)
+if ! echo "$out" | grep -q "CONTRIB_MARKER_XYZ" && \
+   echo "$out" | grep -q "project context unchanged"; then
+    pass "B4: iter 2 checker omits CONTRIB and has pointer"
+else
+    fail "B4: iter 2 checker omits CONTRIB and has pointer" \
+        "has_contrib=$(echo "$out" | grep -c CONTRIB_MARKER_XYZ 2>/dev/null || echo 0)"
+fi
+
+# B5: iter 2 output still has <project-context> tags
+out=$("$BAC" --role planner --iteration 2 "${BAC_COMMON[@]}" \
+    --loop-context "placeholder" 2>&1 || true)
+if echo "$out" | grep -q "<project-context>" && \
+   echo "$out" | grep -q "</project-context>"; then
+    pass "B5: iter 2 output still has <project-context> tags"
+else
+    fail "B5: iter 2 output still has <project-context> tags" \
+        "tags not found in output"
+fi
+
+cd "$SAVED_DIR"
+rm -rf "$TMPDIR_B"
+trap '' EXIT
+
+# ---------------------------------------------------------------------------
+# Group C — build-agent-context internal per-role loop-context fetch
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Group C: build-agent-context internal per-role loop-context fetch ==="
+
+TMPDIR_C=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_C"' EXIT
+
+git -C "$TMPDIR_C" init -b main >/dev/null 2>&1
+git -C "$TMPDIR_C" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -m "seed" >/dev/null 2>&1
+
+git -C "$TMPDIR_C" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+chore: plan commit
+
+PLAN_MARKER_BODY
+Loop-Phase: plan
+Loop-Iteration: 1
+MSG
+
+git -C "$TMPDIR_C" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+test: do-red commit
+
+DO_RED_MARKER_BODY
+Loop-Phase: do-red
+Loop-Iteration: 1
+MSG
+
+git -C "$TMPDIR_C" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+feat: do-green commit
+
+DO_GREEN_MARKER_BODY
+Loop-Phase: do-green
+Loop-Iteration: 1
+MSG
+
+git -C "$TMPDIR_C" -c user.email=test@test -c user.name=test \
+    commit --allow-empty -F - <<'MSG' >/dev/null 2>&1
+test: check commit
+
+VERDICT_MARKER_BODY
+Loop-Phase: check
+Loop-Iteration: 1
+Loop-Verdict: FAIL
+MSG
+
+printf 'CONTRIB_C\n\n## Code Style\n\nFoo.\n' > "$TMPDIR_C/CONTRIBUTING.md"
+
+cd "$TMPDIR_C"
+
+BAC_C_COMMON=(
+    --task test --iteration 2 --task-prompt "test prompt"
+    --scripts-dir "$SCRIPTS_DIR"
+    --dev-port 9999
+    --compose false --compose-services none
+    --worktree-dir "$TMPDIR_C"
+)
+
+# C1: planner role, no --loop-context → internal fetch → plan+verdict in Prior Loop Context
+out=$("$BAC" --role planner "${BAC_C_COMMON[@]}" 2>&1 || true)
+prior=$(echo "$out" | awk '/^## Prior Loop Context/,0' | tail -n +2)
+if echo "$prior" | grep -q "PLAN_MARKER_BODY" && \
+   echo "$prior" | grep -q "VERDICT_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "DO_RED_MARKER_BODY"; then
+    pass "C1: planner internal fetch: plan+verdict in Prior Loop Context"
+else
+    fail "C1: planner internal fetch: plan+verdict in Prior Loop Context" \
+        "prior section: $prior"
+fi
+
+# C2: doer role, no --loop-context → only one-line summary under Prior Loop Context
+out=$("$BAC" --role doer "${BAC_C_COMMON[@]}" 2>&1 || true)
+prior=$(echo "$out" | awk '/^## Prior Loop Context/,0' | tail -n +2)
+if ! echo "$prior" | grep -q "PLAN_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "DO_RED_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "DO_GREEN_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "VERDICT_MARKER_BODY" && \
+   echo "$prior" | grep -q "### Iteration 1 — FAIL"; then
+    pass "C2: doer internal fetch: only summary in Prior Loop Context"
+else
+    fail "C2: doer internal fetch: only summary in Prior Loop Context" \
+        "prior section: $prior"
+fi
+
+# C3: checker role, no --loop-context → only verdict under Prior Loop Context
+out=$("$BAC" --role checker "${BAC_C_COMMON[@]}" 2>&1 || true)
+prior=$(echo "$out" | awk '/^## Prior Loop Context/,0' | tail -n +2)
+if echo "$prior" | grep -q "VERDICT_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "PLAN_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "DO_RED_MARKER_BODY" && \
+   ! echo "$prior" | grep -q "DO_GREEN_MARKER_BODY"; then
+    pass "C3: checker internal fetch: only verdict in Prior Loop Context"
+else
+    fail "C3: checker internal fetch: only verdict in Prior Loop Context" \
+        "prior section: $prior"
+fi
+
+# C4: explicit --loop-context passthrough honored, seeded markers bypassed
+out=$("$BAC" --role planner "${BAC_C_COMMON[@]}" \
+    --loop-context "LITERAL_SENTINEL" 2>&1 || true)
+prior=$(echo "$out" | awk '/^## Prior Loop Context/,0' | tail -n +2)
+if echo "$prior" | grep -q "LITERAL_SENTINEL" && \
+   ! echo "$prior" | grep -q "PLAN_MARKER_BODY"; then
+    pass "C4: explicit --loop-context passthrough honored, internal fetch bypassed"
+else
+    fail "C4: explicit --loop-context passthrough honored, internal fetch bypassed" \
+        "prior section: $prior"
+fi
+
+cd "$SAVED_DIR"
+rm -rf "$TMPDIR_C"
+trap '' EXIT
+
+# ---------------------------------------------------------------------------
+# Group D — planner.md Track A cleanup (static grep assertions)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Group D: planner.md Track A cleanup ==="
+
+PLANNER_FILE="$AGENTS_DIR/planner.md"
+
+# D1: Track A section no longer contains git-loop-context
+track_a_block=$(sed -n '/Track A/,/Track B/p' "$PLANNER_FILE" 2>/dev/null || true)
+if echo "$track_a_block" | grep -q "git-loop-context"; then
+    fail "D1: Track A should not contain git-loop-context" \
+        "Found git-loop-context in Track A block"
+else
+    pass "D1: Track A does not contain git-loop-context"
+fi
+
+# D2: Track A still contains detect-stack
+if echo "$track_a_block" | grep -q "detect-stack"; then
+    pass "D2: Track A still contains detect-stack"
+else
+    fail "D2: Track A still contains detect-stack" \
+        "detect-stack not found in Track A block"
+fi
+
+# D3: file mentions loop context is pre-injected / already injected
+if grep -qE "already.*injected|pre-injected" "$PLANNER_FILE"; then
+    pass "D3: planner.md mentions loop context is pre-injected"
+else
+    fail "D3: planner.md mentions loop context is pre-injected" \
+        "No match for 'already.*injected' or 'pre-injected' in planner.md"
+fi
+
+# D4: Available Skills entry for git-loop-context annotated
+avail_block=$(awk '/^## Available Skills/,/^## [^A]|^$/' "$PLANNER_FILE" 2>/dev/null | head -30 || true)
+glc_line=$(echo "$avail_block" | grep "git-loop-context" || true)
+if echo "$glc_line" | grep -qE "pre-injected|do not call manually"; then
+    pass "D4: git-loop-context Available Skills entry annotated"
+else
+    fail "D4: git-loop-context Available Skills entry annotated" \
+        "git-loop-context line in Available Skills: '$glc_line'"
+fi
+
+# ---------------------------------------------------------------------------
+# Group E — SKILL.md cleanup (static grep assertions)
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Group E: SKILL.md cleanup ==="
+
+# E1: SKILL.md does not contain LOOP_CONTEXT=$(... git-loop-context
+# shellcheck disable=SC2016
+if grep -qE 'LOOP_CONTEXT=\$\(.*git-loop-context' "$SKILL_FILE"; then
+    fail "E1: SKILL.md should not have upstream shared LOOP_CONTEXT fetch" \
+        "Found LOOP_CONTEXT=\$(... git-loop-context in SKILL.md"
+else
+    pass "E1: SKILL.md does not have upstream shared LOOP_CONTEXT fetch"
+fi
+
+# E2: CTX_COMMON in SKILL.md does not contain --loop-context
+ctx_block=$(awk '/CTX_COMMON/,/\)/' "$SKILL_FILE" 2>/dev/null | head -20 || true)
+if echo "$ctx_block" | grep -q "\-\-loop-context"; then
+    fail "E2: CTX_COMMON in SKILL.md should not contain --loop-context" \
+        "Found --loop-context in CTX_COMMON block"
+else
+    pass "E2: CTX_COMMON in SKILL.md does not contain --loop-context"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/plugins/looper/tests/test-loop-context-trim.sh
+++ b/plugins/looper/tests/test-loop-context-trim.sh
@@ -399,13 +399,15 @@ else
 fi
 
 # D4: Available Skills entry for git-loop-context annotated
-avail_block=$(awk '/^## Available Skills/,/^## [^A]|^$/' "$PLANNER_FILE" 2>/dev/null | head -30 || true)
-glc_line=$(echo "$avail_block" | grep "git-loop-context" || true)
-if echo "$glc_line" | grep -qE "pre-injected|do not call manually"; then
+# Extract section from ## Available Skills to next ## header
+avail_block=$(awk '/^## Available Skills/{found=1;next} found && /^## /{exit} found{print}' "$PLANNER_FILE" 2>/dev/null || true)
+glc_annotation=$(echo "$avail_block" | grep -A2 "git-loop-context" | grep -E "pre-injected|do not call manually" || true)
+if [ -n "$glc_annotation" ]; then
     pass "D4: git-loop-context Available Skills entry annotated"
 else
+    glc_line=$(echo "$avail_block" | grep "git-loop-context" || true)
     fail "D4: git-loop-context Available Skills entry annotated" \
-        "git-loop-context line in Available Skills: '$glc_line'"
+        "git-loop-context line/context in Available Skills: '$glc_line'"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Task

Closes #81.

Planner/Doer/Checker each pay input tokens every iteration for content that is either duplicated across roles or unchanged since iteration 1. Three structural leaks: (1) the full `<project-context>` block is re-injected on every iteration even though it hasn't changed, (2) the same monolithic `LOOP_CONTEXT` is fed identically to all three roles even though each needs a different slice, and (3) the Planner re-invokes `git-loop-context` in Track A while the same content is already in its prompt.

**Current behavior:** all three agents receive the full project-context block + full loop-context on every iteration; Planner also calls `git-loop-context` a second time.
**Expected behavior:** project-context appears in full only on iteration 1; each role receives only the loop-context slice it needs; Planner Track A no longer re-fetches.

## Existing Architecture

`build-agent-context` hands the same `LOOP_CONTEXT` and `<project-context>` to every role. The Planner prompt then calls `git-loop-context` again via Bash.

```mermaid
graph TD
    SKILL[SKILL.md step 7a] -->|LOOP_CONTEXT fetched once| BAC[build-agent-context]
    BAC -->|same loop-ctx<br/>+ full project-ctx| P[Planner]
    BAC -->|same loop-ctx<br/>+ full project-ctx| D[Doer]
    BAC -->|same loop-ctx<br/>+ full project-ctx| C[Checker]
    P -->|Track A calls<br/>git-loop-context AGAIN| GLC[(git-loop-context)]
    SKILL --> GLC
    style BAC fill:#f66,stroke:#333
    style P fill:#f66,stroke:#333
```

## Proposed Architecture

`git-loop-context` gains a `--role` flag so each role gets only what it needs. `build-agent-context` fetches per-role internally and collapses `<project-context>` to a pointer on iter > 1. Planner Track A drops the redundant call.

```mermaid
graph TD
    SKILL[SKILL.md step 7a<br/>no shared fetch] --> BAC[build-agent-context<br/>per-role fetch + iter>1 pruning]
    BAC -->|role=planner:<br/>plan+verdict bodies| P[Planner]
    BAC -->|role=doer:<br/>one-line per iter| D[Doer]
    BAC -->|role=checker:<br/>verdict bodies only| C[Checker]
    BAC -->|--role flag| GLC[(git-loop-context)]
    P -.->|Track A: no more call| GLC
    style BAC fill:#6f6,stroke:#333
    style GLC fill:#69f,stroke:#333
    style P fill:#69f,stroke:#333
```

## Key Changes

**`git-loop-context` — new `--role` flag**
- `--role planner` returns prior plan body + last Checker verdict body.
- `--role doer` returns a one-line summary (`### Iteration N — VERDICT`) per prior iteration.
- `--role checker` returns only prior Checker verdict bodies.
- Absent/empty `--role` preserves the original full-output behavior (backward compat).
- Invalid role exits non-zero with a clear stderr message.

**`build-agent-context` — iter>1 pruning + internal per-role fetch**
- `<project-context>` keeps its tags on iter > 1 but collapses to a one-line pointer (`See Planner commit from iteration 1 — project context unchanged.`).
- If `--loop-context` is omitted, fetches internally via `git-loop-context --role $ROLE` instead of requiring the caller to pre-fetch.
- Explicit `--loop-context` passthrough still honored (for tests / custom drivers).
- Dropped the stale "pruning note" trailer block — advice now lives in `planner.md`.

**`SKILL.md` — upstream fetch removed**
- Step 7a no longer calls `git-loop-context` up front.
- `--loop-context` dropped from the shared `CTX_COMMON` array; each `build-agent-context --role <X>` call fetches its own slice.

**`planner.md` — Track A cleanup**
- Track A now runs only `detect-stack` and a note that loop context is pre-injected as `## Prior Loop Context`.
- `git-loop-context` in Available Skills is annotated `(pre-injected; do not call manually)`.

## Tests & Checks

New `plugins/looper/tests/test-loop-context-trim.sh` covers 22 assertions across 5 groups:
- **A (7):** `--role` flag behavior — valid/invalid roles, planner/doer/checker scoping, legacy fall-through.
- **B (5):** `<project-context>` full on iter 1, collapsed on iter > 1 across all roles.
- **C (4):** internal per-role fetch + explicit `--loop-context` passthrough.
- **D (4):** `planner.md` Track A and Available Skills static assertions.
- **E (2):** `SKILL.md` has no upstream fetch and no `--loop-context` in `CTX_COMMON`.

| Check | Status | Details |
|-------|--------|---------|
| New test suite | ✅ | 22 passed, 0 failed |
| shellcheck (both scripts) | ✅ | clean |
| Cargo test | ✅ | 100 passed |
| Cargo clippy | ✅ | clean, no warnings |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)