### PR TITLE
perf(looper): delta-mode planning on iter > 1 (#90)

### DIFF
--- a/plugins/looper/agents/check-adversarial.md
+++ b/plugins/looper/agents/check-adversarial.md
@@ -27,6 +27,11 @@ You will receive a context prompt containing:
 
 If context is thin, read the changed files and tests directly with Read/Glob.
 
+**Delta-mode pointers.** The Checker expands `(unchanged from iteration N-1
+— see <hash>)` pointers before handing you the plan summary. If you still
+see a pointer, resolve it with `git log <hash> -1 --format="%B"` and
+extract the named section.
+
 ## Your Job
 
 1. **Read the implementation.** For every file in the GREEN commit, read it

--- a/plugins/looper/agents/check-code.md
+++ b/plugins/looper/agents/check-code.md
@@ -23,6 +23,12 @@ You will receive a context prompt containing:
 If context is missing or minimal, note it in your report and work with what
 you have — read the recent commits and changed files directly.
 
+**Delta-mode pointers.** The Checker expands `(unchanged from iteration N-1
+— see <hash>)` pointers before handing you the plan summary. If you still
+see a pointer (e.g., in "Tech Stack Constraints"), resolve it with
+`git log <hash> -1 --format="%B"` and extract the named section so your
+tech-stack compliance check runs against the real constraints.
+
 ## Your Focus
 
 - Run `$SCRIPTS_DIR/run-lint 2>&1; echo "EXIT_CODE=$?"`

--- a/plugins/looper/agents/check-tests.md
+++ b/plugins/looper/agents/check-tests.md
@@ -23,6 +23,13 @@ You will receive a context prompt containing:
 If context is missing or minimal, note it in your report and work with what
 you have — read the recent commits and changed files directly.
 
+**Delta-mode pointers.** The Checker expands `(unchanged from iteration N-1
+— see <hash>)` pointers before handing you the plan summary. If you still
+see a pointer in the provided context, resolve it yourself with
+`git log <hash> -1 --format="%B"` and extract the named section. Run
+acceptance-criteria / corner-case coverage against the EXPANDED plan, not
+against pointer stubs.
+
 ## Your Focus
 
 - Run `$SCRIPTS_DIR/run-tests 2>&1; echo "EXIT_CODE=$?"`

--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -88,6 +88,15 @@ context, self-locates its plugin root — no env setup required).
        --all-match --format="%B" -1
    ```
 
+   **Delta-mode pointer resolution.** On iter > 1 the Planner may emit
+   sections or list items as `(unchanged from iteration N-1 — see <hash>)`.
+   Before reviewing, expand every pointer via
+   `$SCRIPTS_DIR/resolve-plan-pointers` (pipe the plan body into it) — or
+   manually with `git log <hash> -1 --format="%B"` — and pass the
+   fully-expanded plan as "plan summary" to the sub-checkers. This ensures
+   acceptance-criteria / corner-case coverage checks run against the real
+   spec, not pointer stubs.
+
    **Call 2 — Get the RED commit (tests) summary + diff:**
    ```bash
    h=$(git log --grep="Loop-Phase: do-red" --grep="Loop-Iteration: $ITERATION" \
@@ -273,6 +282,7 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
 - `security-scan` — Run security vulnerability scan
 - `git-loop-context` — Read prior loop iterations from git log
 - `git-commit-loop` — Create commits with loop trailers
+- `resolve-plan-pointers` — Expand delta-mode pointers in a plan body (reads stdin)
 - `run-integration-tests` — Start app and run tests/integration/ scripts (`--port <PORT>`)
 - `compose-lifecycle` — Start/stop docker-compose services (`up --task`, `down`, `status`)
 - `detect-compose` — Detect docker-compose and extract service port mappings

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -28,6 +28,19 @@ write failing tests first, then write just enough code to make them pass.
    Spawn subagents via the `claude-spawn-agent` command (on `PATH` in every
    context, self-locates its plugin root — no env setup required).
 
+   **Delta-mode pointer resolution.** On iter > 1 the Planner may emit
+   sections or list items as `(unchanged from iteration N-1 — see <hash>)`.
+   Resolve every pointer before acting on the plan — easiest path is:
+   ```bash
+   $SCRIPTS_DIR/resolve-plan-pointers <<< "$PLAN_BODY"
+   ```
+   which expands each pointer in place by running
+   `git log <hash> -1 --format="%B"` on the referenced plan commit and
+   splicing in the matching section body (or list item). If the helper is
+   unavailable, resolve manually with `git log <hash> -1 --format="%B"` and
+   extract the referenced section. Treat the fully-expanded plan — not the
+   pointer form — as the authoritative spec for this iteration.
+
 2. **Size guard for oversize plans.** If the plan commit body exceeds ~400 lines,
    do NOT try to hold the entire plan in working context. Extract only the focused
    sections:
@@ -376,6 +389,7 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
 - `install-deps` — Install project dependencies
 - `git-loop-context` — Read prior loop iterations from git log
 - `git-commit-loop` — Create commits with loop trailers
+- `resolve-plan-pointers` — Expand delta-mode pointers in a plan body (reads stdin)
 - `run-integration-tests` — Start app and run tests/integration/ scripts (`--port <PORT>`)
 - `scaffold-integration-ci` — Generate .github/workflows/integration.yml
 - `compose-lifecycle` — Start/stop docker-compose services (`up --task`, `down`, `status`)

--- a/plugins/looper/agents/plan-completeness.md
+++ b/plugins/looper/agents/plan-completeness.md
@@ -21,6 +21,14 @@ You will receive a context prompt containing:
 If context is missing or minimal, note it in your report and work with what
 you have.
 
+**Delta-mode plans.** On iter > 1 the draft plan may contain
+`(unchanged from iteration N-1 — see <hash>)` pointers. Treat each pointer
+as "this section is inherited verbatim from the referenced plan commit."
+Do NOT flag pointers as missing content — the pointer IS the content. If
+you need to verify the inherited section (e.g., to check acceptance-criteria
+coverage), resolve it with `git log <hash> -1 --format="%B"` and extract
+the named section.
+
 ## Your Focus
 
 - Check plan covers all aspects of the task prompt

--- a/plugins/looper/agents/plan-feasibility.md
+++ b/plugins/looper/agents/plan-feasibility.md
@@ -21,6 +21,13 @@ You will receive a context prompt containing:
 If context is missing or minimal, note it in your report and work with what
 you have.
 
+**Delta-mode plans.** On iter > 1 the draft plan may contain
+`(unchanged from iteration N-1 — see <hash>)` pointers. Resolve each with
+`git log <hash> -1 --format="%B"` and extract the named section before
+checking feasibility of the files / APIs it references. Do NOT flag
+pointer stubs as missing references — the pointer inherits the prior
+plan's section verbatim.
+
 ## Your Focus
 
 - Verify all referenced files actually exist (Glob/Read)

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -158,10 +158,43 @@ which self-locates its plugin root. No env-var setup is required from you.
      The Doer can skip reading these files, saving context window usage. For
      files >50 lines, describe the relevant section and line numbers instead.
 
-   **On iteration > 1:** Project context is pruned — spawn Explore subagents
-   only for areas the Checker flagged, not for a full re-exploration of the
-   codebase. The Checker's FAIL verdict + action items contain the specific
-   areas that need attention.
+   **On iteration > 1 — Delta-mode planning (MANDATORY).** Project context
+   is pruned; spawn Explore subagents only for areas the Checker flagged,
+   not a full re-exploration. Your baseline is the prior plan (in
+   `## Prior Loop Context`). For each section ask: "did the Checker's FAIL
+   feedback materially affect this section?"
+   - **No:** emit `(unchanged from iteration N-1 — see <commit-hash>)` as
+     the section body. Resolve `<commit-hash>` via
+     `git log --grep="Loop-Phase: plan" --grep="Loop-Iteration: $((ITERATION-1))" --all-match --format="%H" -1`.
+   - **Yes:** emit the revised section in full. You MAY mark individual list
+     items as `(unchanged)` inside a partially-changed section (e.g., keep
+     5 prior Corner Cases verbatim and add the newly-missed one).
+
+   **No-drift rule:** you are BANNED from "improving" sections the Checker
+   did not flag — re-drafting correct sections risks regressions. If the
+   Checker did not name a section in its action items, emit the pointer.
+   **Tech Stack Constraints is almost always `(unchanged)`** — it is derived
+   from the issue body, which does not change iteration-to-iteration.
+   **Fallback:** if the prior plan commit cannot be located, full re-draft
+   AND include in the commit body:
+   `NOTE: delta-mode fallback — prior plan commit not found; full re-draft.`
+
+   **Partial-revision example** (iter 3, Checker flagged corner cases + one
+   acceptance criterion):
+   ```markdown
+   ## Goal
+   (unchanged from iteration 2 — see a1b2c3d)
+   ## Tech Stack Constraints
+   (unchanged from iteration 2 — see a1b2c3d)
+   ## Corner cases
+   - (5 prior cases unchanged — see a1b2c3d)
+   - **NEW:** empty-string input → should return 400, not 500
+   ## Acceptance criteria
+   - (criteria 1-3 unchanged — see a1b2c3d)
+   - **REVISED:** criterion 4 now requires `{code,message}` body shape
+   ```
+   Consumers resolve pointers via `git log <hash> -1 --format="%B"` or
+   `$SCRIPTS_DIR/resolve-plan-pointers` (expands every pointer inline).
 
    **Scope discipline — complete the task, slice only when necessary:** Plan to
    accomplish the ENTIRE task in this iteration. Most tasks can be completed in

--- a/plugins/looper/skills/looper/scripts/resolve-plan-pointers
+++ b/plugins/looper/skills/looper/scripts/resolve-plan-pointers
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# resolve-plan-pointers — expand delta-mode pointers in a plan body.
+#
+# Reads a plan body from stdin (or the --file argument) and writes the same
+# body to stdout with every `(unchanged from iteration N-1 — see <hash>)`
+# pointer replaced by the referenced section from that commit.
+#
+# Supported pointer forms (case-insensitive "iteration|iter"):
+#   (unchanged from iteration 2 — see a1b2c3d)
+#   (unchanged from iter 2 - see a1b2c3d)
+#   (N prior cases unchanged — see a1b2c3d)          # list-item form
+#
+# Semantics:
+#   - Section-body pointer (pointer is the ENTIRE body of a `## Heading`
+#     section): the matching `## Heading` block from the referenced commit
+#     replaces the pointer line. Section headings are preserved.
+#   - List-item pointer (pointer is a `- (...)` bullet): the matching list
+#     items from the referenced section in the referenced commit are
+#     spliced in place of the single placeholder bullet.
+#
+# Usage:
+#   resolve-plan-pointers < plan-body.md
+#   resolve-plan-pointers --file plan-body.md
+#   PLAN=$(git log <hash> -1 --format="%B")
+#   echo "$PLAN" | resolve-plan-pointers
+#
+# Exit 0 on success. Pointers that fail to resolve (missing commit, missing
+# section) are left in place and a warning is printed to stderr.
+
+FILE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --file) FILE="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '3,28p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "resolve-plan-pointers: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -n "$FILE" ]; then
+    PLAN_BODY=$(cat "$FILE")
+else
+    PLAN_BODY=$(cat)
+fi
+
+# Fetch the body of a plan commit, cached in memory via an associative array.
+declare -A PLAN_CACHE
+fetch_plan() {
+    local hash="$1"
+    if [ -z "${PLAN_CACHE[$hash]+x}" ]; then
+        local body
+        if body=$(git log "$hash" -1 --format="%B" 2>/dev/null); then
+            PLAN_CACHE[$hash]="$body"
+        else
+            PLAN_CACHE[$hash]="__MISSING__"
+        fi
+    fi
+    printf '%s' "${PLAN_CACHE[$hash]}"
+}
+
+# Extract a `## Heading` block (everything from the heading up to the next
+# `## ` at column 0, exclusive) from a plan body. Prints empty string if
+# missing.
+extract_section() {
+    local body="$1"
+    local heading="$2"
+    # awk: match exact heading line; print until the next `## ` heading.
+    printf '%s\n' "$body" | awk -v h="$heading" '
+        $0 == h { printing=1; print; next }
+        printing && /^## / { printing=0 }
+        printing { print }
+    '
+}
+
+# Extract only the list items from a section (lines beginning with `-` or
+# `*`), dropping the heading and any intro prose.
+extract_list_items() {
+    local body="$1"
+    local heading="$2"
+    extract_section "$body" "$heading" | awk '
+        /^## / { next }
+        /^[[:space:]]*[-*] / { print }
+    '
+}
+
+# Walk the plan body line-by-line, resolving pointers as we go. We track
+# the current `## Heading` so that section-body pointers know which section
+# to pull from the referenced commit.
+resolve() {
+    local current_heading=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [[ "$line" =~ ^##\ .+ ]]; then
+            current_heading="$line"
+            printf '%s\n' "$line"
+            continue
+        fi
+
+        # Section-body pointer: a standalone "(unchanged ... — see HASH)"
+        # line (optionally with the em-dash or an ASCII hyphen). Captures
+        # HASH in BASH_REMATCH[1].
+        if [[ "$line" =~ ^\(unchanged\ from\ (iter(ation)?\ [0-9]+)?[[:space:]]*[—-][[:space:]]*see\ ([0-9a-f]+)\)[[:space:]]*$ ]] \
+            || [[ "$line" =~ ^\(unchanged[[:space:]]+from[[:space:]]+iter(ation)?[[:space:]]+[0-9]+[[:space:]]*[—-][[:space:]]*see[[:space:]]+([0-9a-f]+)\)[[:space:]]*$ ]]; then
+            local hash="${BASH_REMATCH[3]:-${BASH_REMATCH[2]}}"
+            local prior
+            prior=$(fetch_plan "$hash")
+            if [ "$prior" = "__MISSING__" ] || [ -z "$current_heading" ]; then
+                echo "resolve-plan-pointers: WARN: could not resolve section pointer ($hash, heading='$current_heading')" >&2
+                printf '%s\n' "$line"
+                continue
+            fi
+            local extracted
+            extracted=$(extract_section "$prior" "$current_heading")
+            if [ -z "$extracted" ]; then
+                echo "resolve-plan-pointers: WARN: section '$current_heading' not found in $hash" >&2
+                printf '%s\n' "$line"
+                continue
+            fi
+            # Skip the heading line from the extracted section (already emitted).
+            printf '%s\n' "$extracted" | awk 'NR>1'
+            continue
+        fi
+
+        # List-item pointer: a single bullet like
+        #   - (5 prior cases unchanged — see a1b2c3d)
+        # Replace with the list items from the matching section in HASH.
+        if [[ "$line" =~ ^[[:space:]]*[-*][[:space:]]+\(.*unchanged.*see[[:space:]]+([0-9a-f]+)\)[[:space:]]*$ ]]; then
+            local hash="${BASH_REMATCH[1]}"
+            local prior
+            prior=$(fetch_plan "$hash")
+            if [ "$prior" = "__MISSING__" ] || [ -z "$current_heading" ]; then
+                echo "resolve-plan-pointers: WARN: could not resolve list-item pointer ($hash, heading='$current_heading')" >&2
+                printf '%s\n' "$line"
+                continue
+            fi
+            local items
+            items=$(extract_list_items "$prior" "$current_heading")
+            if [ -z "$items" ]; then
+                echo "resolve-plan-pointers: WARN: no list items in section '$current_heading' of $hash" >&2
+                printf '%s\n' "$line"
+                continue
+            fi
+            printf '%s\n' "$items"
+            continue
+        fi
+
+        printf '%s\n' "$line"
+    done <<< "$PLAN_BODY"
+}
+
+resolve

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -34,6 +34,8 @@ run_suite "test-sync-with-remote.sh"
 run_suite "test-check-blocked.sh"
 run_suite "test-fetch-issue-context.sh"
 run_suite "test-build-agent-context.sh"
+run_suite "test-resolve-plan-pointers.sh"
+run_suite "test-delta-mode-prompts.sh"
 
 echo "=============================="
 echo "Corner-case suite: $PASS suites passed, $FAIL suites failed"

--- a/tests/test-delta-mode-prompts.sh
+++ b/tests/test-delta-mode-prompts.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-delta-mode-prompts.sh — Verify that agent prompt files contain the
+# delta-mode planning instructions added for issue #90.
+#
+# Acceptance criteria (from #90):
+#   - planner.md step 4 has a dedicated subsection for iter > 1 behavior
+#     with the "(unchanged from iteration N-1 — see <commit-hash>)" pattern
+#   - planner.md bans "improving" sections the Checker didn't flag (no-drift)
+#   - planner.md includes a partial-revision example
+#   - planner.md flags Tech Stack Constraints as almost always (unchanged)
+#   - planner.md has a fallback path for missing prior commit
+#   - doer.md has a pointer-resolution rule
+#   - checker.md has a pointer-resolution rule
+#   - sub-checkers (check-tests, check-code, check-adversarial, plan-*)
+#     each have a pointer-resolution note
+
+AGENTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../plugins/looper/agents" && pwd)"
+
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"
+    local file="$2"
+    local pattern="$3"
+    if grep -qE "$pattern" "$file"; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        echo "  Expected regex '$pattern' in $file"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# --- Planner prompt updates ---
+echo "=== Planner delta-mode rules ==="
+check "planner.md: iter > 1 delta-mode section present" \
+    "$AGENTS_DIR/planner.md" \
+    "[Dd]elta-mode planning"
+
+check "planner.md: defines pointer syntax '(unchanged from iteration ... — see <hash>)'" \
+    "$AGENTS_DIR/planner.md" \
+    "unchanged from iteration"
+
+check "planner.md: no-drift rule bans improving unflagged sections" \
+    "$AGENTS_DIR/planner.md" \
+    "[Nn]o-drift|BANNED from \"improving\""
+
+check "planner.md: includes partial-revision example block" \
+    "$AGENTS_DIR/planner.md" \
+    "[Pp]artial-revision example"
+
+check "planner.md: Tech Stack Constraints is almost always unchanged" \
+    "$AGENTS_DIR/planner.md" \
+    "Tech Stack Constraints.*almost always.*unchanged"
+
+check "planner.md: fallback for missing prior plan commit" \
+    "$AGENTS_DIR/planner.md" \
+    "delta-mode fallback"
+
+check "planner.md: mentions resolve-plan-pointers helper" \
+    "$AGENTS_DIR/planner.md" \
+    "resolve-plan-pointers"
+
+# --- Consumer prompts ---
+echo "=== Consumer prompt pointer-resolution rules ==="
+check "doer.md: pointer-resolution rule present" \
+    "$AGENTS_DIR/doer.md" \
+    "[Dd]elta-mode pointer resolution|resolve-plan-pointers"
+
+check "doer.md: instructs resolving pointers before acting on the plan" \
+    "$AGENTS_DIR/doer.md" \
+    "unchanged from iteration"
+
+check "checker.md: pointer-resolution rule present" \
+    "$AGENTS_DIR/checker.md" \
+    "[Dd]elta-mode pointer resolution|resolve-plan-pointers"
+
+check "checker.md: passes expanded plan to sub-checkers" \
+    "$AGENTS_DIR/checker.md" \
+    "fully-expanded plan|expand every pointer"
+
+# --- Sub-checker prompts ---
+echo "=== Sub-checker pointer-resolution notes ==="
+for sub in check-tests check-code check-adversarial plan-completeness plan-feasibility; do
+    check "$sub.md: mentions delta-mode pointers" \
+        "$AGENTS_DIR/$sub.md" \
+        "[Dd]elta-mode pointers|unchanged from iteration"
+done
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-resolve-plan-pointers.sh
+++ b/tests/test-resolve-plan-pointers.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-resolve-plan-pointers.sh — Tests for the resolve-plan-pointers helper.
+#
+# Verifies that the helper expands delta-mode pointers:
+#   - section-body pointers ("(unchanged from iteration N-1 — see <hash>)")
+#   - list-item pointers ("- (N prior cases unchanged — see <hash>)")
+#   - missing-commit fallback (pointer left in place + warning)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+RESOLVER="$REPO_ROOT/plugins/looper/skills/looper/scripts/resolve-plan-pointers"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+    local description="$1"
+    local haystack="$2"
+    local needle="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description"
+        echo "  Expected to find: $needle"
+        echo "  In: $haystack"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local description="$1"
+    local haystack="$2"
+    local needle="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "FAIL: $description"
+        echo "  Did not expect to find: $needle"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# --- Setup: create a temp git repo with a prior plan commit ---
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR"
+git init -q
+git config user.email test@example.com
+git config user.name Test
+git commit --allow-empty -qm "init"
+
+# Commit a prior-iteration plan that pointers can resolve against.
+cat > /tmp/prior-plan-$$.txt <<'PRIOR'
+chore(foo): plan iteration 1
+
+## Goal
+Implement the foo feature.
+
+## Tech Stack Constraints
+- Rust + tokio
+- No JS framework
+
+## Corner cases
+- empty input
+- null input
+- whitespace-only input
+
+## Acceptance criteria
+- unit test for happy path
+- unit test for empty input
+PRIOR
+git commit --allow-empty -q -F /tmp/prior-plan-$$.txt
+PRIOR_HASH=$(git rev-parse --short=7 HEAD)
+rm -f /tmp/prior-plan-$$.txt
+
+# --- Test 1: resolver exists and is executable ---
+echo "=== Test 1: resolver exists and is executable ==="
+if [ -x "$RESOLVER" ]; then
+    echo "PASS: resolve-plan-pointers is executable"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: resolve-plan-pointers missing or not executable at $RESOLVER"
+    FAIL=$((FAIL + 1))
+    echo "Results: $PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# --- Test 2: section-body pointer expands to full section ---
+echo "=== Test 2: section-body pointer resolves to the referenced section body ==="
+INPUT=$(cat <<EOF
+## Goal
+(unchanged from iteration 1 — see ${PRIOR_HASH})
+
+## Corner cases
+- new case
+EOF
+)
+OUTPUT=$(printf '%s\n' "$INPUT" | "$RESOLVER")
+assert_contains "section-body pointer expands to 'Implement the foo feature.'" \
+    "$OUTPUT" "Implement the foo feature."
+assert_not_contains "section-body pointer no longer appears verbatim" \
+    "$OUTPUT" "(unchanged from iteration 1 — see ${PRIOR_HASH})"
+
+# --- Test 3: list-item pointer expands to inherited bullets ---
+echo "=== Test 3: list-item pointer expands to the inherited bullets ==="
+INPUT=$(cat <<EOF
+## Corner cases
+- (3 prior cases unchanged — see ${PRIOR_HASH})
+- NEW: unicode RTL characters
+EOF
+)
+OUTPUT=$(printf '%s\n' "$INPUT" | "$RESOLVER")
+assert_contains "list-item pointer expands to include 'empty input'" \
+    "$OUTPUT" "- empty input"
+assert_contains "list-item pointer expands to include 'null input'" \
+    "$OUTPUT" "- null input"
+assert_contains "list-item pointer expands to include 'whitespace-only input'" \
+    "$OUTPUT" "- whitespace-only input"
+assert_contains "new bullet after inherited bullets is preserved" \
+    "$OUTPUT" "- NEW: unicode RTL characters"
+assert_not_contains "list-item pointer no longer appears verbatim" \
+    "$OUTPUT" "(3 prior cases unchanged"
+
+# --- Test 4: Tech Stack Constraints pointer inherits verbatim ---
+echo "=== Test 4: Tech Stack Constraints pointer inherits verbatim ==="
+INPUT=$(cat <<EOF
+## Tech Stack Constraints
+(unchanged from iteration 1 — see ${PRIOR_HASH})
+EOF
+)
+OUTPUT=$(printf '%s\n' "$INPUT" | "$RESOLVER")
+assert_contains "tech-stack pointer resolves to 'Rust + tokio'" \
+    "$OUTPUT" "Rust + tokio"
+assert_contains "tech-stack pointer resolves to 'No JS framework'" \
+    "$OUTPUT" "No JS framework"
+
+# --- Test 5: missing-commit fallback leaves pointer + prints warning ---
+echo "=== Test 5: missing-commit fallback leaves pointer in place ==="
+INPUT=$(cat <<'EOF'
+## Goal
+(unchanged from iteration 1 — see deadbee)
+EOF
+)
+OUTPUT=$(printf '%s\n' "$INPUT" | "$RESOLVER" 2>/tmp/resolver-stderr-$$)
+STDERR=$(cat /tmp/resolver-stderr-$$)
+rm -f /tmp/resolver-stderr-$$
+assert_contains "missing-hash pointer is preserved verbatim" \
+    "$OUTPUT" "(unchanged from iteration 1 — see deadbee)"
+assert_contains "warning is emitted to stderr for missing hash" \
+    "$STDERR" "WARN"
+
+# --- Test 6: plan with no pointers is returned unchanged ---
+echo "=== Test 6: plan with no pointers is passed through unchanged ==="
+INPUT=$(cat <<'EOF'
+## Goal
+Implement bar.
+
+## Corner cases
+- case A
+- case B
+EOF
+)
+OUTPUT=$(printf '%s\n' "$INPUT" | "$RESOLVER")
+# Allow for a trailing newline discrepancy — compare trimmed forms.
+EXPECTED_TRIMMED=$(printf '%s' "$INPUT")
+ACTUAL_TRIMMED=$(printf '%s' "$OUTPUT")
+if [ "$EXPECTED_TRIMMED" = "$ACTUAL_TRIMMED" ]; then
+    echo "PASS: plan with no pointers is unchanged"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: plan with no pointers was modified"
+    echo "  Expected: $EXPECTED_TRIMMED"
+    echo "  Actual:   $ACTUAL_TRIMMED"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- Test 7: size reduction — a delta plan is smaller than the full plan ---
+echo "=== Test 7: pointer-form plan is significantly smaller than resolved form ==="
+POINTER_FORM=$(cat <<EOF
+## Goal
+(unchanged from iteration 1 — see ${PRIOR_HASH})
+
+## Tech Stack Constraints
+(unchanged from iteration 1 — see ${PRIOR_HASH})
+
+## Corner cases
+- (3 prior cases unchanged — see ${PRIOR_HASH})
+- NEW: empty-string input → 400 not 500
+
+## Acceptance criteria
+- (criteria 1-2 unchanged — see ${PRIOR_HASH})
+- REVISED: response body must be {code,message}
+EOF
+)
+RESOLVED=$(printf '%s\n' "$POINTER_FORM" | "$RESOLVER")
+POINTER_LINES=$(printf '%s\n' "$POINTER_FORM" | wc -l)
+RESOLVED_LINES=$(printf '%s\n' "$RESOLVED" | wc -l)
+# Pointer form must be strictly smaller than the resolved form.
+if [ "$POINTER_LINES" -lt "$RESOLVED_LINES" ]; then
+    echo "PASS: pointer form ($POINTER_LINES lines) < resolved form ($RESOLVED_LINES lines)"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: pointer form ($POINTER_LINES) not smaller than resolved ($RESOLVED_LINES)"
+    FAIL=$((FAIL + 1))
+fi
+# Spot-check that the RESOLVED form contains the inherited bullets.
+assert_contains "resolved form inherits 'empty input'" "$RESOLVED" "empty input"
+assert_contains "resolved form inherits 'Rust + tokio'" "$RESOLVED" "Rust + tokio"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #90.

## Summary

On iteration > 1, the Planner now emits a **revision** of the prior plan — only the sections the Checker's FAIL feedback materially affected — instead of re-drafting the full ~500-line plan from scratch. This captures both the output-token and reasoning-token savings from Option A in the issue.

## What changed

### Planner prompt (`plugins/looper/agents/planner.md`)
Step 4 gains a mandatory **Delta-mode planning** subsection for iter > 1:
- For each section: "did the Checker's feedback materially affect this?" — if **no**, emit `(unchanged from iteration N-1 — see <commit-hash>)`; if **yes**, emit the revised section in full. Individual list items inside a partially-changed section may also be marked `(unchanged)`.
- **No-drift rule:** BANNED from "improving" sections the Checker did not flag (prevents regressions from reasoning drift).
- **Tech Stack Constraints** is called out as almost always `(unchanged)` — derived from the issue body, which doesn't change iteration-to-iteration.
- **Fallback:** if the prior plan commit can't be located, full re-draft AND log `NOTE: delta-mode fallback` in the commit body.
- **Concrete partial-revision example** included in the prompt.

### Consumer prompts (doer.md, checker.md)
Both learn a **pointer-resolution rule**: expand every `(unchanged from iteration N-1 — see <hash>)` via `$SCRIPTS_DIR/resolve-plan-pointers` (or `git log <hash> -1 --format=%B`) before acting on / reviewing the plan, so acceptance-criteria and corner-case coverage checks run against the real spec, not pointer stubs.

### Sub-checkers
`check-tests.md`, `check-code.md`, `check-adversarial.md`, `plan-completeness.md`, `plan-feasibility.md` each get a short pointer-resolution note as a safety net — the parent Checker/Planner expands pointers in the summary it forwards, but sub-checkers fall back to `git log <hash>` if a pointer still appears in their context.

### Helper script (`plugins/looper/skills/looper/scripts/resolve-plan-pointers`)
Reads a plan body from stdin (or `--file`) and expands every pointer inline:
- **Section-body pointer** (`(unchanged from iteration 2 — see a1b2c3d)` as the entire body of a `## Heading`): replaces with the matching `## Heading` block from the referenced commit.
- **List-item pointer** (`- (5 prior cases unchanged — see a1b2c3d)`): replaces with the list items from the matching section of the referenced commit.
- **Missing-commit fallback:** preserves the pointer verbatim and prints a warning to stderr.

### Tests
- `tests/test-resolve-plan-pointers.sh` — 16 assertions: section-body expansion, list-item expansion, Tech Stack Constraints inheritance, missing-commit fallback, no-op passthrough, and size-reduction (pointer form strictly smaller than resolved form).
- `tests/test-delta-mode-prompts.sh` — 16 assertions verifying all 7 planner-prompt rules and 7 consumer/sub-checker rules from the issue's acceptance criteria are present.
- Both wired into `tests/run-corner-case-tests.sh`.

## Scope notes

- Landed **Option A** per the issue recommendation ("full plan with unchanged-section pointers"). Consumer change is minimal; output-token savings accrue because pointers are 1 line vs. a section body of dozens/hundreds of lines.
- Kept `planner.md` under the 360-line ceiling enforced by `test-agent-definitions.sh` (currently 359).
- Did NOT change `build-agent-context` or any upstream context-injection — delta-mode is a pure prompt + helper-script change, no infra coupling.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 100 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `shellcheck plugins/looper/skills/looper/scripts/resolve-plan-pointers` — clean
- [x] `bash tests/test-agent-definitions.sh` — 90 pass (planner.md still < 360 lines)
- [x] `bash tests/test-delta-mode-prompts.sh` — 16 pass
- [x] `bash tests/test-resolve-plan-pointers.sh` — 16 pass
- [x] `bash tests/test-checker-structure.sh` — 40 pass
- [x] `bash plugins/looper/tests/test-tech-stack-prompts.sh` — 6 pass
- [x] `bash plugins/looper/tests/test-loop-context-trim.sh` — 22 pass

Note: `test-build-agent-context.sh` has one pre-existing failure on `alpha` unrelated to this PR (verified by running the same test on the base-branch tip before any changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)