### PR TITLE
fix(tests): allow planner.md at exactly 360 lines (#97)

### DIFF
--- a/tests/test-agent-definitions.sh
+++ b/tests/test-agent-definitions.sh
@@ -81,6 +81,22 @@ assert_line_count_lt() {
     fi
 }
 
+assert_line_count_le() {
+    local description="$1"
+    local file="$2"
+    local max_lines="$3"
+    local actual
+    actual=$(wc -l < "$file" 2>/dev/null || echo "0")
+    actual=$(echo "$actual" | tr -d '[:space:]')
+    if [ "$actual" -le "$max_lines" ]; then
+        echo "PASS: $description (lines=$actual, max=$max_lines)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (lines=$actual, expected <= $max_lines)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 # --- Test 1: All 7 new agent files exist ---
 echo "=== Test 1: All 7 new agent files exist ==="
 assert_file_exists "check-build.md exists" "$AGENTS_DIR/check-build.md"
@@ -190,7 +206,9 @@ assert_file_contains "planner.md uses TASK_NAME-namespaced tmpdir" \
 # --- Test 10: Line count reduction ---
 echo "=== Test 10: checker.md and planner.md are significantly shorter ==="
 assert_line_count_lt "checker.md is under 350 lines (was 482)" "$CHECKER_MD" 350
-assert_line_count_lt "planner.md is under 360 lines (was 311, +52 for on-demand gh rules + issue context sub-sections)" "$PLANNER_MD" 360
+# Use <= here: GitHub's squash-merge may add a trailing newline, bumping wc -l
+# by 1 post-merge (see #97). Keep the 360 ceiling but allow the boundary value.
+assert_line_count_le "planner.md is at or under 360 lines (was 311, +52 for on-demand gh rules + issue context sub-sections)" "$PLANNER_MD" 360
 
 # --- Test 11: simplifier.md agent exists with valid frontmatter ---
 echo "=== Test 11: simplifier.md exists with valid frontmatter ==="


### PR DESCRIPTION
## Summary

- `tests/test-agent-definitions.sh` asserted `planner.md < 360` lines, which started failing on alpha because GitHub's squash-merge of #96 added a trailing newline, bumping the file from 359 to 360 lines post-merge.
- Flipped the planner assertion to `<=` via a new `assert_line_count_le` helper (option 1 from the issue). Checker.md's `<` assertion is unchanged.
- Added a short comment above the assertion explaining the newline-normalization pitfall so future threshold bumps know the context.

Closes #97

## Test plan

- [x] `bash tests/test-agent-definitions.sh` - 111 passed, 0 failed (including the modified planner assertion at lines=360, max=360)
- [x] `bash tests/run-corner-case-tests.sh` - only pre-existing `test-build-agent-context.sh` failure (tracked in #98), unrelated
- [x] `cargo build --workspace` - clean
- [x] `cargo test --workspace` - 100 passed
- [x] `cargo clippy --workspace -- -D warnings` - no issues
- [x] `shellcheck --severity=warning tests/test-agent-definitions.sh` - clean (pre-existing SC2016 info-level lints on lines 202/204/264 are intentional literal-string assertions, untouched)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>