### PR TITLE
feat(looper): canonical issue deps + list-ready-issues + entry-point hardening (#92)

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,39 @@
+---
+name: Default
+about: Default issue template — mirrors the canonical Looper format
+---
+
+## Description / Summary
+<2-4 sentences.>
+
+## Motivation
+<Why this is needed — skip for bug reports.>
+
+## Acceptance Criteria
+- [ ] <specific, testable criterion>
+
+<!--
+The next two sections are load-bearing. They are parsed by:
+  - plugins/looper/skills/looper/scripts/check-blocked
+  - crates/looper-watch/src/github.rs::is_blocked
+to decide whether `looper-watch` should pick this issue up.
+
+Use the EXACT format below. Bare issue numbers, no [#42](url) wrapping.
+-->
+
+## Dependencies
+<!-- Open issues this builds on. Remove the section if none. -->
+- [ ] Depends on #<N> — <one-line reason>
+
+## Blockers
+<!-- Open issues that must close before this one starts. Remove if none. -->
+- [ ] Blocked by #<N> — <one-line reason>
+
+## Subtasks
+- [ ] <subtask>
+
+## References
+- `path/to/file` — <why it's relevant>
+
+## Context
+- **Found by:** <how/when discovered>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,30 @@ looper/
         └── ci.yml           # CI pipeline
 ```
 
+### Issue dependency markers
+
+Issues filed by humans or by the `gh-issue-creator` agent must use canonical
+`## Dependencies` / `## Blockers` markers when they reference other open
+issues. These markers are load-bearing — they're parsed by:
+
+- `plugins/looper/skills/looper/scripts/check-blocked` (single-issue primitive)
+- `plugins/looper/skills/looper/scripts/list-ready-issues` (multi-issue
+  primitive — wraps `check-blocked`)
+- `crates/looper-watch/src/github.rs::is_blocked` (Rust source-of-truth)
+
+**DRY rule:** entry-point skills (`looper-issue`, `looper-ee`) MUST call
+`check-blocked` or `list-ready-issues` — never inline the filtering logic.
+
+To validate an issue body manually:
+
+```bash
+cat issue.md | plugins/looper/skills/looper/scripts/validate-issue-body
+```
+
+Note: the `tests/` corner-case suite (`tests/test-issue-tooling.sh`) covers
+`validate-issue-body` and `list-ready-issues` in detail but is not wired into
+CI — run it manually with `bash tests/run-corner-case-tests.sh`.
+
 ---
 
 ## Code Style and Conventions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.47.8"
+version = "0.47.6"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.47.6"
+version = "0.47.12"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ All scripts live in `plugins/looper/skills/looper/scripts/` and auto-detect your
 | `detect-resume` | Detect and resume interrupted loops |
 | `git-commit-loop` | Create commits with loop trailers |
 | `git-loop-context` | Read prior loop iterations from git log |
+| `list-ready-issues` | List open, unassigned, non-blocked issues (`--repo`, `--label`, `--limit`, `--json`) |
+| `validate-issue-body` | Validate issue body has canonical `## Dependencies` / `## Blockers` markers when cross-issue refs are present |
 | `run-tests` | Run test suite |
 | `run-lint` | Run linter (with `--fix`) |
 | `run-typecheck` | Run type checker |

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -531,6 +531,13 @@ Run these via `$SCRIPTS_DIR/<name>` (path provided in dynamic context):
   Description: <what the issue is>
   Observed behavior: <what happens>
   Expected behavior: <what should happen>
-  Found by: Doer agent during task \"<TASK_NAME>\"" &
+  Found by: Doer agent during task \"<TASK_NAME>\"
+  Dependencies: <#N if this work depends on an open issue, else omit>
+  Blockers: <#N if this work is hard-blocked by an open issue, else omit>" &
   ```
+  If you reference another issue number anywhere in the description above
+  but do NOT classify it as a `Dependencies:` or `Blockers:` line, the
+  `gh-issue-creator` agent will refuse to create the issue. Always classify
+  cross-issue references explicitly.
+
   Do not wait for the subagent to finish. Continue with your implementation.

--- a/plugins/looper/agents/gh-issue-creator.md
+++ b/plugins/looper/agents/gh-issue-creator.md
@@ -113,6 +113,45 @@ section only when it has no entries. The markers in `## Dependencies`,
   prefix a subtask with `#<N>` or "Depends on" / "Blocked by".
 - Issue numbers are bare (`#42`), never linkified (`[#42](...)`).
 
+### Dep/blocker detection rule (mandatory)
+
+Before invoking `gh issue create`, scan the **caller's prompt** for either:
+- explicit `dependencies: #<N>` / `blockers: #<N>` keys, OR
+- prose like "depends on #N", "requires #N", "builds on #N", "blocked by #N",
+  or "needs #N before this can land".
+
+For every `#<N>` reference detected in the caller's prompt, you MUST classify
+it as a dependency or a blocker:
+
+1. If the caller passed `dependencies: #N` or `blockers: #N`, use that
+   classification verbatim — emit `## Dependencies` / `## Blockers` sections.
+2. If the caller used prose ("depends on #N", "requires #N", "builds on #N")
+   → classify as a dependency.
+3. If the caller used "blocked by #N", "blocks on #N", "must wait for #N"
+   → classify as a blocker.
+4. If the reference is ambiguous (e.g. prose only says "see #N" or
+   "related to #N"), do NOT silently emit a marker. Skip the section and
+   put the reference under `## References` instead.
+5. After drafting the body, run a self-check: if the body contains any
+   `#<N>` reference outside `## References` / `## Context` AND no
+   `## Dependencies` / `## Blockers` section is present, refuse to create
+   the issue. Report back:
+   "Refused — caller mentioned #N but did not classify it as a
+    dependency or blocker. Re-invoke with `dependencies: #N` or `blockers: #N`."
+
+After creating the issue, pipe the final body through the validator as a
+guard against drift:
+
+```bash
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    echo "$BODY" | "$CLAUDE_PLUGIN_ROOT/skills/looper/scripts/validate-issue-body" || \
+        echo "Warning: validate-issue-body flagged the body" >&2
+fi
+```
+
+If `CLAUDE_PLUGIN_ROOT` is unset or the validator exits non-zero, log to
+stderr but do not retry — the create has already succeeded.
+
 ### Creating the issue
 
 ```bash

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -318,8 +318,15 @@ The `$SCRIPTS_DIR` path is injected as a task variable in your dynamic context.
   Description: <what the issue is>
   Observed behavior: <what happens>
   Expected behavior: <what should happen>
-  Found by: Planner agent during task \"<TASK_NAME>\"" &
+  Found by: Planner agent during task \"<TASK_NAME>\"
+  Dependencies: <#N if this work depends on an open issue, else omit>
+  Blockers: <#N if this work is hard-blocked by an open issue, else omit>" &
   ```
+  If you reference another issue number anywhere in the description above
+  but do NOT classify it as a `Dependencies:` or `Blockers:` line, the
+  `gh-issue-creator` agent will refuse to create the issue. Always classify
+  cross-issue references explicitly.
+
   Continue with your planning — do not wait for the subagent to finish.
 
 ## Rules — Querying GitHub on demand

--- a/plugins/looper/skills/looper-ee/SKILL.md
+++ b/plugins/looper/skills/looper-ee/SKILL.md
@@ -145,6 +145,51 @@ Notes:
 
 ---
 
+## Phase 3c: Pre-Worktree Blocked Check
+
+Before creating a worktree, verify the issue is not blocked. Skip the check
+when the issue was already upstream-claimed (the watcher runs the same
+check pre-claim, so re-running here is wasted work).
+
+`$UPSTREAM_OWNED` set in Phase 3b does NOT survive across Bash tool calls
+(each invocation is a fresh shell), so we re-derive it here.
+
+```bash
+SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT}/skills/looper/scripts"
+
+# Re-derive upstream ownership (fresh shell — cannot reuse Phase 3b's var).
+STATE=$(gh issue view "$ISSUE_NUMBER" --repo "$FULL_REPO" \
+    --json assignees,labels 2>/dev/null || echo '{}')
+ME=$(gh api user --jq .login 2>/dev/null)
+UPSTREAM_OWNED=$(echo "$STATE" | jq -r --arg me "$ME" '
+    ((.assignees // []) | map(.login) | any(. == $me))
+    and ((.labels // []) | map(.name) | any(. == "looper-claimed"))')
+
+if [ "$UPSTREAM_OWNED" = "true" ]; then
+    echo "Skipping blocked check (upstream-claimed by watcher)."
+else
+    if ! BLOCK_REASON=$($SCRIPTS_DIR/check-blocked --issue "$ISSUE_NUMBER" --repo "$FULL_REPO" 2>&1); then
+        echo "Issue #$ISSUE_NUMBER is blocked: $BLOCK_REASON"
+        echo "Aborting before worktree creation. Resolve the blocker, then retry."
+        # Best-effort: release the claim we just took.
+        gh issue edit "$ISSUE_NUMBER" --repo "$FULL_REPO" \
+            --remove-assignee @me --remove-label looper-claimed 2>/dev/null || true
+        exit 0
+    fi
+fi
+```
+
+Notes:
+- The upstream-owned re-derivation matches Phase 3b exactly: `assignee == @me
+  AND label looper-claimed`. When `looper-watch` feeds this session, both are
+  true; otherwise both are false.
+- On block, we release the claim so a future run (after the blocker closes)
+  can pick the issue back up cleanly. Best-effort; we do not fail if
+  release fails.
+- The exit is `0`, not non-zero — being blocked is a normal short-circuit.
+
+---
+
 ## Phase 4: Create Worktree
 
 **CRITICAL:** You MUST create a worktree before delegating to the looper skill.

--- a/plugins/looper/skills/looper-issue/SKILL.md
+++ b/plugins/looper/skills/looper-issue/SKILL.md
@@ -34,47 +34,36 @@ gh auth status
 Find, select, and assign an issue **immediately** to minimize the race window
 where two parallel invocations could claim the same issue.
 
-### 1a. Fetch open unassigned issues
-
-```bash
-gh issue list --state open --search "no:assignee" --limit 20 \
-  --json number,title,labels,body,createdAt
-```
-
-- If the result is an empty array, inform the user:
-  > "No open unassigned issues found."
-  and exit.
-
-Store the result as `ISSUES`.
-
-### 1b. Filter out blocked issues
-
-For each issue in `ISSUES`, check if it is blocked using `check-blocked`:
+### 1a. Fetch ready issues
 
 ```bash
 SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/plugins/looper}/skills/looper/scripts"
-ELIGIBLE_ISSUES=()
-for issue_number in $(echo "$ISSUES" | jq -r '.[].number'); do
-    if $SCRIPTS_DIR/check-blocked --issue "$issue_number" >/dev/null 2>&1; then
-        ELIGIBLE_ISSUES+=("$issue_number")
-    fi
-done
+LRI_STATS=$(mktemp)
+READY_JSON=$($SCRIPTS_DIR/list-ready-issues --json --limit 20 2>"$LRI_STATS")
+SUMMARY=$(cat "$LRI_STATS")
+rm -f "$LRI_STATS"
+echo "$SUMMARY"   # e.g. "Found 3 ready issues (2 blocked skipped)"
 ```
 
-`check-blocked` applies three checks: label-based blocking ("blocked" or
-"dependencies" labels), task-list dependency references (`- [ ] Depends on #N`
-or `- [ ] #N`), and "Blocked by #N" references. Exit 0 means not blocked.
+`list-ready-issues` is the single source of truth for "what's pickable":
+it wraps `gh issue list` + per-issue `check-blocked` and emits a JSON array
+sorted oldest-first, plus the stderr summary line.
 
-### 1c. Select issue
+If `READY_JSON` is `[]`:
+> "No open unassigned ready issues found (none open, or all are blocked)."
+and exit.
 
-- If no eligible issues remain after filtering, inform the user:
-  > "All open unassigned issues are currently blocked."
-  and exit.
+### 1b. Select issue
 
-- Otherwise, sort the remaining issues by `createdAt` ascending and select the
-  first (oldest) issue.
+`list-ready-issues --json` already emits oldest-first. Pick the first entry:
 
-Store the selected issue's number as `NUMBER` and its title as `TITLE`.
+```bash
+NUMBER=$(echo "$READY_JSON" | jq -r '.[0].number')
+TITLE=$(echo "$READY_JSON" | jq -r '.[0].title')
+echo "Picking #$NUMBER: $TITLE"
+```
+
+Store as `NUMBER` and `TITLE` for the claim phase below.
 
 ### 1d. Claim the issue (local lock → remote claim → settle → verify)
 
@@ -156,6 +145,5 @@ This hands off entirely to the existing looper skill, which will:
 |----------|--------|
 | `gh` not authenticated | Abort: "Please run `gh auth login` first." |
 | `gh issue list` fails | Abort: report the error message from `gh` to the user |
-| No open unassigned issues | Inform: "No open unassigned issues found." and exit |
-| All issues blocked | Inform: "All open unassigned issues are currently blocked." and exit |
+| `READY_JSON == []` (none open OR all blocked) | Inform: "No open unassigned ready issues found (none open, or all are blocked)." and exit |
 | Assignment failure | Warn: "Could not assign issue #N. Continuing anyway." and continue |

--- a/plugins/looper/skills/looper/scripts/list-ready-issues
+++ b/plugins/looper/skills/looper/scripts/list-ready-issues
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# list-ready-issues — List open, unassigned, non-blocked GitHub issues
+#
+# Usage: list-ready-issues [--repo owner/repo] [--label LABEL] [--limit N] [--json]
+#   --repo owner/repo  Target repo (default: current repo via gh context).
+#   --label LABEL      Filter to issues carrying this label (default: no filter).
+#   --limit N          Max candidates to fetch from gh (default: 30).
+#   --json             Output JSON array instead of TSV.
+#
+# Default output (TSV, sorted oldest-first by createdAt asc):
+#   #<N>  <title>
+#
+# JSON output (--json), sorted oldest-first by createdAt asc:
+#   [{"number": N, "title": "...", "labels": ["str",...], "createdAt": "..."}]
+#
+# Exit 0 always when gh fetch succeeds (even if zero ready issues).
+# Exit 2: gh fetch failure or invalid args.
+#
+# Stderr summary line (always emitted):
+#   "Found <READY> ready issues (<BLOCKED> blocked skipped)"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO_ARG=""
+LABEL_ARG=""
+LIMIT=30
+JSON_MODE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)
+            REPO_ARG="$2"
+            shift 2
+            ;;
+        --label)
+            LABEL_ARG="$2"
+            shift 2
+            ;;
+        --limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        --json)
+            JSON_MODE=1
+            shift
+            ;;
+        *)
+            echo "Usage: list-ready-issues [--repo owner/repo] [--label LABEL] [--limit N] [--json]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Build gh issue list args
+GH_ARGS=("issue" "list"
+    "--state" "open"
+    "--search" "no:assignee"
+    "--limit" "$LIMIT"
+    "--json" "number,title,labels,createdAt"
+)
+
+if [ -n "$REPO_ARG" ]; then
+    GH_ARGS+=("--repo" "$REPO_ARG")
+fi
+
+if [ -n "$LABEL_ARG" ]; then
+    GH_ARGS+=("--label" "$LABEL_ARG")
+fi
+
+# Build check-blocked repo args
+REPO_ARGS=()
+if [ -n "$REPO_ARG" ]; then
+    REPO_ARGS=("--repo" "$REPO_ARG")
+fi
+
+# Fetch candidates
+ALL_JSON=$(gh "${GH_ARGS[@]}" 2>&1) || {
+    echo "Error: gh issue list failed: $ALL_JSON" >&2
+    exit 2
+}
+
+# Collect ready issue numbers
+READY_NUMBERS=()
+BLOCKED_COUNT=0
+
+for n in $(echo "$ALL_JSON" | jq -r '.[].number'); do
+    if "$SCRIPT_DIR/check-blocked" --issue "$n" "${REPO_ARGS[@]}" >/dev/null 2>&1; then
+        READY_NUMBERS+=("$n")
+    else
+        BLOCKED_COUNT=$((BLOCKED_COUNT + 1))
+    fi
+done
+
+READY_COUNT=${#READY_NUMBERS[@]}
+
+# Re-filter original JSON to ready issues only, sort oldest-first,
+# normalise label objects to label-name strings
+if [ "$READY_COUNT" -eq 0 ]; then
+    READY_JSON='[]'
+else
+    NUMS_JSON=$(printf '%s\n' "${READY_NUMBERS[@]}" | jq -Rn '[inputs | tonumber]')
+    READY_JSON=$(echo "$ALL_JSON" | jq --argjson nums "$NUMS_JSON" '
+        [.[] | select(.number as $n | $nums | index($n))]
+        | sort_by(.createdAt)
+        | map({number, title, labels: [.labels[].name], createdAt})
+    ')
+fi
+
+# Output
+if [ "$JSON_MODE" -eq 1 ]; then
+    echo "$READY_JSON"
+else
+    echo "$READY_JSON" | jq -r '.[] | "#\(.number)\t\(.title)"'
+fi
+
+# Stderr summary
+echo "Found $READY_COUNT ready issues ($BLOCKED_COUNT blocked skipped)" >&2

--- a/plugins/looper/skills/looper/scripts/list-ready-issues
+++ b/plugins/looper/skills/looper/scripts/list-ready-issues
@@ -31,14 +31,29 @@ JSON_MODE=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --repo)
+            if [ $# -lt 2 ]; then
+                echo "Error: --repo requires a value" >&2
+                echo "Usage: list-ready-issues [--repo owner/repo] [--label LABEL] [--limit N] [--json]" >&2
+                exit 2
+            fi
             REPO_ARG="$2"
             shift 2
             ;;
         --label)
+            if [ $# -lt 2 ]; then
+                echo "Error: --label requires a value" >&2
+                echo "Usage: list-ready-issues [--repo owner/repo] [--label LABEL] [--limit N] [--json]" >&2
+                exit 2
+            fi
             LABEL_ARG="$2"
             shift 2
             ;;
         --limit)
+            if [ $# -lt 2 ]; then
+                echo "Error: --limit requires a value" >&2
+                echo "Usage: list-ready-issues [--repo owner/repo] [--label LABEL] [--limit N] [--json]" >&2
+                exit 2
+            fi
             LIMIT="$2"
             shift 2
             ;;
@@ -75,17 +90,34 @@ if [ -n "$REPO_ARG" ]; then
     REPO_ARGS=("--repo" "$REPO_ARG")
 fi
 
-# Fetch candidates
-ALL_JSON=$(gh "${GH_ARGS[@]}" 2>&1) || {
-    echo "Error: gh issue list failed: $ALL_JSON" >&2
+# Fetch candidates — keep stderr OUT of the JSON capture so advisory lines
+# from gh (rate-limit warnings, token expiry notices, etc.) do not corrupt
+# the JSON string.
+GH_STDERR=$(mktemp)
+trap 'rm -f "$GH_STDERR"' EXIT
+ALL_JSON=$(gh "${GH_ARGS[@]}" 2>"$GH_STDERR") || {
+    echo "Error: gh issue list failed: $(cat "$GH_STDERR")" >&2
+    rm -f "$GH_STDERR"
     exit 2
 }
+# Forward any advisory stderr from gh to our own stderr (visible to caller,
+# not captured into the JSON variable).
+if [ -s "$GH_STDERR" ]; then
+    cat "$GH_STDERR" >&2
+fi
 
 # Collect ready issue numbers
 READY_NUMBERS=()
 BLOCKED_COUNT=0
 
 for n in $(echo "$ALL_JSON" | jq -r '.[].number'); do
+    # check-blocked exit codes:
+    #   0 = not blocked (ready)
+    #   1 = blocked (label or open dep)
+    #   2 = internal error (bad args) — should never occur here since $n is
+    #       always a numeric id from jq. If it ever does, we conservatively
+    #       count it as blocked (safer to skip than to claim a possibly-blocked
+    #       issue).
     if "$SCRIPT_DIR/check-blocked" --issue "$n" "${REPO_ARGS[@]}" >/dev/null 2>&1; then
         READY_NUMBERS+=("$n")
     else
@@ -112,7 +144,9 @@ fi
 if [ "$JSON_MODE" -eq 1 ]; then
     echo "$READY_JSON"
 else
-    echo "$READY_JSON" | jq -r '.[] | "#\(.number)\t\(.title)"'
+    # Replace any embedded tab/newline/CR in titles so each line is exactly
+    # two tab-separated fields: #N<TAB><sanitised-title>
+    echo "$READY_JSON" | jq -r '.[] | "#\(.number)\t\(.title | gsub("[\t\n\r]"; " "))"'
 fi
 
 # Stderr summary

--- a/plugins/looper/skills/looper/scripts/validate-issue-body
+++ b/plugins/looper/skills/looper/scripts/validate-issue-body
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-issue-body — Validate an issue body has canonical ## Dependencies /
+# ## Blockers markers when cross-issue #<N> references are present outside
+# the allowed sections (## References, ## Context).
+#
+# Usage: validate-issue-body [--file PATH] [--quiet]
+#   --file PATH   Read body from PATH instead of stdin.
+#   --quiet       Suppress warnings; rely on exit code only.
+#
+# Exit 0: body OK (no offending refs, or refs inside allowed sections,
+#         or canonical dep/blocker section present alongside refs).
+# Exit 1: body has #<N> refs outside allowed sections AND no
+#         ## Dependencies / ## Blockers section present.
+# Exit 2: usage / IO error.
+
+FILE=""
+QUIET=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --file)
+            FILE="$2"
+            shift 2
+            ;;
+        --quiet)
+            QUIET=1
+            shift
+            ;;
+        *)
+            echo "Usage: validate-issue-body [--file PATH] [--quiet]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Read body
+if [ -n "$FILE" ]; then
+    BODY=$(cat "$FILE" 2>/dev/null) || {
+        echo "Error: cannot read file '$FILE'" >&2
+        exit 2
+    }
+else
+    BODY=$(cat 2>/dev/null) || {
+        echo "Error: cannot read stdin" >&2
+        exit 2
+    }
+fi
+
+# Empty body is always OK
+if [ -z "$BODY" ]; then
+    exit 0
+fi
+
+# Check if the original body has a canonical h2 dep/blocker section
+# (exact ^## prefix — h3 and below do not count)
+has_canonical_section() {
+    echo "$BODY" | grep -qE '^## (Dependencies|Blockers)$'
+}
+
+# Build a stripped body that removes the contents of allowed sections:
+# ## References and ## Context (between the heading and the next ## heading or EOF).
+# ## Subtasks is NOT a safe zone.
+STRIPPED=$(echo "$BODY" | awk '
+BEGIN { in_allowed = 0 }
+/^## (References|Context)$/ { in_allowed = 1; next }
+/^## / { in_allowed = 0 }
+!in_allowed { print }
+')
+
+# In the stripped body, search for bare #<N> (digits only, preceded by #)
+# Use grep with word-boundary-like pattern: # followed by one or more digits,
+# not followed by additional alpha chars (to avoid #abc123 false positives).
+REFS=$(echo "$STRIPPED" | grep -oE '#[0-9]+' || true)
+
+if [ -z "$REFS" ]; then
+    exit 0
+fi
+
+# Refs exist outside allowed sections — check for canonical section
+if has_canonical_section; then
+    exit 0
+fi
+
+# Violation found
+if [ "$QUIET" -eq 0 ]; then
+    REFS_SUMMARY=$(echo "$REFS" | tr '\n' ' ')
+    echo "Warning: issue body references ${REFS_SUMMARY% } outside ## References / ## Context" >&2
+    echo "  but has no ## Dependencies or ## Blockers section." >&2
+    echo "  Add one of:" >&2
+    echo "    ## Dependencies" >&2
+    echo "    - [ ] Depends on #<N> — <reason>" >&2
+    echo "  or:" >&2
+    echo "    ## Blockers" >&2
+    echo "    - [ ] Blocked by #<N> — <reason>" >&2
+fi
+exit 1

--- a/plugins/looper/skills/looper/scripts/validate-issue-body
+++ b/plugins/looper/skills/looper/scripts/validate-issue-body
@@ -21,6 +21,11 @@ QUIET=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --file)
+            if [ $# -lt 2 ]; then
+                echo "Error: --file requires a value" >&2
+                echo "Usage: validate-issue-body [--file PATH] [--quiet]" >&2
+                exit 2
+            fi
             FILE="$2"
             shift 2
             ;;
@@ -59,20 +64,46 @@ has_canonical_section() {
     echo "$BODY" | grep -qE '^## (Dependencies|Blockers)$'
 }
 
-# Build a stripped body that removes the contents of allowed sections:
-# ## References and ## Context (between the heading and the next ## heading or EOF).
+# Build a stripped body that removes:
+# 1. The contents of allowed sections: ## References and ## Context
+# 2. Fenced code blocks (``` or ~~~ lines — simple toggle-based detection)
 # ## Subtasks is NOT a safe zone.
 STRIPPED=$(echo "$BODY" | awk '
-BEGIN { in_allowed = 0 }
-/^## (References|Context)$/ { in_allowed = 1; next }
+BEGIN { in_allowed = 0; in_code = 0 }
+# Toggle code-fence state on lines that start a fence marker (``` or ~~~
+# optionally followed by a language tag).
+/^```/ || /^~~~/ {
+    in_code = !in_code
+    next
+}
+in_code { next }
+/^## (References|Context)[[:space:]]*$/ { in_allowed = 1; next }
 /^## / { in_allowed = 0 }
 !in_allowed { print }
 ')
 
-# In the stripped body, search for bare #<N> (digits only, preceded by #)
-# Use grep with word-boundary-like pattern: # followed by one or more digits,
-# not followed by additional alpha chars (to avoid #abc123 false positives).
-REFS=$(echo "$STRIPPED" | grep -oE '#[0-9]+' || true)
+# In the stripped body, extract bare #<N> refs with a boundary-aware regex:
+# require that the character after the digits is NOT alphanumeric/underscore/hyphen
+# (or is end-of-line). This avoids false positives like #123abc (identifier-like
+# suffixes) while still catching #42, #42., #42) etc.
+RAW_REFS=$(echo "$STRIPPED" | grep -oE '#[0-9]+([^0-9A-Za-z_-]|$)' | grep -oE '#[0-9]+' || true)
+
+# Post-filter: drop hex-color-like refs whose source line contains the
+# case-insensitive word "color" (e.g. "hex color #123456").
+# Heuristic — imperfect; users can sidestep ambiguous cases by moving refs
+# to ## References or ## Context, or by adding a ## Dependencies / ## Blockers
+# section. Never blocks builds — this is a warning-only validator.
+REFS=""
+while IFS= read -r ref; do
+    [ -z "$ref" ] && continue
+    # Check if the source line containing this ref also contains 'color'
+    if echo "$STRIPPED" | grep -F -- "$ref" | grep -qi "color"; then
+        continue  # Likely a hex color, skip
+    fi
+    REFS="${REFS}${ref}"$'\n'
+done <<< "$RAW_REFS"
+# Trim trailing newline
+REFS="${REFS%$'\n'}"
 
 if [ -z "$REFS" ]; then
     exit 0

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -38,6 +38,7 @@ run_suite "test-fetch-issue-context.sh"
 run_suite "test-build-agent-context.sh"
 run_suite "test-resolve-plan-pointers.sh"
 run_suite "test-delta-mode-prompts.sh"
+run_suite "test-issue-tooling.sh"
 
 echo "=============================="
 echo "Corner-case suite: $PASS suites passed, $FAIL suites failed"

--- a/tests/test-issue-tooling.sh
+++ b/tests/test-issue-tooling.sh
@@ -528,6 +528,133 @@ else
 fi
 
 # ============================================================
+# Section H: Iteration 2 regression tests (H1–H12)
+# ============================================================
+
+echo ""
+echo "=== Section H: Iteration 2 regression tests ==="
+
+# H1: gh stderr noise must not poison JSON capture
+echo "=== H1: gh stderr noise + valid JSON -> issue still surfaced ==="
+TMPDIR_TEST=$(mktemp -d)
+cat > "$TMPDIR_TEST/gh" << 'GHEOF'
+#!/usr/bin/env bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+    echo "gh: warning: token will expire in 7 days" >&2
+    echo "gh: notice: rate limit at 50%" >&2
+    echo '[{"number":42,"title":"Real Issue","labels":[],"createdAt":"2024-01-01T00:00:00Z"}]'
+    exit 0
+fi
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+    echo '{"labels":[],"body":""}'
+    exit 0
+fi
+exit 1
+GHEOF
+chmod +x "$TMPDIR_TEST/gh"
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/tmp/lri_stderr_h1.txt) && EXIT_CODE=0 || EXIT_CODE=$?
+STDERR=$(cat /tmp/lri_stderr_h1.txt)
+assert_exit_zero "H1: exit 0 despite gh stderr noise" "$EXIT_CODE"
+assert_output_contains "H1: real issue surfaced in TSV" "$STDOUT" "#42"
+assert_output_contains "H1: summary reports 1 ready" "$STDERR" "Found 1"
+cleanup
+
+# H2: --repo missing value -> exit 2
+echo "=== H2: --repo missing value -> exit 2 ==="
+STDERR_OUT=$("$LIST_READY" --repo 2>&1 1>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_two "H2: --repo missing value exit 2" "$EXIT_CODE"
+assert_output_contains "H2: stderr mentions --repo or usage" "$STDERR_OUT" "repo"
+
+# H3: --label missing value -> exit 2
+echo "=== H3: --label missing value -> exit 2 ==="
+STDERR_OUT=$("$LIST_READY" --label 2>&1 1>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_two "H3: --label missing value exit 2" "$EXIT_CODE"
+assert_output_contains "H3: stderr mentions --label or usage" "$STDERR_OUT" "label"
+
+# H4: --limit missing value -> exit 2
+echo "=== H4: --limit missing value -> exit 2 ==="
+STDERR_OUT=$("$LIST_READY" --limit 2>&1 1>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_two "H4: --limit missing value exit 2" "$EXIT_CODE"
+assert_output_contains "H4: stderr mentions --limit or usage" "$STDERR_OUT" "limit"
+
+# H5: validate-issue-body --file missing value -> exit 2
+echo "=== H5: validate-issue-body --file missing value -> exit 2 ==="
+STDERR_OUT=$("$VALIDATE" --file 2>&1 1>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_two "H5: --file missing value exit 2" "$EXIT_CODE"
+assert_output_contains "H5: stderr mentions --file or usage" "$STDERR_OUT" "file"
+
+# H6: TSV title with embedded tab -> sanitised (exactly 2 fields)
+echo "=== H6: TSV title with embedded tab -> sanitised ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[{"number":10,"title":"Title	with	tabs","labels":[],"createdAt":"2024-01-01T00:00:00Z"}]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "H6: exit 0" "$EXIT_CODE"
+assert_line_count "H6: exactly 1 line of output" "$STDOUT" 1
+FIELD_COUNT=$(echo "$STDOUT" | awk -F'	' '{print NF}')
+if [ "$FIELD_COUNT" = "2" ]; then
+    echo "PASS: H6: exactly 2 tab-separated fields"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: H6: expected 2 tab-separated fields, got $FIELD_COUNT"
+    FAIL=$((FAIL + 1))
+fi
+cleanup
+
+# H7: TSV title with embedded newline -> single line
+echo "=== H7: TSV title with embedded newline -> single line ==="
+TMPDIR_TEST=$(mktemp -d)
+# Title contains a real newline in the JSON string
+ALL_JSON='[{"number":11,"title":"Line one\nLine two","labels":[],"createdAt":"2024-01-01T00:00:00Z"}]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_11.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "H7: exit 0" "$EXIT_CODE"
+assert_line_count "H7: exactly 1 line of output" "$STDOUT" 1
+cleanup
+
+# H8: hex color #123456 should NOT trigger validator warning (exit 0)
+echo "=== H8: hex color #123456 -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nUse hex color #123456 for the badge.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "H8: hex color #123456: exit 0" "$EXIT_CODE"
+cleanup
+
+# H9: ref inside ``` fenced code block -> exit 0
+echo "=== H9: ref inside fenced code block -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nWorking on it.\n\n```\ngit show #123\n```\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "H9: fenced code-block ref: exit 0" "$EXIT_CODE"
+cleanup
+
+# H10: #123abc (digits-then-alpha) should NOT trigger warning (exit 0)
+echo "=== H10: #123abc -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nThe identifier is #123abc not an issue.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "H10: #123abc identifier: exit 0" "$EXIT_CODE"
+cleanup
+
+# H11: ref inside ~~~ fenced code block -> exit 0
+echo "=== H11: ref inside ~~~ fenced block -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nLook at this snippet.\n\n~~~\nrelates to #456\n~~~\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "H11: ~~~ fenced block ref: exit 0" "$EXIT_CODE"
+cleanup
+
+# H12: real ref with period suffix '#42.' still triggers warning (exit 1)
+echo "=== H12: regression — '#42.' still triggers warning ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nThis builds on #42. It is needed.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" --quiet && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "H12: '#42.' still flagged: exit 1" "$EXIT_CODE"
+cleanup
+
+# ============================================================
 # Summary
 # ============================================================
 

--- a/tests/test-issue-tooling.sh
+++ b/tests/test-issue-tooling.sh
@@ -8,7 +8,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 VALIDATE="$REPO_ROOT/plugins/looper/skills/looper/scripts/validate-issue-body"
 LIST_READY="$REPO_ROOT/plugins/looper/skills/looper/scripts/list-ready-issues"
-CHECK_BLOCKED="$REPO_ROOT/plugins/looper/skills/looper/scripts/check-blocked"
 
 PASS=0
 FAIL=0
@@ -29,18 +28,6 @@ assert_exit_zero() {
         PASS=$((PASS + 1))
     else
         echo "FAIL: $description (expected exit 0, got $exit_code)"
-        FAIL=$((FAIL + 1))
-    fi
-}
-
-assert_exit_nonzero() {
-    local description="$1"
-    local exit_code="$2"
-    if [ "$exit_code" -ne 0 ]; then
-        echo "PASS: $description"
-        PASS=$((PASS + 1))
-    else
-        echo "FAIL: $description (expected non-zero exit, got 0)"
         FAIL=$((FAIL + 1))
     fi
 }
@@ -329,7 +316,7 @@ ALL_JSON='[
   {"number":30,"title":"Issue Thirty","labels":[],"createdAt":"2024-01-03T00:00:00Z"}
 ]'
 echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
-echo '{"labels":[],"body":"Blocked by #99\nNeeds auth first."}' > "$TMPDIR_TEST/issue_json_20.txt"
+printf '{"labels":[],"body":"Blocked by #99\\nNeeds auth first."}\n' > "$TMPDIR_TEST/issue_json_20.txt"
 echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_30.txt"
 write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" "99 OPEN"
 STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/tmp/lri_stderr_b3.txt) && EXIT_CODE=0 || EXIT_CODE=$?
