### PR TITLE
refactor(looper): Doer scope guard + simplifier agent + smarter retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.47.6"
+version = "0.47.8"
 dependencies = [
  "chrono",
  "clap",

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -191,15 +191,55 @@ If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
    4. Only modify tests if they have a genuine bug (wrong assertion, typo),
       NOT because the implementation took a different approach
 
-   **If the same test is still failing after 2 fix attempts in this phase,
-   STOP guessing and spawn the systematic debugger** before attempting a third
-   fix. Random patches mask root causes and waste loop iterations.
+   **Smarter fix-attempt policy (error-delta aware).** Instead of a flat "2
+   attempts then debugger" rule, decide escalation by comparing the *current*
+   error against the *previous* attempt. This distinguishes "Doer is learning"
+   from "Doer is stuck guessing" and escalates exactly when it helps.
+
+   After each failed test run, record the error prefix to a scratch file so
+   the comparison is robust across shell-turn boundaries:
+   ```bash
+   TMPDIR="/tmp/looper-${TASK_NAME}"
+   mkdir -p "$TMPDIR"
+   ATTEMPT_N=<1 for the first failure, +1 for each subsequent failed run>
+   CUR_ERR_FILE="$TMPDIR/last-error-${ITERATION}-${ATTEMPT_N}.txt"
+   PREV_ERR_FILE="$TMPDIR/last-error-${ITERATION}-$((ATTEMPT_N-1)).txt"
+   # Capture "failing test name + first ~10 error lines" as the comparable prefix
+   $SCRIPTS_DIR/run-tests 2>&1 | head -40 > "$CUR_ERR_FILE" || true
+   ```
+
+   Decide what to do next based on the delta:
+   - **Attempt 1 failed:** Try one more fix. Do not escalate yet.
+   - **Attempt 2+ failed AND current error prefix matches previous** (same
+     failing test and same error string prefix within the scratch file):
+     the Doer is not learning. Spawn the debugger immediately — do NOT
+     consume another blind fix attempt.
+   - **Attempt 2+ failed AND error prefix changed:** the Doer IS making
+     progress. Allow up to 2 more attempts (total cap: 4 attempts per test),
+     then escalate.
+   - **4 attempts on the same test regardless of delta:** hard cap — spawn
+     the debugger.
+
+   A simple delta check in shell:
+   ```bash
+   if [ -f "$PREV_ERR_FILE" ] && diff -q "$CUR_ERR_FILE" "$PREV_ERR_FILE" >/dev/null 2>&1; then
+       ERROR_DELTA="unchanged"   # stuck — escalate now
+   else
+       ERROR_DELTA="changed"     # learning — one more attempt allowed (up to cap)
+   fi
+   ```
+
+   When escalating, pass both the current error and the delta observation to
+   the debugger so it can pick its strategy:
    ```bash
    claude-spawn-agent "looper:debugger" "Iteration: $ITERATION
    Task: $TASK_NAME
    Failing test(s): <test name + full error output>
    GREEN commit files: <list>
    Fix attempts so far: <brief summary of what you tried>
+   Error delta: ${ERROR_DELTA}  # unchanged | changed
+   Previous error prefix: $(cat "$PREV_ERR_FILE" 2>/dev/null || echo '(none)')
+   Current error prefix:  $(cat "$CUR_ERR_FILE" 2>/dev/null || echo '(none)')
    Plan acceptance criteria: <relevant excerpt>"
    ```
    Read the debugger's report. Apply ONLY its recommended fix (one change),
@@ -221,6 +261,61 @@ If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
        --iteration $ITERATION
    ```
 
+10. **Scope-creep check after GREEN** — Verify the GREEN commit only touches
+    files the Planner listed under "Files to create or modify" (plus their
+    tests and common companion edits like `Cargo.lock`, `package-lock.json`,
+    and snapshot files). Catching drift here is cheaper than letting the
+    Checker spawn review subagents to flag a bloated diff.
+
+    ```bash
+    green_hash=$(git log --grep="Loop-Phase: do-green" --grep="Loop-Iteration: $ITERATION" \
+        --all-match --format="%H" -1)
+
+    # Extract the "Files to create or modify" list from the plan commit.
+    TMPDIR="/tmp/looper-${TASK_NAME}"
+    mkdir -p "$TMPDIR"
+    EXPECTED_FILE="$TMPDIR/expected-files-${ITERATION}.txt"
+    git log --grep="Loop-Phase: plan" --grep="Loop-Iteration: $ITERATION" \
+        --all-match --format="%B" -1 \
+        | awk '
+            /^##[[:space:]]*Files to (create|modify)/ { p=1; next }
+            /^## / && p { p=0 }
+            p { print }
+        ' \
+        | grep -oE '`[^`]+`|\*\*[^*]+\*\*|[[:space:]][-\*[:space:]]+[A-Za-z0-9_./-]+' \
+        | sed -E 's/^[[:space:]]*[-\*][[:space:]]+//; s/[`*]//g' \
+        | awk 'NF' \
+        > "$EXPECTED_FILE"
+
+    if [ ! -s "$EXPECTED_FILE" ]; then
+        echo "WARNING: could not parse expected-files list from plan — skipping scope check" >&2
+    else
+        set +e
+        DRIFT=$("$SCRIPTS_DIR/check-scope" \
+            --expected-files-file "$EXPECTED_FILE" \
+            --commit "$green_hash" 2>/dev/null)
+        DRIFT_EC=$?
+        set -e
+        if [ "$DRIFT_EC" -ne 0 ]; then
+            echo "Scope drift detected in GREEN commit:"
+            echo "$DRIFT"
+            # Either revert the extraneous changes OR amend the GREEN commit
+            # body documenting why they were necessary. Undocumented drift
+            # will be treated as scope creep by the Checker.
+        fi
+    fi
+    ```
+
+    On drift, you have two options:
+    - **Revert.** `git checkout <green_hash>^ -- <drift-file>` then amend the
+      GREEN commit (`git commit --amend --no-edit`) or follow up with a fix
+      commit that removes the drift.
+    - **Justify.** Amend the GREEN commit body to explain why each drift
+      file was necessary (e.g. "Cargo.lock regenerated — Cargo.toml dep
+      bump", "src/util.rs shared helper required by new module"). Use
+      `git commit --amend` to edit the body. Checker treats undocumented
+      drift as scope creep; justified drift is acceptable.
+
 ---
 
 ### Phase 2.5: SIMPLIFY — Refine the implementation
@@ -233,41 +328,45 @@ git log --grep="Loop-Phase: do-simplify" --grep="Loop-Iteration: $ITERATION" \
 ```
 If it exists, skip this phase entirely.
 
