### PR TITLE
fix(tests): restore test-build-agent-context.sh iter>1 assertion (#98)

### DIFF
--- a/tests/test-build-agent-context.sh
+++ b/tests/test-build-agent-context.sh
@@ -213,18 +213,23 @@ assert_output_contains "loop ctx: has Prior Loop Context section" "$OUTPUT" "Pri
 assert_output_contains "loop ctx: content present" "$OUTPUT" "fixed typo"
 cleanup
 
-# --- Test 11: --role planner with --iteration > 1: has pruning note ---
+# --- Test 11: --role planner with --iteration > 1: project-context pruned to pointer ---
+# Since PR #87, the iteration>1 pruning signal lives in planner.md (Delta-mode).
+# build-agent-context's iter>1 behavior is to replace the full <project-context>
+# bundle with a pointer to iteration 1's plan commit. Assert that pointer is
+# emitted. Pass --loop-context explicitly so the script does not try to shell out
+# to a non-existent git-loop-context under --scripts-dir.
 echo "=== Test 11: Planner with iteration > 1 has pruning note ==="
 setup_fixture_dir
-OUTPUT=$(eval "$BUILD_CTX --role planner --task my-task --iteration 2 --task-prompt 'Fix the bug' --scripts-dir /tmp/scripts --worktree-dir $TMPDIR_TEST --dev-port 9876 --compose false --compose-services none" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
-assert_output_contains "planner iter>1: has pruning note" "$OUTPUT" "Spawn Explore subagents ONLY\|re-explore\|action items"
+OUTPUT=$(eval "$BUILD_CTX --role planner --task my-task --iteration 2 --task-prompt 'Fix the bug' --scripts-dir /tmp/scripts --worktree-dir $TMPDIR_TEST --dev-port 9876 --compose false --compose-services none --loop-context 'prior iter notes'" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_output_contains "planner iter>1: has pruning note" "$OUTPUT" "project context unchanged"
 cleanup
 
 # --- Test 12: --role planner with --iteration 1: NO pruning note ---
 echo "=== Test 12: Planner with iteration 1 has no pruning note ==="
 setup_fixture_dir
 OUTPUT=$(eval "$BUILD_CTX --role planner $COMMON_FLAGS --worktree-dir $TMPDIR_TEST" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
-assert_output_not_contains "planner iter=1: no pruning note" "$OUTPUT" "re-explore the entire codebase"
+assert_output_not_contains "planner iter=1: no pruning note" "$OUTPUT" "project context unchanged"
 cleanup
 
 # --- Test 13: Missing required flags -> exit nonzero ---


### PR DESCRIPTION
## Summary

- Retargets Test 11 in `tests/test-build-agent-context.sh` at the current iter>1 pruning signal emitted by `build-agent-context` (`"See Planner commit from iteration 1 — project context unchanged."`), which replaced the inline `Spawn Explore subagents ONLY / re-explore / action items` note removed in PR #87.
- Passes `--loop-context` in the iter>1 invocation so the script no longer shells out to the non-existent `/tmp/scripts/git-loop-context` for per-role loop context (source of the `No such file or directory` stderr in the failing run).
- Flips Test 12's no-pruning-note assertion to the same phrase for symmetry.

## Root cause

Prompt-wording drift (not test-setup drift). PR #87 intentionally migrated the iter>1 "pruning note" language out of `build-agent-context` into `planner.md`'s Delta-mode block. The test was not updated to match.

## Test plan

- [x] `bash tests/test-build-agent-context.sh` → `58 passed, 0 failed`
- [x] `bash tests/run-corner-case-tests.sh` → `11 suites passed, 0 suites failed`
- [x] `cargo test --workspace` → green
- [x] `cargo clippy --workspace -- -D warnings` → clean
- [x] `shellcheck tests/test-build-agent-context.sh` → clean

Closes #98