@@ -351,7 +338,7 @@ echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_20.txt"
 write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
 JSON_OUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" --json 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
 assert_exit_zero "B4: --json exit 0" "$EXIT_CODE"
-VALID=$(echo "$JSON_OUT" | jq -e 'length == 2 and (.[0] | has("number") and has("title") and has("labels") and has("createdAt"))' 2>/dev/null) && JQ_EXIT=0 || JQ_EXIT=$?
+echo "$JSON_OUT" | jq -e 'length == 2 and (.[0] | has("number") and has("title") and has("labels") and has("createdAt"))' > /dev/null 2>/dev/null && JQ_EXIT=0 || JQ_EXIT=$?
 assert_exit_zero "B4: JSON has required fields (number,title,labels,createdAt)" "$JQ_EXIT"
 cleanup
 
@@ -365,7 +352,7 @@ echo '{"labels":[{"name":"enhancement"}],"body":""}' > "$TMPDIR_TEST/issue_json_
 write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
 JSON_OUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" --json 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
 assert_exit_zero "B5: --json exit 0" "$EXIT_CODE"
-ALL_STRINGS=$(echo "$JSON_OUT" | jq -e '.[0].labels | all(. | type == "string")' 2>/dev/null) && JQ_EXIT=0 || JQ_EXIT=$?
+echo "$JSON_OUT" | jq -e '.[0].labels | all(. | type == "string")' > /dev/null 2>/dev/null && JQ_EXIT=0 || JQ_EXIT=$?
 assert_exit_zero "B5: labels are strings not objects" "$JQ_EXIT"
 cleanup
 