-10. **Run the code-simplifier** — Spawn a `code-simplifier` subagent to review
-   and simplify the implementation files changed in the GREEN phase. The
-   subagent should:
-   - Read only the files modified in the GREEN commit (not test files)
-   - Simplify: reduce redundancy, flatten nesting, improve naming, remove
-     dead code, consolidate duplicated logic
-   - Preserve all behavior — no feature changes
-   - Skip if changes are trivial (1-2 small files with clean code)
+11. **Run the simplifier subagent** — Spawn the dedicated `looper:simplifier`
+    subagent (defined in `agents/simplifier.md`) to review and simplify the
+    implementation files changed in the GREEN phase. The subagent is
+    scope-aware: it refuses edits outside the file list you pass in its
+    prompt, and it runs the test suite itself — if tests fail after its
+    edits, it reverts its own changes and reports "no simplification
+    applied". You do NOT need to re-run tests or revert on its behalf.
 
-   Get the list of files changed in GREEN:
-   ```bash
-   green_hash=$(git log --grep="Loop-Phase: do-green" --grep="Loop-Iteration: $ITERATION" \
-       --all-match --format="%H" -1)
-   git diff-tree --no-commit-id --name-only -r "$green_hash"
-   ```
-
-   Then spawn the simplifier:
-   ```bash
-   claude-spawn-agent "general-purpose" "You are a code simplifier. Review and simplify these files: <files>. Reduce redundancy, flatten nesting, improve naming, remove dead code. Preserve all behavior."
-   ```
-
-   If the subagent made no changes (code was already clean), skip the commit
-   and proceed to Phase 3.
-
-11. **Verify tests still pass** after simplification:
+    Get the list of files changed in GREEN, then spawn the simplifier:
     ```bash
-    $SCRIPTS_DIR/run-tests 2>&1; echo "EXIT_CODE=$?"
+    green_hash=$(git log --grep="Loop-Phase: do-green" --grep="Loop-Iteration: $ITERATION" \
+        --all-match --format="%H" -1)
+    GREEN_FILES=$(git diff-tree --no-commit-id --name-only -r "$green_hash" \
+        | grep -vE '(^|/)(tests?|__tests__|spec)/' || true)
+
+    if [ -z "$GREEN_FILES" ]; then
+        echo "No non-test files in GREEN commit — skipping simplify phase"
+    else
+        claude-spawn-agent "looper:simplifier" "Task: $TASK_NAME
+    Iteration: $ITERATION
+    SCRIPTS_DIR: $SCRIPTS_DIR
+    Files to review (GREEN-phase non-test files — do NOT edit anything outside this list):
+    $GREEN_FILES
+
+    Reduce redundancy, flatten nesting, improve naming, and remove dead code.
+    Preserve all behavior. Verify tests pass before returning control; revert
+    your own edits if they fail. Do NOT commit — the Doer owns the SIMPLIFY
+    commit."
+    fi
     ```
 
-    If tests fail, revert the simplification changes and skip this phase:
-    ```bash
-    git checkout -- .
-    ```
+    The simplifier returns one of three verdicts:
+    - **APPLIED** — edits are in the working tree, tests pass. Proceed to commit.
+    - **SKIPPED** — code was already clean, no edits made. Skip the commit,
+      proceed to Phase 3.
+    - **REVERTED** — edits broke tests and were rolled back. Skip the commit,
+      proceed to Phase 3.
 
