### PR TITLE
refactor(looper): self-locating spawn-agent + PATH wrapper (#88)

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -16,7 +16,8 @@ reviewer — report all findings but do NOT fix code or modify any files.
 
 ## Instructions
 
-`SUBAGENTS_DIR="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts"`
+Spawn subagents via the `claude-spawn-agent` command (on `PATH` in every
+context, self-locates its plugin root — no env setup required).
 
 1. **Verify Doer committed work and run TDD sequence checks** — The Doer must
    produce two or three commits per iteration: `do-red` (tests), `do-green`
@@ -122,19 +123,19 @@ reviewer — report all findings but do NOT fix code or modify any files.
    The values for `$TASK_NAME` and `$ITERATION` are provided in the dynamic
    context injected into this session.
 
-3. **Spawn 5 parallel review subagents** — Launch all five as parallel spawn-agent
-   calls in a single Bash command. Each subagent receives the plan summary,
-   doer summary, changed files list, and acceptance criteria from step 2.
+3. **Spawn 5 parallel review subagents** — Launch all five as parallel
+   claude-spawn-agent calls in a single Bash command. Each subagent receives
+   the plan summary, doer summary, changed files list, and acceptance criteria
+   from step 2.
 
    ```bash
    TMPDIR="/tmp/looper-${TASK_NAME}"
    mkdir -p "$TMPDIR"
-   SPAWN="$SUBAGENTS_DIR/spawn-agent"
-   $SPAWN "looper:check-build" "<context>" > "$TMPDIR/check-build.txt" &
-   $SPAWN "looper:check-tests" "<context>" > "$TMPDIR/check-tests.txt" &
-   $SPAWN "looper:check-code" "<context>" > "$TMPDIR/check-code.txt" &
-   $SPAWN "looper:check-runtime" "<context>" > "$TMPDIR/check-runtime.txt" &
-   $SPAWN "looper:check-adversarial" "<context>" > "$TMPDIR/check-adversarial.txt" &
+   claude-spawn-agent "looper:check-build" "<context>" > "$TMPDIR/check-build.txt" &
+   claude-spawn-agent "looper:check-tests" "<context>" > "$TMPDIR/check-tests.txt" &
+   claude-spawn-agent "looper:check-code" "<context>" > "$TMPDIR/check-code.txt" &
+   claude-spawn-agent "looper:check-runtime" "<context>" > "$TMPDIR/check-runtime.txt" &
+   claude-spawn-agent "looper:check-adversarial" "<context>" > "$TMPDIR/check-adversarial.txt" &
    wait
    cat "$TMPDIR"/check-*.txt
    ```
@@ -174,7 +175,7 @@ reviewer — report all findings but do NOT fix code or modify any files.
    error-path failures the happy-path tests miss. Proposes concrete failing
    test cases. See `agents/check-adversarial.md` for full instructions.
 
-   All five MUST be launched as parallel spawn-agent calls in a single Bash command.
+   All five MUST be launched as parallel claude-spawn-agent calls in a single Bash command.
 
 4. **Collect and consolidate results** — After all 5 subagents complete:
    - Gather all BLOCKER issues from TDD checks in step 1 and subagent reports
@@ -311,7 +312,7 @@ If any convention is violated, flag it in your verdict.
   NOT include them in the PASS/FAIL verdict — they are out of scope. Instead,
   spawn a fire-and-forget `looper:gh-issue-creator` subagent for each:
   ```bash
-  $SUBAGENTS_DIR/spawn-agent "looper:gh-issue-creator" "Type: bug (or feature/improvement)
+  claude-spawn-agent "looper:gh-issue-creator" "Type: bug (or feature/improvement)
   File(s): <file paths>
   Description: <what the issue is>
   Observed behavior: <what happens>

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -25,7 +25,8 @@ write failing tests first, then write just enough code to make them pass.
    The values for `$TASK_NAME` and `$ITERATION` are provided in the dynamic
    context injected into this session.
 
-   `SUBAGENTS_DIR="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts"`
+   Spawn subagents via the `claude-spawn-agent` command (on `PATH` in every
+   context, self-locates its plugin root — no env setup required).
 
 2. **Size guard for oversize plans.** If the plan commit body exceeds ~400 lines,
    do NOT try to hold the entire plan in working context. Extract only the focused
@@ -52,9 +53,8 @@ write failing tests first, then write just enough code to make them pass.
    faster than subagent overhead).
 
    ```bash
-   SPAWN="$SUBAGENTS_DIR/spawn-agent"
-   $SPAWN "Explore" "<prompt for source files>" > /tmp/explore-src.txt &
-   $SPAWN "Explore" "<prompt for test files>" > /tmp/explore-tests.txt &
+   claude-spawn-agent "Explore" "<prompt for source files>" > /tmp/explore-src.txt &
+   claude-spawn-agent "Explore" "<prompt for test files>" > /tmp/explore-tests.txt &
    wait
    cat /tmp/explore-src.txt /tmp/explore-tests.txt
    ```
@@ -150,9 +150,8 @@ If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
    After subagents complete, review for consistency between groups.
 
    ```bash
-   SPAWN="$SUBAGENTS_DIR/spawn-agent"
-   $SPAWN "general-purpose" "<prompt for area 1>" > /tmp/impl1.txt &
-   $SPAWN "general-purpose" "<prompt for area 2>" > /tmp/impl2.txt &
+   claude-spawn-agent "general-purpose" "<prompt for area 1>" > /tmp/impl1.txt &
+   claude-spawn-agent "general-purpose" "<prompt for area 2>" > /tmp/impl2.txt &
    wait
    ```
 
@@ -183,7 +182,7 @@ If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
    STOP guessing and spawn the systematic debugger** before attempting a third
    fix. Random patches mask root causes and waste loop iterations.
    ```bash
-   $SUBAGENTS_DIR/spawn-agent "looper:debugger" "Iteration: $ITERATION
+   claude-spawn-agent "looper:debugger" "Iteration: $ITERATION
    Task: $TASK_NAME
    Failing test(s): <test name + full error output>
    GREEN commit files: <list>
@@ -239,7 +238,7 @@ If it exists, skip this phase entirely.
 
    Then spawn the simplifier:
    ```bash
-   $SUBAGENTS_DIR/spawn-agent "general-purpose" "You are a code simplifier. Review and simplify these files: <files>. Reduce redundancy, flatten nesting, improve naming, remove dead code. Preserve all behavior."
+   claude-spawn-agent "general-purpose" "You are a code simplifier. Review and simplify these files: <files>. Reduce redundancy, flatten nesting, improve naming, remove dead code. Preserve all behavior."
    ```
 
    If the subagent made no changes (code was already clean), skip the commit
@@ -409,7 +408,7 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
   that is unrelated to your current task, do NOT fix it — stay on scope.
   Instead, spawn a fire-and-forget `looper:gh-issue-creator` subagent:
   ```bash
-  $SUBAGENTS_DIR/spawn-agent "looper:gh-issue-creator" "Type: bug (or feature/improvement)
+  claude-spawn-agent "looper:gh-issue-creator" "Type: bug (or feature/improvement)
   File(s): <file paths>
   Description: <what the issue is>
   Observed behavior: <what happens>

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -17,7 +17,9 @@ modify any project files — only commit a plan as a git commit message.
 
 ## Instructions
 
-`SUBAGENTS_DIR="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts"`
+Spawn subagents via the `claude-spawn-agent` command, which Claude Code
+exposes on `PATH` in every context (main session and subagents alike) and
+which self-locates its plugin root. No env-var setup is required from you.
 
 1. **Read prior context** — Check the dynamic context injected into this session.
    If this is not iteration 1, study the loop context carefully. Understand what
@@ -46,18 +48,18 @@ modify any project files — only commit a plan as a git commit message.
      source directory, test directory
    - **Track C:** If iteration > 1, spawn an Explore subagent to
      investigate files referenced in the Checker's prior feedback:
-     `$SUBAGENTS_DIR/spawn-agent "Explore" "<prompt>"`
+     `claude-spawn-agent "Explore" "<prompt>"`
      **In addition**, if the prior iteration FAILed on the same symptom that
      a still-earlier iteration also failed on (i.e. the loop is stuck on the
      same problem), spawn the systematic debugger in parallel to root-cause
      it before you write the new plan:
-     `$SUBAGENTS_DIR/spawn-agent "looper:debugger" "<prior FAIL feedback +
+     `claude-spawn-agent "looper:debugger" "<prior FAIL feedback +
      failing test names + error output + files touched so far>"`
      Use the debugger's Root Cause and Recommended Fix sections as the
      foundation for the new plan instead of guessing a different approach.
    - **Track D:** If iteration 1 AND the
      task is a bug fix or involves changing runtime behavior of a web app/API/CLI,
-     use `$SUBAGENTS_DIR/spawn-agent "Explore" "<prompt>"` to spawn a subagent to **observe the current behavior before planning**:
+     use `claude-spawn-agent "Explore" "<prompt>"` to spawn a subagent to **observe the current behavior before planning**:
      1. Run `$SCRIPTS_DIR/detect-stack` to identify the project type
      2. If `HAS_COMPOSE` is `true`: start backing services first:
         `$SCRIPTS_DIR/compose-lifecycle up --task $TASK_NAME` and
@@ -79,7 +81,7 @@ modify any project files — only commit a plan as a git commit message.
      Pass it the reproduction steps, observed vs expected behavior, the exact
      error output, and the issue description:
      ```bash
-     $SUBAGENTS_DIR/spawn-agent "looper:debugger" "Task: $TASK_NAME (iteration 1, bug fix)
+     claude-spawn-agent "looper:debugger" "Task: $TASK_NAME (iteration 1, bug fix)
      Issue: <issue title + body>
      Reproduction: <steps from Track D>
      Observed: <what Track D actually saw>
@@ -179,7 +181,7 @@ modify any project files — only commit a plan as a git commit message.
    details ("function Z should call W").
 
 4.5. **Review the draft plan (parallel subagents)** — Spawn 3 review subagents
-   in parallel via spawn-agent calls in a single Bash block. Each receives
+   in parallel via claude-spawn-agent calls in a single Bash block. Each receives
    the draft plan text and the task context. They are read-only reporters — they
    do NOT modify anything.
 
@@ -187,10 +189,9 @@ modify any project files — only commit a plan as a git commit message.
    ```bash
    TMPDIR="/tmp/looper-${TASK_NAME}"
    mkdir -p "$TMPDIR"
-   SPAWN="$SUBAGENTS_DIR/spawn-agent"
-   $SPAWN "looper:plan-feasibility" "<context>" > "$TMPDIR/plan-feasibility.txt" &
-   $SPAWN "looper:plan-completeness" "<context>" > "$TMPDIR/plan-completeness.txt" &
-   $SPAWN "looper:plan-scope" "<context>" > "$TMPDIR/plan-scope.txt" &
+   claude-spawn-agent "looper:plan-feasibility" "<context>" > "$TMPDIR/plan-feasibility.txt" &
+   claude-spawn-agent "looper:plan-completeness" "<context>" > "$TMPDIR/plan-completeness.txt" &
+   claude-spawn-agent "looper:plan-scope" "<context>" > "$TMPDIR/plan-scope.txt" &
    wait
    cat "$TMPDIR"/plan-*.txt
    ```
@@ -211,7 +212,7 @@ modify any project files — only commit a plan as a git commit message.
    Reviews plan scope for unnecessary changes and over-engineering.
    See `agents/plan-scope.md` for full instructions.
 
-   All three MUST be launched as parallel spawn-agent calls in one message.
+   All three MUST be launched as parallel claude-spawn-agent calls in one message.
 
 4.6. **Revise the plan** — After all 3 subagents return:
    1. Collect all BLOCKER findings — these must be addressed
@@ -278,13 +279,13 @@ The `$SCRIPTS_DIR` path is injected as a task variable in your dynamic context.
 - **Unrelated bugs or improvements:** If you discover a bug, missing feature,
   or improvement that is unrelated to your current task, do NOT include it in
   your plan. Instead, spawn a fire-and-forget `looper:gh-issue-creator` subagent:
-  ```
-  Type: bug (or feature/improvement)
+  ```bash
+  claude-spawn-agent "looper:gh-issue-creator" "Type: bug (or feature/improvement)
   File(s): <file paths>
   Description: <what the issue is>
   Observed behavior: <what happens>
   Expected behavior: <what should happen>
-  Found by: Planner agent during task "<TASK_NAME>"
+  Found by: Planner agent during task \"<TASK_NAME>\"" &
   ```
   Continue with your planning — do not wait for the subagent to finish.
 

--- a/plugins/looper/bin/claude-spawn-agent
+++ b/plugins/looper/bin/claude-spawn-agent
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Thin wrapper so callers can invoke spawn-agent by name from PATH.
+# Claude Code puts plugin bin/ on PATH in all contexts including subagents,
+# so this resolves without any env-var or plugin-root knowledge from the caller.
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/subagents/scripts/spawn-agent" "$@"

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -18,23 +18,24 @@ the loop, determine which mechanism to use:
 
 - **If the `Agent` tool is NOT in your toolset** (you are running inside a
   subagent, a `claude -p` session, or any non-interactive context where looper
-  was invoked by another agent): you MUST fall back to the `subagents` skill's
-  `spawn-agent` script. Do not attempt to call `Agent(...)` — it will fail.
-  Invoke the skill once (`Skill("subagents")`) to load its guidance, then use
-  the `--async` pattern below.
+  was invoked by another agent): you MUST fall back to the `claude-spawn-agent`
+  command. Do not attempt to call `Agent(...)` — it will fail.
+
+  `claude-spawn-agent` is on `PATH` in every Claude Code context (including
+  subagents) and self-locates its plugin root, so no env-var or path setup is
+  needed — just call it by name.
 
   **CRITICAL — stream watchdog:** Nested agents (planner/doer/checker) regularly
   run for several minutes. Parent agents have a stream watchdog that kills the