--- a/tests/test-issue-tooling.sh
+++ b/tests/test-issue-tooling.sh
@@ -1,0 +1,555 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-issue-tooling.sh — Tests for validate-issue-body and list-ready-issues
+# Runs against the scripts under plugins/looper/skills/looper/scripts/
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATE="$REPO_ROOT/plugins/looper/skills/looper/scripts/validate-issue-body"
+LIST_READY="$REPO_ROOT/plugins/looper/skills/looper/scripts/list-ready-issues"
+CHECK_BLOCKED="$REPO_ROOT/plugins/looper/skills/looper/scripts/check-blocked"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+    if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_nonzero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -ne 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected non-zero exit, got 0)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_one() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 1 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 1, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_exit_two() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 2 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 2, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -qi "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output to contain '$expected')"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_empty() {
+    local description="$1"
+    local output="$2"
+    if [ -z "$output" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected empty output, got: $output)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_line_count() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    local actual
+    if [ -z "$output" ]; then
+        actual=0
+    else
+        actual=$(echo "$output" | wc -l | tr -d ' ')
+    fi
+    if [ "$actual" -eq "$expected" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected $expected lines, got $actual)"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Write a mock gh script for list-ready-issues tests
+# Arguments: mock_dir, issue_list_json (what gh issue list returns),
+#            dep_states (lines of "NUMBER STATE" for issue view state queries)
+write_mock_gh_for_lri() {
+    local mock_dir="$1"
+    local issue_list_json="$2"
+    local dep_states="${3:-}"
+
+    # Write the issue list JSON to a file
+    echo "$issue_list_json" > "$mock_dir/issue_list.json"
+    if [ -n "$dep_states" ]; then
+        echo "$dep_states" > "$mock_dir/dep_states.txt"
+    fi
+
+    cat > "$mock_dir/gh" << 'GHEOF'
+#!/usr/bin/env bash
+MOCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Record what was called (for --label flag test)
+echo "$@" >> "$MOCK_DIR/gh_calls.log" 2>/dev/null || true
+
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+    cat "$MOCK_DIR/issue_list.json"
+    exit 0
+fi
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+    issue_num="$3"
+    shift 3
+    args="$*"
+    # Handle --json labels,body (used by check-blocked for main fetch)
+    if echo "$args" | grep -q -- "--json"; then
+        json_fields=$(echo "$args" | grep -o -- '--json [^ ]*' | sed 's/--json //')
+        if echo "$json_fields" | grep -q "body\|labels"; then
+            # Return issue data from our fixture
+            if [ -f "$MOCK_DIR/issue_json_${issue_num}.txt" ]; then
+                cat "$MOCK_DIR/issue_json_${issue_num}.txt"
+            else
+                echo '{"labels":[],"body":""}'
+            fi
+            exit 0
+        fi
+        if echo "$json_fields" | grep -q "state"; then
+            # Dep state lookup — handle --jq '.state' case
+            state="CLOSED"
+            if [ -f "$MOCK_DIR/dep_states.txt" ]; then
+                match=$(grep "^${issue_num} " "$MOCK_DIR/dep_states.txt" 2>/dev/null || true)
+                if [ -n "$match" ]; then
+                    state=$(echo "$match" | awk '{print $2}')
+                fi
+            fi
+            echo "$state"
+            exit 0
+        fi
+    fi
+fi
+
+# Fallback — unknown command
+exit 1
+GHEOF
+    chmod +x "$mock_dir/gh"
+}
+
+# ============================================================
+# Section A: validate-issue-body tests
+# ============================================================
+
+echo ""
+echo "=== Section A: validate-issue-body tests ==="
+
+# A1: Empty body (--file /dev/null) -> exit 0
+echo "=== A1: Empty body -> exit 0 ==="
+"$VALIDATE" --file /dev/null && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A1: empty body: exit 0" "$EXIT_CODE"
+
+# A2: Plain body with no refs -> exit 0
+echo "=== A2: Plain body no refs -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nThis is a plain issue with no issue references.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A2: no refs: exit 0" "$EXIT_CODE"
+cleanup
+
+# A3: Ref in Description, no canonical section -> exit 1
+echo "=== A3: Ref in Description, no canonical section -> exit 1 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nThis builds on #42 to extend behavior.\n\n## Motivation\nImportant change.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "A3: ref in Description, no canonical section: exit 1" "$EXIT_CODE"
+cleanup
+
+# A4: Ref in Description, ## Dependencies present -> exit 0
+echo "=== A4: Ref in Description, ## Dependencies present -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nThis builds on #42.\n\n## Dependencies\n- [ ] Depends on #42 — needed for auth\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A4: ref with ## Dependencies present: exit 0" "$EXIT_CODE"
+cleanup
+
+# A5: Ref only in ## References -> exit 0
+echo "=== A5: Ref only in ## References -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nA standalone improvement.\n\n## References\n- See #42 for prior art\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A5: ref only in ## References: exit 0" "$EXIT_CODE"
+cleanup
+
+# A6: Ref only in ## Subtasks, no ## Dependencies / ## Blockers -> exit 1
+# (## Subtasks is NOT a safe zone — check-blocked scans the full body)
+echo "=== A6: Ref only in ## Subtasks, no canonical section -> exit 1 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nA standalone feature.\n\n## Subtasks\n- [ ] Implement after #42 lands\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "A6: ref in Subtasks, no canonical section: exit 1" "$EXIT_CODE"
+cleanup
+
+# A7: Ref only in ## Context -> exit 0
+echo "=== A7: Ref only in ## Context -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nAn improvement.\n\n## Context\n- Found by reviewing #42 behavior\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A7: ref only in ## Context: exit 0" "$EXIT_CODE"
+cleanup
+
+# A8: #abc (hex/non-digit) -> exit 0
+echo "=== A8: #abc (non-digit) -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nSee commit #abc123 for details.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A8: #abc hex: exit 0" "$EXIT_CODE"
+cleanup
+
+# A9: PR URL /pull/123 -> exit 0 (no false positive from URL paths)
+echo "=== A9: PR URL /pull/123 -> exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nSee https://github.com/owner/repo/pull/123 for context.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "A9: PR URL /pull/123: exit 0" "$EXIT_CODE"
+cleanup
+
+# A10: ### Dependencies (h3) with ref outside it -> exit 1 (h3 doesn't count)
+echo "=== A10: ### Dependencies (h3) with ref, no h2 canonical section -> exit 1 ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nBuilds on #42.\n\n### Dependencies\nThis is h3, not h2.\n' > "$TMPDIR_TEST/body.md"
+"$VALIDATE" --file "$TMPDIR_TEST/body.md" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "A10: h3 Dependencies with ref outside: exit 1" "$EXIT_CODE"
+cleanup
+
+# A11: --quiet mode -> exit 1 with no stderr output
+echo "=== A11: --quiet mode -> exit 1, no stderr ==="
+TMPDIR_TEST=$(mktemp -d)
+printf '## Description\nBuilds on #42.\n' > "$TMPDIR_TEST/body.md"
+STDERR_OUT=$("$VALIDATE" --file "$TMPDIR_TEST/body.md" --quiet 2>&1 1>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_one "A11: --quiet mode: exit 1" "$EXIT_CODE"
+assert_output_empty "A11: --quiet mode: no stderr output" "$STDERR_OUT"
+cleanup
+
+# ============================================================
+# Section B: list-ready-issues tests (mocked gh)
+# ============================================================
+
+echo ""
+echo "=== Section B: list-ready-issues tests ==="
+
+# B1: Three open unassigned, none blocked -> 3 TSV lines, summary "Found 3 ... (0 blocked)"
+echo "=== B1: Three issues, none blocked -> 3 TSV lines ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[
+  {"number":10,"title":"Issue Ten","labels":[],"createdAt":"2024-01-01T00:00:00Z"},
+  {"number":20,"title":"Issue Twenty","labels":[],"createdAt":"2024-01-02T00:00:00Z"},
+  {"number":30,"title":"Issue Thirty","labels":[],"createdAt":"2024-01-03T00:00:00Z"}
+]'
+# No blocking — all issues have empty bodies, no blocking labels
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_20.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_30.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/tmp/lri_stderr_b1.txt) && EXIT_CODE=0 || EXIT_CODE=$?
+STDERR=$(cat /tmp/lri_stderr_b1.txt)
+assert_exit_zero "B1: exit 0" "$EXIT_CODE"
+assert_line_count "B1: 3 TSV lines" "$STDOUT" 3
+assert_output_contains "B1: summary has Found 3" "$STDERR" "Found 3"
+assert_output_contains "B1: summary has 0 blocked" "$STDERR" "0 blocked"
+cleanup
+
+# B2: One blocked by label -> 2 TSV lines, summary "Found 2 ... (1 blocked)"
+echo "=== B2: One blocked by label -> 2 TSV lines ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[
+  {"number":10,"title":"Issue Ten","labels":[],"createdAt":"2024-01-01T00:00:00Z"},
+  {"number":20,"title":"Issue Twenty","labels":[{"name":"blocked","color":"red"}],"createdAt":"2024-01-02T00:00:00Z"},
+  {"number":30,"title":"Issue Thirty","labels":[],"createdAt":"2024-01-03T00:00:00Z"}
+]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+echo '{"labels":[{"name":"blocked"}],"body":""}' > "$TMPDIR_TEST/issue_json_20.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_30.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/tmp/lri_stderr_b2.txt) && EXIT_CODE=0 || EXIT_CODE=$?
+STDERR=$(cat /tmp/lri_stderr_b2.txt)
+assert_exit_zero "B2: exit 0" "$EXIT_CODE"
+assert_line_count "B2: 2 TSV lines" "$STDOUT" 2
+assert_output_contains "B2: summary has Found 2" "$STDERR" "Found 2"
+assert_output_contains "B2: summary has 1 blocked" "$STDERR" "1 blocked"
+cleanup
+
+# B3: One blocked by "Blocked by #99" ref to open #99 -> that issue filtered out
+echo "=== B3: One blocked by dep ref -> filtered out ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[
+  {"number":10,"title":"Issue Ten","labels":[],"createdAt":"2024-01-01T00:00:00Z"},
+  {"number":20,"title":"Issue Twenty","labels":[],"createdAt":"2024-01-02T00:00:00Z"},
+  {"number":30,"title":"Issue Thirty","labels":[],"createdAt":"2024-01-03T00:00:00Z"}
+]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+echo '{"labels":[],"body":"Blocked by #99\nNeeds auth first."}' > "$TMPDIR_TEST/issue_json_20.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_30.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" "99 OPEN"
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/tmp/lri_stderr_b3.txt) && EXIT_CODE=0 || EXIT_CODE=$?
+STDERR=$(cat /tmp/lri_stderr_b3.txt)
+assert_exit_zero "B3: exit 0" "$EXIT_CODE"
+assert_line_count "B3: 2 TSV lines (blocked filtered)" "$STDOUT" 2
+assert_output_contains "B3: summary has 1 blocked" "$STDERR" "1 blocked"
+cleanup
+
+# B4: --json mode -> valid JSON with required fields including createdAt
+echo "=== B4: --json mode -> valid JSON with required fields ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[
+  {"number":10,"title":"Issue Ten","labels":[],"createdAt":"2024-01-01T00:00:00Z"},
+  {"number":20,"title":"Issue Twenty","labels":[],"createdAt":"2024-01-02T00:00:00Z"}
+]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_20.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+JSON_OUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" --json 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "B4: --json exit 0" "$EXIT_CODE"
+VALID=$(echo "$JSON_OUT" | jq -e 'length == 2 and (.[0] | has("number") and has("title") and has("labels") and has("createdAt"))' 2>/dev/null) && JQ_EXIT=0 || JQ_EXIT=$?
+assert_exit_zero "B4: JSON has required fields (number,title,labels,createdAt)" "$JQ_EXIT"
+cleanup
+
+# B5: JSON labels is an array of strings, not objects
+echo "=== B5: JSON labels are strings not objects ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[
+  {"number":10,"title":"Issue Ten","labels":[{"name":"enhancement","color":"blue"}],"createdAt":"2024-01-01T00:00:00Z"}
+]'
+echo '{"labels":[{"name":"enhancement"}],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+JSON_OUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" --json 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "B5: --json exit 0" "$EXIT_CODE"
+ALL_STRINGS=$(echo "$JSON_OUT" | jq -e '.[0].labels | all(. | type == "string")' 2>/dev/null) && JQ_EXIT=0 || JQ_EXIT=$?
+assert_exit_zero "B5: labels are strings not objects" "$JQ_EXIT"
+cleanup
+
+# B6: --label feature flag -> forwarded to gh
+echo "=== B6: --label feature -> forwarded to gh ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[{"number":10,"title":"Feature Issue","labels":[{"name":"feature"}],"createdAt":"2024-01-01T00:00:00Z"}]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" --label feature 2>/dev/null && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "B6: --label feature exit 0" "$EXIT_CODE"
+# Check that --label feature was forwarded to gh
+GH_CALLS=$(cat "$TMPDIR_TEST/gh_calls.log" 2>/dev/null || echo "")
+assert_output_contains "B6: --label feature forwarded to gh" "$GH_CALLS" "feature"
+cleanup
+
+# B7: Sort order (TSV) oldest-first by createdAt
+echo "=== B7: Sort order oldest-first ==="
+TMPDIR_TEST=$(mktemp -d)
+# Issues in reverse order in the list output
+ALL_JSON='[
+  {"number":30,"title":"Newest","labels":[],"createdAt":"2024-03-01T00:00:00Z"},
+  {"number":10,"title":"Oldest","labels":[],"createdAt":"2024-01-01T00:00:00Z"},
+  {"number":20,"title":"Middle","labels":[],"createdAt":"2024-02-01T00:00:00Z"}
+]'
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_20.txt"
+echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_30.txt"
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+FIRST_LINE=$(echo "$STDOUT" | head -1)
+assert_exit_zero "B7: exit 0" "$EXIT_CODE"
+assert_output_contains "B7: first line is oldest (#10)" "$FIRST_LINE" "#10"
+cleanup
+
+# B8: Empty result -> 0 stdout lines, summary "Found 0 ... (0 blocked)", exit 0
+echo "=== B8: Empty result -> 0 lines, exit 0 ==="
+TMPDIR_TEST=$(mktemp -d)
+ALL_JSON='[]'
+write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
+STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/tmp/lri_stderr_b8.txt) && EXIT_CODE=0 || EXIT_CODE=$?
+STDERR=$(cat /tmp/lri_stderr_b8.txt)
+assert_exit_zero "B8: empty list exit 0" "$EXIT_CODE"
+assert_output_empty "B8: no stdout lines" "$STDOUT"
+assert_output_contains "B8: summary Found 0" "$STDERR" "Found 0"
+cleanup
+
+# B9: gh failure -> list-ready-issues exit 2, error on stderr
+echo "=== B9: gh failure -> exit 2 ==="
+TMPDIR_TEST=$(mktemp -d)
+cat > "$TMPDIR_TEST/gh" << 'GHEOF'
+#!/usr/bin/env bash
+echo "gh: error: network failure" >&2
+exit 1
+GHEOF
+chmod +x "$TMPDIR_TEST/gh"
+STDERR_OUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>&1 1>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_two "B9: gh failure exit 2" "$EXIT_CODE"
+assert_output_contains "B9: stderr has error" "$STDERR_OUT" "error\|fail\|Error\|Fail"
+cleanup
+
+# ============================================================
+# Section C: gh-issue-creator.md rule presence (static greps)
+# ============================================================
+
+echo ""
+echo "=== Section C: gh-issue-creator.md rule presence ==="
+GH_CREATOR="$REPO_ROOT/plugins/looper/agents/gh-issue-creator.md"
+
+grep -q "Dep/blocker detection rule" "$GH_CREATOR" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "C1: gh-issue-creator has 'Dep/blocker detection rule'" "$EXIT_CODE"
+
+grep -q "validate-issue-body" "$GH_CREATOR" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "C2: gh-issue-creator mentions validate-issue-body" "$EXIT_CODE"
+
+grep -q "Refused — caller mentioned" "$GH_CREATOR" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "C3: gh-issue-creator has refusal message" "$EXIT_CODE"
+
+# ============================================================
+# Section D: planner.md / doer.md template extension
+# ============================================================
+
+echo ""
+echo "=== Section D: planner.md / doer.md template extension ==="
+PLANNER_MD="$REPO_ROOT/plugins/looper/agents/planner.md"
+DOER_MD="$REPO_ROOT/plugins/looper/agents/doer.md"
+
+grep -q "Dependencies: <#N" "$PLANNER_MD" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "D1: planner.md has Dependencies template" "$EXIT_CODE"
+
+grep -q "Blockers: <#N" "$PLANNER_MD" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "D2: planner.md has Blockers template" "$EXIT_CODE"
+
+grep -q "Dependencies: <#N" "$DOER_MD" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "D3: doer.md has Dependencies template" "$EXIT_CODE"
+
+grep -q "Blockers: <#N" "$DOER_MD" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "D4: doer.md has Blockers template" "$EXIT_CODE"
+
+# ============================================================
+# Section E: looper-issue/SKILL.md migration
+# ============================================================
+
+echo ""
+echo "=== Section E: looper-issue/SKILL.md migration ==="
+LOOPER_ISSUE="$REPO_ROOT/plugins/looper/skills/looper-issue/SKILL.md"
+
+grep -q "list-ready-issues --json" "$LOOPER_ISSUE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "E1: looper-issue uses list-ready-issues --json" "$EXIT_CODE"
+
+# Old raw gh issue list call should be removed
+if grep -q 'gh issue list --state open --search "no:assignee" --limit 20' "$LOOPER_ISSUE"; then
+    echo "FAIL: E2: old raw gh issue list call still present"
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: E2: old raw gh issue list call removed"
+    PASS=$((PASS + 1))
+fi
+
+grep -q "Found .* ready issues\|Found.*ready" "$LOOPER_ISSUE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "E3: looper-issue has visibility line pattern" "$EXIT_CODE"
+
+grep -q "mktemp" "$LOOPER_ISSUE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "E4: looper-issue uses mktemp for stats capture" "$EXIT_CODE"
+
+# ============================================================
+# Section F: looper-ee/SKILL.md Phase 3c
+# ============================================================
+
+echo ""
+echo "=== Section F: looper-ee/SKILL.md Phase 3c ==="
+LOOPER_EE="$REPO_ROOT/plugins/looper/skills/looper-ee/SKILL.md"
+
+grep -q "## Phase 3c: Pre-Worktree Blocked Check" "$LOOPER_EE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "F1: looper-ee has Phase 3c heading" "$EXIT_CODE"
+
+grep -q "UPSTREAM_OWNED" "$LOOPER_EE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "F2: looper-ee Phase 3c re-derives UPSTREAM_OWNED" "$EXIT_CODE"
+
+grep -qE 'check-blocked --issue.*--repo' "$LOOPER_EE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "F3: looper-ee Phase 3c calls check-blocked with --issue and --repo" "$EXIT_CODE"
+
+grep -q "Skipping blocked check" "$LOOPER_EE" && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "F4: looper-ee Phase 3c skips when upstream-claimed" "$EXIT_CODE"
+
+# ============================================================
+# Section G: ISSUE_TEMPLATE existence
+# ============================================================
+
+echo ""
+echo "=== Section G: .github/ISSUE_TEMPLATE/default.md ==="
+ISSUE_TEMPLATE="$REPO_ROOT/.github/ISSUE_TEMPLATE/default.md"
+
+[ -f "$ISSUE_TEMPLATE" ] && EXIT_CODE=0 || EXIT_CODE=$?
+assert_exit_zero "G1: .github/ISSUE_TEMPLATE/default.md exists" "$EXIT_CODE"
+
+if [ -f "$ISSUE_TEMPLATE" ]; then
+    grep -q "load-bearing" "$ISSUE_TEMPLATE" && EXIT_CODE=0 || EXIT_CODE=$?
+    assert_exit_zero "G2: default.md contains 'load-bearing'" "$EXIT_CODE"
+
+    grep -qE '^## Dependencies' "$ISSUE_TEMPLATE" && EXIT_CODE=0 || EXIT_CODE=$?
+    assert_exit_zero "G3: default.md has ## Dependencies heading" "$EXIT_CODE"
+
+    grep -qE '^## Blockers' "$ISSUE_TEMPLATE" && EXIT_CODE=0 || EXIT_CODE=$?
+    assert_exit_zero "G4: default.md has ## Blockers heading" "$EXIT_CODE"
+else
+    echo "FAIL: G2: cannot check content (file missing)"
+    FAIL=$((FAIL + 1))
+    echo "FAIL: G3: cannot check content (file missing)"
+    FAIL=$((FAIL + 1))
+    echo "FAIL: G4: cannot check content (file missing)"
+    FAIL=$((FAIL + 1))
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-issue-tooling.sh
+++ b/tests/test-issue-tooling.sh
@@ -584,9 +584,10 @@ assert_exit_two "H5: --file missing value exit 2" "$EXIT_CODE"
 assert_output_contains "H5: stderr mentions --file or usage" "$STDERR_OUT" "file"
 
 # H6: TSV title with embedded tab -> sanitised (exactly 2 fields)