-12. **Commit SIMPLIFY** (only if changes were made):
+12. **Commit SIMPLIFY** (only if the simplifier returned APPLIED):
     ```bash
     $SCRIPTS_DIR/git-commit-loop \
         --type "refactor" \
@@ -305,7 +404,8 @@ If it exists, skip Phase 3 entirely.
    - `dev_command` is not "none" (project has a runnable dev server)
    - The plan mentions API endpoints, routes, or CLI commands
 
-   If none apply, skip to step 9 commit above (no integration tests needed).
+   If none apply, skip Phase 3 entirely — the GREEN commit (step 9) is
+   already sufficient; no integration tests needed.
 
 14. **Write integration test scripts** — Create scripts in `tests/integration/`
     that exercise the running application with real HTTP requests or CLI invocations.
@@ -390,6 +490,10 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
 - `git-loop-context` — Read prior loop iterations from git log
 - `git-commit-loop` — Create commits with loop trailers
 - `resolve-plan-pointers` — Expand delta-mode pointers in a plan body (reads stdin)
+- `check-scope` — Detect files changed outside an expected-files list
+  (`--expected-files <list>` or `--expected-files-file <path>`, `--commit <hash>`).
+  Tolerates lockfile companions (`Cargo.lock`, `package-lock.json`, etc.),
+  matching test files, and snapshot updates. Exit 1 + drift filenames on stdout.
 - `run-integration-tests` — Start app and run tests/integration/ scripts (`--port <PORT>`)
 - `scaffold-integration-ci` — Generate .github/workflows/integration.yml
 - `compose-lifecycle` — Start/stop docker-compose services (`up --task`, `down`, `status`)

--- a/plugins/looper/agents/simplifier.md
+++ b/plugins/looper/agents/simplifier.md
@@ -1,0 +1,133 @@
+---
+name: simplifier
+description: Reviews and simplifies a bounded set of recently-changed files. Reduces redundancy, flattens nesting, improves naming, and removes dead code while strictly preserving behavior. Runs the test suite before returning control; reverts its own changes on failure.
+tools: Read, Edit, Bash, Glob, Grep
+model: sonnet
+---
+
+# Simplifier Subagent
+
+You are the **Simplifier** subagent invoked by the Doer during Phase 2.5
+(SIMPLIFY) of the Plan-Do-Check loop. You review the files the Doer just
+committed in the GREEN phase and refine them — nothing else.
+
+## The Iron Law
+
+**Preserve behavior. Stay in scope. Verify tests still pass.**
+
+If you cannot keep the tests green, your output is a no-op — you revert your
+own edits and report "no simplification applied". The Doer should never have
+to undo your work.
+
+## Context You Will Receive
+
+A prompt containing:
+- The list of GREEN-phase files (absolute or repo-relative paths) you are
+  allowed to edit.
+- `$TASK_NAME` and `$ITERATION` for the current loop iteration.
+- A pointer to `$SCRIPTS_DIR` where `run-tests` lives (typically
+  `${CLAUDE_PLUGIN_ROOT}/skills/looper/scripts`).
+
+If the prompt does not list files explicitly, do not guess — report back
+"no simplification applied — file list missing" and exit.
+
+## Scope Guard
+
+You MUST refuse to edit any file outside the list provided in the prompt.
+This includes:
+- Test files (tests were locked in the RED phase — do not touch them).
+- Configuration files, build scripts, or documentation not in the list.
+- Sibling files in the same module that "look related" — if they are not
+  in the list, they are out of scope.
+
+If simplifying an in-scope file seems to require changing an out-of-scope
+file, stop the simplification, leave that file untouched, and note it in
+your report under "Out of Scope".
+
+## Instructions
+
+1. **Read every file in the list.** Understand what the GREEN code does
+   before proposing any change. Do not skim.
+
+2. **Decide whether to simplify at all.** Skip (commit no changes) when:
+   - The diff is trivial (1-2 small files with clean, idiomatic code).
+   - The code is already minimal — any change would be stylistic noise.
+   - You cannot identify a concrete redundancy, dead branch, or naming
+     issue worth addressing.
+
+   A clean no-op is always better than a churn commit.
+
+3. **Apply targeted simplifications** (in order of preference):
+   - **Reduce redundancy.** Consolidate duplicated blocks into a single
+     function or expression.
+   - **Flatten nesting.** Early returns beat deeply-indented `if/else`.
+   - **Improve naming.** Replace cryptic or misleading identifiers with
+     clear ones — but only when the new name is obviously better.
+   - **Remove dead code.** Unused imports, unreachable branches, commented-
+     out code, stub values that are never read.
+   - **Collapse obviously-redundant patterns** (e.g., `if x { true } else
+     { false }` → `x`; one-shot variables that are immediately returned).
+
+4. **Do NOT:**
+   - Change public API surfaces, function signatures, or behavior.
+   - Reorder arguments, rename exported symbols, or introduce new types.
+   - Add error handling for paths the tests do not exercise.
+   - "Modernize" or "prettify" code that is already correct.
+   - Rewrite algorithms — this phase is for polish, not re-design.
+   - Touch any file outside the provided list.
+
+5. **Verify tests still pass.** After your edits, run the test suite:
+   ```bash
+   $SCRIPTS_DIR/run-tests 2>&1; echo "EXIT_CODE=$?"
+   ```
+   If tests pass, your simplifications stay.
+
+   If tests fail, revert your edits immediately:
+   ```bash
+   git checkout -- <files-you-edited>
+   ```
+   Then report "no simplification applied — tests failed after edit".
+   Do NOT attempt to fix the failures — the Doer is responsible for the
+   GREEN implementation, not you.
+
+6. **Do NOT commit.** The Doer owns the SIMPLIFY commit. You only edit
+   working-tree files (or revert them). The Doer will inspect the diff
+   and create the commit if changes remain.
+
+## Report Format
+
+Return your findings in exactly this structure. Do NOT add prose outside it.
+
+```
+## Simplifier Report
+
+### Verdict
+APPLIED | SKIPPED | REVERTED
+
+### Files Edited
+- <path> — <1-line description of the change>
+(OR: "none")
+
+### Simplifications
+1. <file:line> — <specific change, e.g. "flatten nested if into guard clause">
+2. <file:line> — <specific change>
+(OR: "none — code was already clean")
+
+### Test Verification
+<exact command + exit code, e.g. "run-tests EXIT_CODE=0">
+
+### Out of Scope
+<anything you noticed but did NOT change because it was outside the file
+list, e.g. "src/util.rs has a similar redundancy but is not in scope">
+(OR: "none")
+```
+
+## Rules
+
+- Stay within the provided file list — refuse silently, report explicitly.
+- Preserve all behavior — no feature changes, no API shifts.
+- Run the test suite before returning. If tests fail, revert and report.
+- Never commit. Leave commit authorship to the Doer.
+- Prefer "SKIPPED — already clean" over a speculative simplification.
+- If the file list is empty or missing, report "no simplification applied"
+  and exit cleanly.

--- a/plugins/looper/skills/looper/scripts/check-scope
+++ b/plugins/looper/skills/looper/scripts/check-scope
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-scope — Verify a commit's changed files are within an expected-files set
+#
+# Usage: check-scope --expected-files <list> --commit <hash>
+#        check-scope --expected-files-file <path> --commit <hash>
+#
+# --expected-files    Comma-separated or newline-separated list of expected paths.
+#                     Each entry may be a plain file path or a glob (matched via
+#                     bash extended globbing).
+# --expected-files-file  Path to a file with one expected path per line.
+# --commit            Commit hash to inspect. The script diffs <hash>^..<hash>.
+#
+# Exit 0: All changed files are within the expected set (+ their tests + common
+#         companion edits). Prints nothing.
+# Exit 1: One or more changed files fall outside the expected set. Prints drift
+#         files one per line to stdout, then a human-readable summary to stderr.
+# Exit 2: Invalid arguments or git failure.
+#
+# Tolerance rules (companion edits allowed without being explicitly listed):
+#   - <package>-lock files when the matching manifest is expected:
+#       Cargo.toml      -> Cargo.lock
+#       package.json    -> package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb
+#       pyproject.toml  -> poetry.lock, uv.lock
+#       Gemfile         -> Gemfile.lock
+#       go.mod          -> go.sum
+#       composer.json   -> composer.lock
+#   - Test files that match an expected source file via common conventions
+#     (e.g. tests/test_<name>.sh, __tests__/<name>.test.*, <name>_test.*,
+#     tests/<name>_test.rs, tests/integration/<any>.sh).
+#   - Snapshot files under __snapshots__/, snapshots/, or *.snap alongside
+#     expected files.
+
+EXPECTED_LIST=""
+EXPECTED_FILE=""
+COMMIT=""
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: check-scope --expected-files <list> --commit <hash>
+       check-scope --expected-files-file <path> --commit <hash>
+
+Options:
+  --expected-files <list>        Comma- or newline-separated expected paths.
+  --expected-files-file <path>   File with one expected path per line.
+  --commit <hash>                Commit hash to inspect (diffs <hash>^..<hash>).
+  -h, --help                     Show this help.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --expected-files)
+            EXPECTED_LIST="$2"
+            shift 2
+            ;;
+        --expected-files-file)
+            EXPECTED_FILE="$2"
+            shift 2
+            ;;
+        --commit)
+            COMMIT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$COMMIT" ]; then
+    echo "Error: --commit is required" >&2
+    usage
+    exit 2
+fi
+
+if [ -z "$EXPECTED_LIST" ] && [ -z "$EXPECTED_FILE" ]; then
+    echo "Error: one of --expected-files or --expected-files-file is required" >&2
+    usage
+    exit 2
+fi
+
+# Collect expected paths into an array, stripping blanks and comments.
+declare -a EXPECTED=()
+add_expected() {
+    local raw="$1"
+    # Allow comma-separated or newline-separated
+    while IFS= read -r line; do
+        # Trim whitespace
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        # Skip blanks and comment lines
+        [ -z "$line" ] && continue
+        case "$line" in \#*) continue ;; esac
+        # Strip surrounding quotes/backticks commonly seen in markdown plans
+        line="${line#\`}"
+        line="${line%\`}"
+        line="${line#\"}"
+        line="${line%\"}"
+        EXPECTED+=("$line")
+    done < <(printf '%s\n' "$raw" | tr ',' '\n')
+}
+
+if [ -n "$EXPECTED_FILE" ]; then
+    if [ ! -f "$EXPECTED_FILE" ]; then
+        echo "Error: expected-files file not found: $EXPECTED_FILE" >&2
+        exit 2
+    fi
+    add_expected "$(cat "$EXPECTED_FILE")"
+fi
+
+if [ -n "$EXPECTED_LIST" ]; then
+    add_expected "$EXPECTED_LIST"
+fi
+
+if [ "${#EXPECTED[@]}" -eq 0 ]; then
+    echo "Error: no expected files parsed from input" >&2
+    exit 2
+fi
+
+# Get the list of changed files in the commit.
+CHANGED=$(git diff --name-only "$COMMIT^..$COMMIT" 2>/dev/null) || {
+    echo "Error: could not diff $COMMIT^..$COMMIT" >&2
+    exit 2
+}
+
+if [ -z "$CHANGED" ]; then
+    # No changes — trivially within scope.
+    exit 0
+fi
+
+# Build the companion-edit map based on expected manifests.
+declare -a COMPANIONS=()
+add_companion() {
+    COMPANIONS+=("$1")
+}
+
+for exp in "${EXPECTED[@]}"; do
+    base="$(basename "$exp")"
+    dir="$(dirname "$exp")"
+    # Normalize "." dir to empty
+    [ "$dir" = "." ] && dir=""
+    prefix=""
+    [ -n "$dir" ] && prefix="${dir}/"
+    case "$base" in
+        Cargo.toml)
+            add_companion "${prefix}Cargo.lock"
+            ;;
+        package.json)
+            add_companion "${prefix}package-lock.json"
+            add_companion "${prefix}yarn.lock"
+            add_companion "${prefix}pnpm-lock.yaml"
+            add_companion "${prefix}bun.lockb"
+            ;;
+        pyproject.toml)
+            add_companion "${prefix}poetry.lock"
+            add_companion "${prefix}uv.lock"
+            ;;
+        Gemfile)
+            add_companion "${prefix}Gemfile.lock"
+            ;;
+        go.mod)
+            add_companion "${prefix}go.sum"
+            ;;
+        composer.json)
+            add_companion "${prefix}composer.lock"
+            ;;
+    esac
+done
+
+# match_path: returns 0 if $path is within the expected/tolerance set.
+match_path() {
+    local path="$1"
+    local exp
+    local base
+    local stem
+    local dir
+
+    # 1. Exact or glob match against expected
+    for exp in "${EXPECTED[@]}"; do
+        if [ "$path" = "$exp" ]; then
+            return 0
+        fi
+        # Glob match (bash pattern). Use [[ ]] with pattern on RHS unquoted.
+        # Extglob patterns may be present; enable extglob for the match.
+        shopt -s extglob
+        # shellcheck disable=SC2053
+        if [[ "$path" == $exp ]]; then
+            shopt -u extglob
+            return 0
+        fi
+        shopt -u extglob
+        # Directory-prefix expected: "foo/" or "foo" treated as dir if it exists
+        if [ -d "$exp" ] || [[ "$exp" == */ ]]; then
+            local trimmed="${exp%/}"
+            if [[ "$path" == "$trimmed"/* ]]; then
+                return 0
+            fi
+        fi
+    done
+
+    # 2. Companion match
+    for exp in "${COMPANIONS[@]}"; do
+        if [ "$path" = "$exp" ]; then
+            return 0
+        fi
+    done
+
+    # 3. Test-file heuristics for each expected source file.
+    base="$(basename "$path")"
+    for exp in "${EXPECTED[@]}"; do
+        local exp_base
+        exp_base="$(basename "$exp")"
+        # Strip extension to get the stem
+        stem="${exp_base%.*}"
+        [ -z "$stem" ] && continue
+        # Skip if expected is itself a test-y file — no derivation
+        # Accept test files that reference the stem in common conventions:
+        #   test_<stem>.*        tests/test_<stem>.*
+        #   <stem>_test.*        <stem>.test.*  <stem>.spec.*
+        #   __tests__/<stem>.*   __tests__/<stem>.test.*
+        case "$path" in
+            *"test_${stem}".*|*"tests/test_${stem}".*) return 0 ;;
+            *"${stem}_test".*|*"${stem}.test".*|*"${stem}.spec".*) return 0 ;;
+            *"__tests__/${stem}".*|*"__tests__/${stem}/"*) return 0 ;;
+            *"tests/${stem}_test".*|*"tests/${stem}".*) return 0 ;;
+        esac
+    done
+
+    # 4. Generic test directories are always acceptable as companion test
+    #    output when at least one expected file is a source file — tests for
+    #    new behavior live there even if the planner did not list them.
+    case "$path" in
+        tests/*|test/*|__tests__/*|spec/*)
+            return 0
+            ;;
+    esac
+
+    # 5. Snapshot updates alongside expected files.
+    dir="$(dirname "$path")"
+    case "$path" in
+        *__snapshots__/*|*/snapshots/*|*.snap)
+            # Accept if the containing parent dir matches any expected dir.
+            for exp in "${EXPECTED[@]}"; do
+                local exp_dir
+                exp_dir="$(dirname "$exp")"
+                if [[ "$dir" == "$exp_dir"* ]]; then
+                    return 0
+                fi
+            done
+            ;;
+    esac
+
+    return 1
+}
+
+declare -a DRIFT=()
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    if ! match_path "$file"; then
+        DRIFT+=("$file")
+    fi
+done <<< "$CHANGED"
+
+if [ "${#DRIFT[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+# Print drift files to stdout, one per line (machine-readable).
+for f in "${DRIFT[@]}"; do
+    printf '%s\n' "$f"
+done
+
+# Human-readable summary to stderr.
+{
+    echo ""
+    echo "Scope drift detected in commit $COMMIT:"
+    echo "  ${#DRIFT[@]} file(s) changed outside the expected set."
+    echo ""
+    echo "Expected files:"
+    for exp in "${EXPECTED[@]}"; do
+        echo "  - $exp"
+    done
+    echo ""
+    echo "Action: revert the extraneous changes OR document why they were"
+    echo "necessary in the GREEN commit body. Undocumented drift will be"
+    echo "treated as scope creep by the Checker."
+} >&2
+
+exit 1

--- a/plugins/looper/skills/looper/scripts/check-scope
+++ b/plugins/looper/skills/looper/scripts/check-scope
@@ -28,7 +28,9 @@ set -euo pipefail
 #       composer.json   -> composer.lock
 #   - Test files that match an expected source file via common conventions
 #     (e.g. tests/test_<name>.sh, __tests__/<name>.test.*, <name>_test.*,
-#     tests/<name>_test.rs, tests/integration/<any>.sh).
+#     tests/<name>_test.rs). Test files that do NOT derive from an expected
+#     source stem are treated as drift — unrelated tests dropped under
+#     tests/ are precisely the kind of scope creep this guard should catch.
 #   - Snapshot files under __snapshots__/, snapshots/, or *.snap alongside
 #     expected files.
 
@@ -234,16 +236,7 @@ match_path() {
         esac
     done
 
-    # 4. Generic test directories are always acceptable as companion test
-    #    output when at least one expected file is a source file — tests for
-    #    new behavior live there even if the planner did not list them.
-    case "$path" in
-        tests/*|test/*|__tests__/*|spec/*)
-            return 0
-            ;;
-    esac
-
-    # 5. Snapshot updates alongside expected files.
+    # 4. Snapshot updates alongside expected files.
     dir="$(dirname "$path")"
     case "$path" in
         *__snapshots__/*|*/snapshots/*|*.snap)

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # Executes: test-detect-stack.sh, test-detect-resume.sh,
 #           test-git-commit-loop-validation.sh, test-git-loop-context.sh,
 #           test-sync-with-remote.sh, test-check-blocked.sh,
+#           test-check-scope.sh,
 #           test-fetch-issue-context.sh, test-build-agent-context.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,6 +33,7 @@ run_suite "test-git-commit-loop-validation.sh"
 run_suite "test-git-loop-context.sh"
 run_suite "test-sync-with-remote.sh"
 run_suite "test-check-blocked.sh"
+run_suite "test-check-scope.sh"
 run_suite "test-fetch-issue-context.sh"
 run_suite "test-build-agent-context.sh"
 run_suite "test-resolve-plan-pointers.sh"

--- a/tests/test-agent-definitions.sh
+++ b/tests/test-agent-definitions.sh
@@ -192,6 +192,62 @@ echo "=== Test 10: checker.md and planner.md are significantly shorter ==="
 assert_line_count_lt "checker.md is under 350 lines (was 482)" "$CHECKER_MD" 350
 assert_line_count_lt "planner.md is under 360 lines (was 311, +52 for on-demand gh rules + issue context sub-sections)" "$PLANNER_MD" 360
 
+# --- Test 11: simplifier.md agent exists with valid frontmatter ---
+echo "=== Test 11: simplifier.md exists with valid frontmatter ==="
+SIMPLIFIER_MD="$AGENTS_DIR/simplifier.md"
+assert_file_exists "simplifier.md exists" "$SIMPLIFIER_MD"
+if [ -f "$SIMPLIFIER_MD" ]; then
+    first_line="$(head -1 "$SIMPLIFIER_MD" 2>/dev/null || echo "")"
+    assert_true "simplifier.md starts with ---" "$([ "$first_line" = "---" ] && echo "true" || echo "false")"
+    assert_file_contains "simplifier.md has name: simplifier" "$SIMPLIFIER_MD" "^name: simplifier$"
+    assert_file_contains "simplifier.md has model: sonnet" "$SIMPLIFIER_MD" "^model: sonnet$"
+    assert_file_contains "simplifier.md has tools: field" "$SIMPLIFIER_MD" "^tools:"
+    assert_file_contains "simplifier.md tools include Read" "$SIMPLIFIER_MD" "^tools:.*Read"
+    assert_file_contains "simplifier.md tools include Edit" "$SIMPLIFIER_MD" "^tools:.*Edit"
+    assert_file_contains "simplifier.md tools include Bash" "$SIMPLIFIER_MD" "^tools:.*Bash"
+    assert_file_contains "simplifier.md tools include Glob" "$SIMPLIFIER_MD" "^tools:.*Glob"
+    assert_file_contains "simplifier.md tools include Grep" "$SIMPLIFIER_MD" "^tools:.*Grep"
+    # Scope-awareness + verdict structure
+    assert_file_contains "simplifier.md mentions Scope Guard" "$SIMPLIFIER_MD" "Scope Guard"
+    assert_file_contains "simplifier.md defines APPLIED verdict" "$SIMPLIFIER_MD" "APPLIED"
+    assert_file_contains "simplifier.md defines SKIPPED verdict" "$SIMPLIFIER_MD" "SKIPPED"
+    assert_file_contains "simplifier.md defines REVERTED verdict" "$SIMPLIFIER_MD" "REVERTED"
+fi
+
+# --- Test 12: doer.md step numbering is unique (each step 1..16 appears once) ---
+echo "=== Test 12: doer.md step numbers are unique ==="
+DOER_MD="$AGENTS_DIR/doer.md"
+if [ -f "$DOER_MD" ]; then
+    dup_count=$(grep -oE '^[0-9]+\.' "$DOER_MD" | sort | uniq -d | wc -l)
+    dup_count=$(echo "$dup_count" | tr -d '[:space:]')
+    assert_true "doer.md has no duplicate step numbers (duplicates=$dup_count)" \
+        "$([ "$dup_count" = "0" ] && echo "true" || echo "false")"
+fi
+
+# --- Test 13: doer.md references looper:simplifier (not general-purpose simplifier) ---
+echo "=== Test 13: doer.md uses looper:simplifier subagent ==="
+if [ -f "$DOER_MD" ]; then
+    assert_file_contains "doer.md spawns looper:simplifier" "$DOER_MD" 'looper:simplifier'
+    assert_file_not_contains "doer.md does not inline 'You are a code simplifier' prompt" \
+        "$DOER_MD" "You are a code simplifier"
+fi
+
+# --- Test 14: doer.md mentions check-scope helper ---
+echo "=== Test 14: doer.md invokes check-scope after GREEN ==="
+if [ -f "$DOER_MD" ]; then
+    assert_file_contains "doer.md references check-scope helper" "$DOER_MD" "check-scope"
+fi
+
+# --- Test 15: doer.md replaces '2 fix attempts' with delta-aware rule ---
+echo "=== Test 15: doer.md smarter retry policy ==="
+if [ -f "$DOER_MD" ]; then
+    assert_file_contains "doer.md mentions error delta" "$DOER_MD" "Error delta\|error delta\|error prefix\|ERROR_DELTA"
+    assert_file_contains "doer.md references per-iteration last-error scratch file" \
+        "$DOER_MD" 'last-error-\${ITERATION}'
+    assert_file_not_contains "doer.md no longer uses 'after 2 fix attempts' language" \
+        "$DOER_MD" "after 2 fix attempts"
+fi
+
 # --- Summary ---
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-check-scope.sh
+++ b/tests/test-check-scope.sh
@@ -288,6 +288,48 @@ OUTPUT=$("$CHECK_SCOPE" --expected-files "anything" --commit "$HASH" 2>/dev/null
 assert_exit_zero "empty commit: exit 0" "$EC"
 teardown_repo
 
+# --- Test 16: Unrelated test under tests/ is flagged as drift ---
+echo "=== Test 16: Unrelated test file is drift ==="
+setup_repo
+mkdir -p src tests
+echo "fn main() {}" > src/main.rs
+echo "// unrelated" > tests/test_unrelated.sh
+git add -A
+git commit -q -m "drift"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/main.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_one "unrelated test: exit 1" "$EC"
+assert_stdout_contains "unrelated test: lists tests/test_unrelated.sh" "$OUTPUT" "tests/test_unrelated.sh"
+teardown_repo
+
+# --- Test 17: Test with a non-matching stem is flagged as drift ---
+echo "=== Test 17: Misleading-stem test is drift ==="
+setup_repo
+mkdir -p src tests
+echo "fn baz() {}" > src/baz.rs
+echo "// unrelated name" > tests/test_misleading.sh
+git add -A
+git commit -q -m "drift"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/baz.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_one "misleading stem: exit 1" "$EC"
+assert_stdout_contains "misleading stem: lists tests/test_misleading.sh" "$OUTPUT" "tests/test_misleading.sh"
+teardown_repo
+
+# --- Test 18: Unrelated spec/ file is flagged as drift ---
+echo "=== Test 18: Unrelated spec file is drift ==="
+setup_repo
+mkdir -p src spec
+echo "fn x() {}" > src/x.rs
+echo "// random spec" > spec/unrelated_spec.rb
+git add -A
+git commit -q -m "drift"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/x.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_one "unrelated spec: exit 1" "$EC"
+assert_stdout_contains "unrelated spec: lists spec/unrelated_spec.rb" "$OUTPUT" "spec/unrelated_spec.rb"
+teardown_repo
+
 # --- Summary ---
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-check-scope.sh
+++ b/tests/test-check-scope.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-check-scope.sh — Corner-case tests for the check-scope helper.
+# Sets up a throwaway git repo, creates commits, and asserts the helper's
+# stdout/exit-code against expected-files lists with tolerance rules.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCOPE="$SCRIPT_DIR/../plugins/looper/skills/looper/scripts/check-scope"
+
+if [ ! -x "$CHECK_SCOPE" ]; then
+    echo "FAIL: $CHECK_SCOPE not found or not executable" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+    if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+setup_repo() {
+    TMPDIR_TEST="$(mktemp -d)"
+    cd "$TMPDIR_TEST"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git commit --allow-empty -q -m "root"
+}
+
+teardown_repo() {
+    cd /
+    if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+    TMPDIR_TEST=""
+}
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_one() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 1 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 1, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_two() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 2 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 2, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_stdout_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -q -- "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected stdout to contain '$expected')"
+        echo "  Actual stdout: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_stdout_not_contains() {
+    local description="$1"
+    local output="$2"
+    local unexpected="$3"
+    if echo "$output" | grep -q -- "$unexpected"; then
+        echo "FAIL: $description (stdout unexpectedly contains '$unexpected')"
+        echo "  Actual stdout: $output"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# --- Test 1: All changed files are expected -> exit 0 ---
+echo "=== Test 1: All changed files within expected set ==="
+setup_repo
+mkdir -p src
+echo "hello" > src/a.rs
+echo "world" > src/b.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/a.rs,src/b.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "within-scope: exit 0" "$EC"
+teardown_repo
+
+# --- Test 2: Extra file outside expected -> exit 1 ---
+echo "=== Test 2: Drift file ==="
+setup_repo
+mkdir -p src
+echo "a" > src/a.rs
+echo "b" > src/unrelated.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/a.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_one "drift: exit 1" "$EC"
+assert_stdout_contains "drift: lists drift file" "$OUTPUT" "src/unrelated.rs"
+teardown_repo
+
+# --- Test 3: Cargo.lock tolerated when Cargo.toml is expected ---
+echo "=== Test 3: Cargo.lock companion tolerance ==="
+setup_repo
+echo "[package]" > Cargo.toml
+echo "# lock" > Cargo.lock
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "Cargo.toml" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "Cargo.lock tolerated: exit 0" "$EC"
+teardown_repo
+
+# --- Test 4: package-lock.json tolerated when package.json is expected ---
+echo "=== Test 4: package-lock.json companion tolerance ==="
+setup_repo
+echo "{}" > package.json
+echo "{}" > package-lock.json
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "package.json" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "package-lock.json tolerated: exit 0" "$EC"
+teardown_repo
+
+# --- Test 5: pnpm-lock.yaml tolerated when package.json is expected ---
+echo "=== Test 5: pnpm-lock.yaml companion tolerance ==="
+setup_repo
+echo "{}" > package.json
+echo "lockfileVersion: 6.0" > pnpm-lock.yaml
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "package.json" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "pnpm-lock.yaml tolerated: exit 0" "$EC"
+teardown_repo
+
+# --- Test 6: Test files tolerated for expected source files ---
+echo "=== Test 6: Test-file heuristic tolerance ==="
+setup_repo
+mkdir -p src tests
+echo "fn foo() {}" > src/foo.rs
+echo "// test" > tests/foo_test.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/foo.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "test file tolerated: exit 0" "$EC"
+teardown_repo
+
+# --- Test 7: Snapshot files alongside expected dir tolerated ---
+echo "=== Test 7: Snapshot tolerance ==="
+setup_repo
+mkdir -p src/__snapshots__
+echo "fn x() {}" > src/x.rs
+echo "snap" > src/__snapshots__/x.snap
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/x.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "snapshot tolerated: exit 0" "$EC"
+teardown_repo
+
+# --- Test 8: Glob pattern in expected set ---
+echo "=== Test 8: Glob match in expected ==="
+setup_repo
+mkdir -p src
+echo "a" > src/a.rs
+echo "b" > src/b.rs
+echo "c" > src/c.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/*.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "glob match: exit 0" "$EC"
+teardown_repo
+
+# --- Test 9: Directory-prefix expected matches nested path ---
+echo "=== Test 9: Directory prefix match ==="
+setup_repo
+mkdir -p src/sub
+echo "a" > src/sub/a.rs
+echo "b" > src/sub/b.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "dir prefix match: exit 0" "$EC"
+teardown_repo
+
+# --- Test 10: Expected-files-file input works ---
+echo "=== Test 10: --expected-files-file input ==="
+setup_repo
+mkdir -p src
+echo "a" > src/a.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+EXPFILE="$(mktemp)"
+printf '# plan-list\nsrc/a.rs\n' > "$EXPFILE"
+OUTPUT=$("$CHECK_SCOPE" --expected-files-file "$EXPFILE" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "expected-files-file: exit 0" "$EC"
+rm -f "$EXPFILE"
+teardown_repo
+
+# --- Test 11: Missing --commit flag -> exit 2 ---
+echo "=== Test 11: Missing --commit ==="
+setup_repo
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/a.rs" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_two "missing --commit: exit 2" "$EC"
+teardown_repo
+
+# --- Test 12: Missing expected input -> exit 2 ---
+echo "=== Test 12: Missing --expected-files and --expected-files-file ==="
+setup_repo
+OUTPUT=$("$CHECK_SCOPE" --commit HEAD 2>/dev/null) && EC=0 || EC=$?
+assert_exit_two "missing expected: exit 2" "$EC"
+teardown_repo
+
+# --- Test 13: Multiple drift files all reported ---
+echo "=== Test 13: Multiple drift files listed ==="
+setup_repo
+mkdir -p src
+echo "a" > src/a.rs
+echo "x" > src/x.rs
+echo "y" > src/y.rs
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "src/a.rs" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_one "multi drift: exit 1" "$EC"
+assert_stdout_contains "multi drift: lists x" "$OUTPUT" "src/x.rs"
+assert_stdout_contains "multi drift: lists y" "$OUTPUT" "src/y.rs"
+assert_stdout_not_contains "multi drift: does NOT list a" "$OUTPUT" "src/a.rs"
+teardown_repo
+
+# --- Test 14: go.sum tolerated when go.mod is expected ---
+echo "=== Test 14: go.sum companion tolerance ==="
+setup_repo
+echo "module x" > go.mod
+echo "hash" > go.sum
+git add -A
+git commit -q -m "green"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "go.mod" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "go.sum tolerated: exit 0" "$EC"
+teardown_repo
+
+# --- Test 15: Empty commit (no changes) -> exit 0 ---
+echo "=== Test 15: Empty commit ==="
+setup_repo
+git commit --allow-empty -q -m "empty"
+HASH=$(git rev-parse HEAD)
+OUTPUT=$("$CHECK_SCOPE" --expected-files "anything" --commit "$HASH" 2>/dev/null) && EC=0 || EC=$?
+assert_exit_zero "empty commit: exit 0" "$EC"
+teardown_repo
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #82.

## Summary
Four tightenings to the Doer prompt and supporting assets — no change to the TDD shape.

- **Scope-creep check after GREEN.** New `plugins/looper/skills/looper/scripts/check-scope` helper validates `git diff --name-only <green>^..<green>` against the Planner's "Files to create or modify" list. Tolerates lockfile companions (`Cargo.lock`, `package-lock.json`, `pnpm-lock.yaml`, `uv.lock`, `go.sum`, `Gemfile.lock`, `composer.lock`), matching test files via naming conventions, and snapshot updates. Doer runs it after step 9 and must revert or justify-in-commit-body on drift.
- **Dedicated `looper:simplifier` subagent.** `plugins/looper/agents/simplifier.md` replaces the hard-coded `general-purpose` spawn + inline prompt. Scope-aware (refuses edits outside the GREEN file list), runs `run-tests` itself, and reverts its own changes on failure. Returns APPLIED/SKIPPED/REVERTED — Doer no longer re-runs tests or reverts on its behalf.
- **Smarter fix-attempt policy.** Replace the flat "2 attempts then debugger" rule with an error-delta-aware rule. Each failed run's error prefix is recorded to `/tmp/looper-${TASK_NAME}/last-error-${ITERATION}-${N}.txt` so comparisons survive shell-turn boundaries. Unchanged error -> escalate to debugger immediately (non-learning); changed error -> up to 2 more attempts (learning), with a hard cap at 4. Debugger prompt now carries the delta so it can pick a strategy.
- **Step numbering.** Verified every step number 1..16 appears exactly once in `doer.md`. Phase 3 (INTEGRATION) now follows Phase 2.5 cleanly (13–16 after SIMPLIFY's 11–12). Cleaned up the stale "skip to step 9" reference.

## Test plan
- [x] `tests/test-check-scope.sh` — 19 new corner-case tests (within-scope, drift, Cargo.lock/package-lock.json/pnpm-lock.yaml/go.sum companions, test-file heuristics, snapshot tolerance, globs, dir-prefix, empty commit, missing flags). All pass.
- [x] `tests/test-agent-definitions.sh` — 5 new checks (simplifier.md frontmatter + verdict structure, doer.md step uniqueness, `looper:simplifier` spawn, check-scope reference, delta-aware retry language, absence of "after 2 fix attempts"). All pass.
- [x] `tests/run-corner-case-tests.sh` — added `test-check-scope.sh` to the suite.
- [x] `cargo build`, `cargo test` (100 passed), `cargo clippy` (clean).
- [x] `shellcheck plugins/looper/skills/looper/scripts/check-scope` — clean.
- [x] Pre-existing failure in `tests/test-build-agent-context.sh` confirmed unrelated (fails on `alpha` before these changes too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)