-  child after ~600s of no tool-call activity. Do NOT run `spawn-agent` in
-  synchronous mode (`RESULT=$($SPAWN ...)`) — that single blocking Bash call
-  will trip the watchdog on any non-trivial subagent. Instead, launch `--async`
-  and poll with short bounded Bash calls so each poll emits a tool event that
-  keeps the watchdog alive.
+  child after ~600s of no tool-call activity. Do NOT run `claude-spawn-agent`
+  in synchronous mode (`RESULT=$(claude-spawn-agent ...)`) — that single
+  blocking Bash call will trip the watchdog on any non-trivial subagent.
+  Instead, launch `--async` and poll with short bounded Bash calls so each
+  poll emits a tool event that keeps the watchdog alive.
 
   ```bash
-  SPAWN="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts/spawn-agent"
   # 1. Fire async — returns result path instantly, subagent runs in background.
-  RESULT_PATH=$($SPAWN --async "looper:planner" "$PLANNER_CONTEXT")
+  RESULT_PATH=$(claude-spawn-agent --async "looper:planner" "$PLANNER_CONTEXT")
   ```
 
   Then poll in a loop. Each Bash call is short (≤60s), so the watchdog resets
@@ -54,8 +55,8 @@ the loop, determine which mechanism to use:
   ```
 
   Every `Agent(subagent_type="X", prompt="Y")` call below has an equivalent
-  `$SPAWN --async "X" "Y"` + poll form. Use whichever is appropriate for your
-  context.
+  `claude-spawn-agent --async "X" "Y"` + poll form. Use whichever is
+  appropriate for your context.
 
 ## Steps
 
@@ -246,11 +247,11 @@ to complete before proceeding to the next.
 
 1. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: PLAN phase ===`
    `Agent(subagent_type="looper:planner", prompt=<Planner context from 7c>)`