+# Use \t JSON escape sequence so jq can parse it; jq will decode to a real tab.
 echo "=== H6: TSV title with embedded tab -> sanitised ==="
 TMPDIR_TEST=$(mktemp -d)
-ALL_JSON='[{"number":10,"title":"Title	with	tabs","labels":[],"createdAt":"2024-01-01T00:00:00Z"}]'
+ALL_JSON='[{"number":10,"title":"Title\twith\ttabs","labels":[],"createdAt":"2024-01-01T00:00:00Z"}]'
 echo '{"labels":[],"body":""}' > "$TMPDIR_TEST/issue_json_10.txt"
 write_mock_gh_for_lri "$TMPDIR_TEST" "$ALL_JSON" ""
 STDOUT=$(PATH="$TMPDIR_TEST:$PATH" "$LIST_READY" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?


### PR DESCRIPTION
## Problem / Task

Three workflow gaps reduced the reliability of `looper-watch`'s ready-issue dispatch (issue #92):

1. **Issues filed without canonical `## Dependencies` / `## Blockers` markers** — prose "Relationship" sections are human docs only; the markers are the machine-readable signal `check-blocked` and `looper-watch::is_blocked` parse. Several issues filed this session (#82, #85, #88, #89, #90) had to be backfilled retroactively.
2. **No CLI to list ready-to-work issues** — humans and external scripts had no shell equivalent of `looper-watch`'s internal "what's pickable?" filter.
3. **Entry-point skills were inconsistent** — `looper-issue` duplicated the block-detection logic and silently skipped blocked issues; `looper-ee` skipped the check entirely and could spin up a worktree on a blocked issue.

**Current behavior:** dependency markers are convention-only (no enforcement); no `list-ready-issues` CLI; `looper-ee` claims+worktrees blocked issues; `looper-issue` lacks visibility into what was filtered.
**Expected behavior:** `gh-issue-creator` enforces the marker contract; new `validate-issue-body` script flags missing canonical sections; new `list-ready-issues` script is the single source of truth for "what's pickable"; `looper-issue` reports filter visibility; `looper-ee` aborts cleanly before worktree on a blocked issue (skipping when upstream-claimed).

Closes #92.

## Existing Architecture

The block-detection logic was scattered across two callers and the `looper-watch` daemon, with no enforcement at issue-creation time and no shell CLI for ad-hoc queries.

```mermaid
graph TD
    GHIC[gh-issue-creator agent] -.->|may forget markers| Issue[GitHub Issue]
    Planner[planner agent] -->|spawn for unrelated bug| GHIC
    Doer[doer agent] -->|spawn for unrelated bug| GHIC
    LooperIssue[looper-issue Phase 1a/b/c] -->|inline gh+loop| CheckBlocked[check-blocked script]
    LooperEE[looper-ee] -.->|no check| Worktree[(worktree)]
    LooperWatch[looper-watch crate] -->|GraphQL| Issue
    style GHIC fill:#f66,stroke:#333
    style LooperEE fill:#f66,stroke:#333
    style LooperIssue fill:#ff6,stroke:#333
```

## Proposed Architecture

A new `list-ready-issues` script becomes the single source of truth for shell-side dispatch; `validate-issue-body` enforces marker presence; `looper-ee` gains a Phase 3c pre-worktree gate; agent prompts now refuse ambiguous cross-issue references.

```mermaid
graph TD
    GHIC[gh-issue-creator agent — refuses ambiguous refs] --> Validator[validate-issue-body]
    Validator -->|warn on missing markers| Issue[GitHub Issue]
    Planner[planner agent — passes Dependencies:/Blockers:] --> GHIC
    Doer[doer agent — passes Dependencies:/Blockers:] --> GHIC
    LooperIssue[looper-issue Phase 1a/b/c — single call] --> ListReady[list-ready-issues]
    LooperEE[looper-ee Phase 3c — pre-worktree gate] --> CheckBlocked[check-blocked]
    LooperEE -->|on block| ReleaseClaim((release claim))
    ListReady --> CheckBlocked
    Template[.github/ISSUE_TEMPLATE/default.md] --> Issue
    style GHIC fill:#69f,stroke:#333
    style Validator fill:#6f6,stroke:#333
    style ListReady fill:#6f6,stroke:#333
    style LooperEE fill:#69f,stroke:#333
    style LooperIssue fill:#69f,stroke:#333
    style Template fill:#6f6,stroke:#333
```

## Key Changes

**Part 1 — canonical markers (enforcement)**
- `plugins/looper/agents/gh-issue-creator.md` — new `### Dep/blocker detection rule (mandatory)` with classification rules + refusal contract.
- `plugins/looper/agents/planner.md`, `plugins/looper/agents/doer.md` — unrelated-bug spawn templates extended with `Dependencies:` / `Blockers:` lines.
- `plugins/looper/skills/looper/scripts/validate-issue-body` — strips `## References` / `## Context` (and fenced code blocks), detects bare `#N` refs in remaining body, exits 1 if no canonical `## Dependencies` / `## Blockers` h2 section is present. Boundary-aware regex avoids `#123abc` and hex-color false positives.
- `.github/ISSUE_TEMPLATE/default.md` — canonical template with load-bearing comment.

**Part 2 — `list-ready-issues` script (Approach A: pure shell)**
- New `plugins/looper/skills/looper/scripts/list-ready-issues` — flags `--repo`, `--label`, `--limit`, `--json`. Wraps `gh issue list` + per-issue `check-blocked`. TSV (`#<N>\t<title>`) or JSON (`number/title/labels/createdAt`) output, oldest-first. Stderr summary `Found N ready (M blocked skipped)`. Exit 2 on `gh` failure; arg-parse guards exit 2 with usage on missing flag values (no crash under `set -u`). Stderr captured to `mktemp` so `gh` advisory output cannot poison the JSON capture.

**Part 3 — entry-point hardening**
- `plugins/looper/skills/looper-issue/SKILL.md` — Phase 1a/1b/1c rewritten to a single `list-ready-issues --json` call + visibility line + consolidated error-handling table.
- `plugins/looper/skills/looper-ee/SKILL.md` — new `## Phase 3c: Pre-Worktree Blocked Check` re-derives `UPSTREAM_OWNED` in a fresh shell, runs `check-blocked`, releases the claim cleanly when blocked.

**Tests**
- `tests/test-issue-tooling.sh` — 76 assertions across 8 sections (A–H). Section H added in iteration 2 to regression-cover the BLOCKERs found by the iter-1 Checker.
- Registered in `tests/run-corner-case-tests.sh`.

**Docs**
- `README.md` — `list-ready-issues` and `validate-issue-body` rows in the Utility Scripts table.
- `CONTRIBUTING.md` — `### Issue dependency markers` sub-section with DRY rule and usage example.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Issue-tooling tests | ✅ | 76/76 passed |
| Cargo Test (workspace) | ✅ | 100/100 passed |
| Shellcheck | ✅ | clean on both new scripts |
| Pre-check | ✅ | `ALL_CHECKS_PASSED` |

PDC loop: PASS at iteration 2 (iter-1 FAIL surfaced two BLOCKERs — `gh ... 2>&1` JSON contamination and `set -u` arg-parse crashes — both fixed and covered by H1–H5 regression tests).