### PR TITLE
fix(looper-watch): move kill_all_repo_sessions before test module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.47.4"
+version = "0.47.6"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/looper-watch/src/state.rs
+++ b/crates/looper-watch/src/state.rs
@@ -234,6 +234,18 @@ pub async fn list_repo_sessions_with_age(repo: &str) -> Vec<(String, Option<i64>
     }
 }
 
+/// Kill all tmux sessions for this repo.
+pub async fn kill_all_repo_sessions(repo: &str) -> usize {
+    let sessions = list_repo_sessions(repo).await;
+    for s in &sessions {
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", s.as_str()])
+            .output()
+            .await;
+    }
+    sessions.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -541,16 +553,4 @@ mod tests {
 
         let _ = tokio::fs::remove_file(&path).await;
     }
-}
-
-/// Kill all tmux sessions for this repo.
-pub async fn kill_all_repo_sessions(repo: &str) -> usize {
-    let sessions = list_repo_sessions(repo).await;
-    for s in &sessions {
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", s.as_str()])
-            .output()
-            .await;
-    }
-    sessions.len()
 }


### PR DESCRIPTION
## Problem / Task

The `clippy::items-after-test-module` lint (default-warn in current clippy) fires in CI when running `cargo clippy --workspace --all-targets -- -D warnings`, because the public async function `kill_all_repo_sessions` was declared after the `#[cfg(test)] mod tests` block in `crates/looper-watch/src/state.rs`. Since CI treats warnings as errors, this broke the workspace clippy gate on the default branch.

**Current behavior:** `cargo clippy --workspace --all-targets -- -D warnings` fails with `error: items after a test module` at `crates/looper-watch/src/state.rs:238`.
**Expected behavior:** Clippy is clean; all non-test items are declared before `#[cfg(test)] mod tests`. Closes #84.

## Existing Architecture

`state.rs` is a single module. All its public/private items should live above the `#[cfg(test)]` test module per the lint rule. Before this PR, exactly one offender existed: `pub async fn kill_all_repo_sessions` was placed after the test module. Its sole external caller is `state::kill_all_repo_sessions(repo).await` inside `crates/looper-watch/src/worker.rs`, so the call path only depends on the module-level name and is not affected by the in-file position.

```mermaid
graph TD
    W[worker.rs::spawn_cleanup] -->|"state::kill_all_repo_sessions(repo)"| SKAR
    subgraph SR["state.rs (before)"]
        direction TB
        LRS["list_repo_sessions (line 195)"]
        OTHER["... other items ..."]
        TESTS["#cfg(test) mod tests (lines 237-544)"]
        SKAR["pub async fn kill_all_repo_sessions (lines 546-556)"]
        LRS --> OTHER
        OTHER --> TESTS
        TESTS --> SKAR
    end
    style SKAR fill:#f66,stroke:#333
    style TESTS fill:#ff6,stroke:#333
```

## Proposed Architecture

The function is relocated byte-identically (doc comment + `pub async fn` signature + body preserved) to sit immediately before the `#[cfg(test)]` attribute. Its only internal dependency (`list_repo_sessions`) already lives earlier in the file, so there is no forward-reference risk. `worker.rs` is untouched because the module-qualified call path is unchanged.

```mermaid
graph TD
    W[worker.rs::spawn_cleanup] -->|"state::kill_all_repo_sessions(repo)"| SKAR
    subgraph SR["state.rs (after)"]
        direction TB
        LRS["list_repo_sessions (line 195)"]
        OTHER["... other items ..."]
        SKAR["pub async fn kill_all_repo_sessions (lines 237-247)"]
        TESTS["#cfg(test) mod tests (lines 249-556)"]
        LRS --> OTHER
        OTHER --> SKAR
        SKAR --> TESTS
    end
    style SKAR fill:#6f6,stroke:#333
    style TESTS fill:#6f6,stroke:#333
```

## Key Changes

- **`crates/looper-watch/src/state.rs`** — Moved the 11-line `kill_all_repo_sessions` block (doc comment + `pub async fn` + body) from post-`mod tests` position to just before `#[cfg(test)]`. No `#[allow(...)]` suppression was introduced; the lint was resolved by fixing the code arrangement. Function body, signature, visibility, and doc comment are byte-identical to the original.
- **No changes to `worker.rs`** — The sole external caller uses the module-qualified path `state::kill_all_repo_sessions`, so an intra-file move is transparent to it.
- **`Cargo.lock`** — Carries an upstream workspace version bump (0.47.4 → 0.47.6) already present on `alpha` that became visible after cargo regenerated the lockfile in this worktree; no new or changed dependencies.

## Tests & Checks

All gates run inside the worktree during the PDC loop's Checker phase:

| Check | Status | Details |
|-------|--------|---------|
| `cargo clippy --workspace --all-targets -- -D warnings` | PASS | zero warnings |
| `cargo test -p looper-watch` | PASS | 100 / 100 pass |
| `cargo test --workspace` | PASS | full suite green |
| `cargo build --workspace` | PASS | success |
| `cargo fmt -p looper-watch -- --check` | PASS | no formatting drift |

The lint itself acts as the permanent regression test — CI's `-D warnings` gate will reject any future regression.

---
🤖 Generated by looper PDC loop (iteration 1 → PASS)