-   (Fallback when Agent tool is unavailable: `$SPAWN --async "looper:planner" "$PLANNER_CONTEXT"` + poll, per "Agent spawning mode")
+   (Fallback when Agent tool is unavailable: `claude-spawn-agent --async "looper:planner" "$PLANNER_CONTEXT"` + poll, per "Agent spawning mode")
 
 2. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: DO phase (TDD: red→green) ===`
    `Agent(subagent_type="looper:doer", prompt=<Doer context from 7c>)`
-   (Fallback when Agent tool is unavailable: `$SPAWN --async "looper:doer" "$DOER_CONTEXT"` + poll, per "Agent spawning mode")
+   (Fallback when Agent tool is unavailable: `claude-spawn-agent --async "looper:doer" "$DOER_CONTEXT"` + poll, per "Agent spawning mode")
 
    Before spawning the Checker, run mechanical pre-checks:
    ```bash
@@ -269,7 +270,7 @@ to complete before proceeding to the next.
 
 3. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: CHECK phase ===`
    `Agent(subagent_type="looper:checker", prompt=<Checker context from 7c>)`
-   (Fallback when Agent tool is unavailable: `$SPAWN --async "looper:checker" "$CHECKER_CONTEXT"` + poll, per "Agent spawning mode")
+   (Fallback when Agent tool is unavailable: `claude-spawn-agent --async "looper:checker" "$CHECKER_CONTEXT"` + poll, per "Agent spawning mode")
 
 #### 7e. Read verdict
 

--- a/plugins/looper/skills/subagents/SKILL.md
+++ b/plugins/looper/skills/subagents/SKILL.md
@@ -59,11 +59,16 @@ Report the full list to the user before proceeding.
 
 ## Phase 2: Spawn a subagent
 
-Use the `spawn-agent` script to call a subagent. It handles nested-session detection bypass, JSON output, and permission skipping.
+Use the `claude-spawn-agent` command to call a subagent. It handles nested-session detection bypass, JSON output, and permission skipping.
 
-```
-Scripts: ${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts/
-```
+Claude Code puts every plugin's `bin/` directory on `PATH` in all contexts —
+main session, Agent-tool subagents, and fresh `claude -p` subprocesses alike —
+so `claude-spawn-agent` resolves without any caller-side configuration. The
+underlying script self-locates its `CLAUDE_PLUGIN_ROOT` from its own path
+(the plugin root is derived from `BASH_SOURCE`), so plugin-scoped agents like
+`looper:checker` continue to resolve even when `CLAUDE_PLUGIN_ROOT` is unset
+in the caller's environment. Callers never need to know the plugin's install
+layout or export any env vars.
 
 ### Sync mode (default)
 
@@ -73,15 +78,13 @@ Blocks until the subagent completes. Prints the path to the result file.
 foreground mode).
 
 ```bash
-SPAWN="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts/spawn-agent"
-
 # Run in background, then read result
-$SPAWN "looper:checker" "Review the doer's work" # prints /tmp/subagent-response-<ts>-<pid>.txt
+claude-spawn-agent "looper:checker" "Review the doer's work" # prints /tmp/subagent-response-<ts>-<pid>.txt
 ```
 
 ```bash
 # Full pattern: launch in background Bash, read result file after
-RESULT=$($SPAWN "Explore" "What language is this repo?")
+RESULT=$(claude-spawn-agent "Explore" "What language is this repo?")
 cat "$RESULT"
 ```
 
@@ -91,10 +94,8 @@ Returns the result file path immediately, runs the subagent in background.
 Ideal for parallel spawning — fire multiple agents, do other work, read later.
 
 ```bash
-SPAWN="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts/spawn-agent"
-
 # Fire and get path back instantly
-RESULT=$($SPAWN --async "Explore" "Find all API endpoints")
+RESULT=$(claude-spawn-agent --async "Explore" "Find all API endpoints")
 # ... do other work ...
 # Poll until file is non-empty
 cat "$RESULT"
@@ -103,10 +104,8 @@ cat "$RESULT"
 ### Run multiple subagents in parallel (async)
 
 ```bash
-SPAWN="${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts/spawn-agent"
-
-R1=$($SPAWN --async "looper:planner" "Plan how to add rate limiting")
-R2=$($SPAWN --async "Explore" "Find all API endpoint definitions")
+R1=$(claude-spawn-agent --async "looper:planner" "Plan how to add rate limiting")
+R2=$(claude-spawn-agent --async "Explore" "Find all API endpoint definitions")
 
 # Wait for both to finish (poll until files are non-empty)
 while [ ! -s "$R1" ] || [ ! -s "$R2" ]; do sleep 2; done
@@ -119,13 +118,13 @@ echo "=== Explore ===" && cat "$R2"
 
 ```bash
 # Limit turns and budget
-$SPAWN "looper:planner" "Plan the auth refactor" --max-turns 10 --max-budget-usd 0.50
+claude-spawn-agent "looper:planner" "Plan the auth refactor" --max-turns 10 --max-budget-usd 0.50
 
 # Pass file contents in the prompt
-$SPAWN "Explore" "What does this code do: $(cat src/main.ts)"
+claude-spawn-agent "Explore" "What does this code do: $(cat src/main.ts)"
 
 # Pass a system prompt
-$SPAWN "general-purpose" "Your prompt" \
+claude-spawn-agent "general-purpose" "Your prompt" \
   --append-system-prompt "You are working on a Node.js backend."
 ```
 

--- a/plugins/looper/skills/subagents/scripts/spawn-agent
+++ b/plugins/looper/skills/subagents/scripts/spawn-agent
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Self-locate: derive CLAUDE_PLUGIN_ROOT from this script's own path.
+# spawn-agent lives at <PLUGIN_ROOT>/skills/subagents/scripts/spawn-agent,
+# so the plugin root is three directories up. The ${VAR:-default} guard
+# preserves any value the caller may have already exported.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$_SCRIPT_DIR/../../.." && pwd)}"
+
 # Spawns a Claude subagent via claude -p and returns the text response.
 # Bypasses nested-session detection and skips permission prompts.
 #


### PR DESCRIPTION
## Summary

- `spawn-agent` now self-locates `CLAUDE_PLUGIN_ROOT` from its own `BASH_SOURCE` path (three dirs up) when unset, and `export`s it so `claude -p` subprocesses inherit it. Any existing `CLAUDE_PLUGIN_ROOT` the caller set is preserved via the `${VAR:-default}` guard.
- New `bin/claude-spawn-agent` wrapper `exec`s the underlying script with all args forwarded. Since Claude Code puts each plugin's `bin/` on `PATH` in every context (main session, Agent-tool subagents, `claude -p`), callers can now invoke `claude-spawn-agent <agent> <prompt>` by name with zero env-var or path knowledge.
- All call sites (`skills/looper/SKILL.md`, `agents/planner.md`, `agents/doer.md`, `agents/checker.md`, `skills/subagents/SKILL.md`) migrated from `"${CLAUDE_PLUGIN_ROOT}/skills/subagents/scripts/spawn-agent"` (or the `SUBAGENTS_DIR` helper) to `claude-spawn-agent`.
- Docs simplified: `subagents/SKILL.md` documents the self-location behavior; the `looper/SKILL.md` agent-spawning-mode section drops env-var prerequisites.

## Why

Subagents spawned via the Agent tool don't inherit `CLAUDE_PLUGIN_ROOT`, and Agent-tool nesting is architecturally blocked — but `spawn-agent`'s `claude -p` subprocess mechanism is not blocked. The only missing piece was path discovery, which this change resolves. After this lands, any caller (main session, subagent, cron, arbitrary script) can dispatch looper's planner/doer/checker cleanly with nothing more than the `claude-spawn-agent` command on `PATH`.

Supersedes the "recovery path via filesystem discovery" section of #85.

## Test plan

- [x] `shellcheck plugins/looper/bin/claude-spawn-agent plugins/looper/skills/subagents/scripts/spawn-agent` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 100 passed
- [x] `tests/test-agent-definitions.sh` — 90 passed, 0 failed
- [x] `tests/test-checker-structure.sh` — 40 passed, 0 failed
- [x] `plugins/looper/tests/test-tech-stack-prompts.sh` — 6 passed
- [x] `plugins/looper/tests/test-loop-context-trim.sh` — 22 passed
- [x] Self-location preamble smoke test with `CLAUDE_PLUGIN_ROOT` unset resolves to the correct plugin root (contains `.claude-plugin/plugin.json`).
- [x] `bin/claude-spawn-agent` wrapper `exec`-chains through to `spawn-agent` and forwards args (verified by arg-parse error progression).
- [x] Wrapper marked executable in the git index (`100755`).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)