### PR TITLE
fix(checker): add BLOCKER+TechStack rule to checker.md (#83)

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -296,6 +296,12 @@ If any convention is violated, flag it in your verdict.
   (UI, API endpoints, CLI behavior) and Subagent 4 could not run integration
   tests (reports "N/A"), flag this as [WARNING] in the verdict. The Doer
   should ensure adequate test coverage compensates for the lack of manual testing.
+- **Tech Stack Compliance:** Tech-stack violations reported by Subagent 3
+  (check-code) — files from a wrong ecosystem, dependencies from a
+  different package manager, or a framework other than the one the plan
+  specifies — are treated as [BLOCKER] severity and MUST cause a FAIL
+  verdict until fixed. Flag each violation as [BLOCKER] — Tech Stack
+  Compliance failure with the offending file path.
 - **Always use `$LOOPER_DEV_PORT`** for any dev server started during review.
   Never use the project's default port — this avoids conflicts with the user's
   running dev server in the main repo.


### PR DESCRIPTION
Fixes #83.

## Problem / Task

`plugins/looper/tests/test-tech-stack-prompts.sh` asserts that `plugins/looper/agents/checker.md` contains the BRE pattern `BLOCKER.*[Tt]ech [Ss]tack\|[Tt]ech [Ss]tack.*BLOCKER` — i.e. that the Checker agent explicitly classifies wrong-ecosystem tech-stack violations as `[BLOCKER]`. The pattern was missing, so assertion #6 failed (`5 passed, 1 failed`). This left a gap between the agent-prompt test suite and the Checker's rules: the Planner and Doer both already have explicit "Tech stack compliance" rules, but the Checker didn't tie tech-stack violations to the BLOCKER severity tier the test expects.

**Current behavior:** `test-tech-stack-prompts.sh` exits 1 (5/6 assertions pass).
**Expected behavior:** all 6 assertions pass; the Checker prompt explicitly flags wrong-ecosystem / wrong-package-manager / wrong-framework files reported by the `check-code` subagent as `[BLOCKER]` severity, forcing a FAIL verdict until fixed.

## Existing Architecture

The `check-code` subagent already flagged tech-stack violations (see `plugins/looper/agents/check-code.md`), but the Checker's `## Rules` section in `checker.md` did not mandate that those violations be escalated to `[BLOCKER]` in the final verdict. Downstream test and the Planner/Doer prompts assumed this escalation; the Checker prompt did not.

```mermaid
graph TD
    Doer["Doer agent"] -->|"commits code"| Checker["Checker agent (checker.md)"]
    Checker --> S3["Subagent 3: check-code"]
    S3 -.->|"tech-stack violation reported"| Rules["checker.md ## Rules (no BLOCKER mapping)"]
    Rules -->|"severity unclear"| Verdict["Verdict"]
    Test["test-tech-stack-prompts.sh assertion #6"] -.->|"grep fails"| Rules
    style Rules fill:#f66,stroke:#333
    style Test fill:#f66,stroke:#333
```

## Proposed Architecture

A single new bullet in `checker.md` → `## Rules` ties tech-stack violations from subagent 3 to the `[BLOCKER]` severity tier, mandating a FAIL verdict until fixed. No other files change.

```mermaid
graph TD
    Doer["Doer agent"] -->|"commits code"| Checker["Checker agent (checker.md)"]
    Checker --> S3["Subagent 3: check-code"]
    S3 -->|"tech-stack violation reported"| Rules["checker.md ## Rules (now includes Tech Stack Compliance = BLOCKER)"]
    Rules -->|"[BLOCKER] → FAIL"| Verdict["Verdict: FAIL"]
    Test["test-tech-stack-prompts.sh assertion #6"] -->|"grep matches"| Rules
    style Rules fill:#6f6,stroke:#333
    style Test fill:#6f6,stroke:#333
```

## Key Changes

- **`plugins/looper/agents/checker.md`** — added a single `**Tech Stack Compliance:**` bullet to the `## Rules` section, inserted between "Integration test strictness" and "Always use `$LOOPER_DEV_PORT`". The bullet states that tech-stack violations from subagent 3 (check-code) are `[BLOCKER]` and must cause a FAIL verdict until fixed. The substring `[BLOCKER] — Tech Stack Compliance failure` sits on a single physical line so the BRE grep `BLOCKER.*[Tt]ech [Ss]tack` matches.
- No code, tests, or other prompts modified. `check-code.md` already uses the matching `[BLOCKER] — Tech Stack Compliance failure` wording, so severity is consistent between subagent and orchestrator.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| `test-tech-stack-prompts.sh` | ✅ | 6 passed, 0 failed (previously 5/1) |
| `test-checker-structure.sh` | ✅ | 40 passed, 0 failed (checker.md still under 350-line cap: 322 lines) |
| `test-agent-definitions.sh` | ✅ | 90 passed, 0 failed |
| ShellCheck | ✅ | clean over scripts + backends |
| JSON validation (`plugin.json`, `marketplace.json`) | ✅ | valid |
| `cargo test --workspace` | ✅ | 100 passed |
| `cargo clippy --workspace -- -D warnings` | ✅ | clean |

---