### PR TITLE
refactor(looper): replace async+poll with Bash run_in_background (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.47.12"
+version = "0.48.0"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -329,9 +329,11 @@ All scripts live in `plugins/looper/skills/looper/scripts/` and auto-detect your
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
 | `LOOPER_MAX_ITERATIONS` | `10` | Maximum PDC loop iterations |
+| `CLAUDE_STREAM_IDLE_TIMEOUT_MS` | `300000` (Claude Code default, 5 min) | Stream idle timer that fires on stalled model streams (no tokens flowing from the API). Set to `7200000` (2 h) for longer loops — productive subagents actively generating tokens do not trip it, but this provides belt-and-suspenders headroom for rare model stalls. |
 
 ```bash
 LOOPER_MAX_ITERATIONS=5 claude
+CLAUDE_STREAM_IDLE_TIMEOUT_MS=7200000 claude   # recommended for longer loops
 ```
 
 ---

--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -16,8 +16,16 @@ reviewer — report all findings but do NOT fix code or modify any files.
 
 ## Instructions
 
-Spawn subagents via the `claude-spawn-agent` command (on `PATH` in every
-context, self-locates its plugin root — no env setup required).
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
+single subagent, invoke it through the Bash tool with
+`run_in_background: true` — the Bash tool returns immediately with a task
+handle and the parent receives an automatic completion notification when
+the subprocess exits; read the result-file path it printed on stdout
+then, no polling required. For parallel fan-out (multiple subagents at
+once), use `claude-spawn-agent --async X Y` inside a single shell block
+with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
+Code context and self-locates its plugin root — no env-var setup is
+required.
 
 1. **Verify Doer committed work and run TDD sequence checks** — The Doer must
    produce two or three commits per iteration: `do-red` (tests), `do-green`

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -25,8 +25,16 @@ write failing tests first, then write just enough code to make them pass.
    The values for `$TASK_NAME` and `$ITERATION` are provided in the dynamic
    context injected into this session.
 
-   Spawn subagents via the `claude-spawn-agent` command (on `PATH` in every
-   context, self-locates its plugin root — no env setup required).
+   Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
+   single subagent, invoke it through the Bash tool with
+   `run_in_background: true` — the Bash tool returns immediately with a task
+   handle and the parent receives an automatic completion notification when
+   the subprocess exits; read the result-file path it printed on stdout
+   then, no polling required. For parallel fan-out (multiple subagents at
+   once), use `claude-spawn-agent --async X Y` inside a single shell block
+   with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
+   Code context and self-locates its plugin root — no env-var setup is
+   required.
 
    **Delta-mode pointer resolution.** On iter > 1 the Planner may emit
    sections or list items as `(unchanged from iteration N-1 — see <hash>)`.

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -17,9 +17,16 @@ modify any project files — only commit a plan as a git commit message.
 
 ## Instructions
 
-Spawn subagents via the `claude-spawn-agent` command, which Claude Code
-exposes on `PATH` in every context (main session and subagents alike) and
-which self-locates its plugin root. No env-var setup is required from you.
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
+single subagent, invoke it through the Bash tool with
+`run_in_background: true` — the Bash tool returns immediately with a task
+handle and the parent receives an automatic completion notification when
+the subprocess exits; read the result-file path it printed on stdout
+then, no polling required. For parallel fan-out (multiple subagents at
+once), use `claude-spawn-agent --async X Y` inside a single shell block
+with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
+Code context and self-locates its plugin root — no env-var setup is
+required.
 
 1. **Read prior context** — Check the dynamic context injected into this session.
    If this is not iteration 1, study the loop context carefully. Understand what

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -10,53 +10,22 @@ Three subagents (Planner, Doer, Checker) iterate until the Checker issues a PASS
 
 ## Agent spawning mode
 
-This loop spawns subagents (planner, doer, checker). Before running
-the loop, determine which mechanism to use:
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked via
+the Bash tool with `run_in_background: true`. The Bash tool returns
+immediately; the parent receives an automatic completion notification when
+the subprocess exits — read the result-file path printed on stdout then.
+No polling is required.
 
-- **If the `Agent` tool is in your toolset** (the normal interactive case):
-  spawn directly, e.g. `Agent(subagent_type="looper:planner", prompt=<context>)`.
+- Sync: `Bash(command="claude-spawn-agent X Y", run_in_background=true)` → completion notification → read result file.
+- Parallel fan-out: several `Bash(run_in_background=true, ...)` calls in one message, or `claude-spawn-agent --async` with `& ... wait`.
 
-- **If the `Agent` tool is NOT in your toolset** (you are running inside a
-  subagent, a `claude -p` session, or any non-interactive context where looper
-  was invoked by another agent): you MUST fall back to the `claude-spawn-agent`
-  command. Do not attempt to call `Agent(...)` — it will fail.
+`claude-spawn-agent` is on `PATH` in every context and self-locates its
+plugin root — no env-var setup is required.
 
-  `claude-spawn-agent` is on `PATH` in every Claude Code context (including
-  subagents) and self-locates its plugin root, so no env-var or path setup is
-  needed — just call it by name.
-
-  **CRITICAL — stream watchdog:** Nested agents (planner/doer/checker) regularly
-  run for several minutes. Parent agents have a stream watchdog that kills the
-  child after ~600s of no tool-call activity. Do NOT run `claude-spawn-agent`
-  in synchronous mode (`RESULT=$(claude-spawn-agent ...)`) — that single
-  blocking Bash call will trip the watchdog on any non-trivial subagent.
-  Instead, launch `--async` and poll with short bounded Bash calls so each
-  poll emits a tool event that keeps the watchdog alive.
-
-  ```bash
-  # 1. Fire async — returns result path instantly, subagent runs in background.
-  RESULT_PATH=$(claude-spawn-agent --async "looper:planner" "$PLANNER_CONTEXT")
-  ```
-
-  Then poll in a loop. Each Bash call is short (≤60s), so the watchdog resets
-  between iterations. Write one poll per Bash call — do NOT wrap the whole
-  `until` loop in a single long-running Bash invocation:
-
-  ```bash
-  # Each of these is a separate Bash tool call in the agent's turn.
-  # Repeat until it reports DONE.
-  test -s "$RESULT_PATH" && echo DONE || { sleep 30; echo WAIT; }
-  ```
-
-  Once the poll prints `DONE`, read the result:
-
-  ```bash
-  AGENT_OUTPUT=$(cat "$RESULT_PATH")
-  ```
-
-  Every `Agent(subagent_type="X", prompt="Y")` call below has an equivalent
-  `claude-spawn-agent --async "X" "Y"` + poll form. Use whichever is
-  appropriate for your context.
+Stream-idle watchdog (`CLAUDE_STREAM_IDLE_TIMEOUT_MS`, v2.1.84+) fires only
+on **stalled model streams** (no tokens flowing from the API), NOT from lack
+of tool-call activity in the parent. A productive subagent does not trip it
+regardless of runtime. Looper recommends `7200000` ms (2 h) — see README.
 
 ## Steps
 
@@ -247,11 +216,11 @@ to complete before proceeding to the next.
 
 1. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: PLAN phase ===`
    `Agent(subagent_type="looper:planner", prompt=<Planner context from 7c>)`
-   (Fallback when Agent tool is unavailable: `claude-spawn-agent --async "looper:planner" "$PLANNER_CONTEXT"` + poll, per "Agent spawning mode")
+   (If the Agent tool is unavailable, spawn via `claude-spawn-agent` per "Agent spawning mode".)
 
 2. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: DO phase (TDD: red→green) ===`
    `Agent(subagent_type="looper:doer", prompt=<Doer context from 7c>)`
-   (Fallback when Agent tool is unavailable: `claude-spawn-agent --async "looper:doer" "$DOER_CONTEXT"` + poll, per "Agent spawning mode")
+   (If the Agent tool is unavailable, spawn via `claude-spawn-agent` per "Agent spawning mode".)
 
    Before spawning the Checker, run mechanical pre-checks:
    ```bash
@@ -270,7 +239,7 @@ to complete before proceeding to the next.
 
 3. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: CHECK phase ===`
    `Agent(subagent_type="looper:checker", prompt=<Checker context from 7c>)`
-   (Fallback when Agent tool is unavailable: `claude-spawn-agent --async "looper:checker" "$CHECKER_CONTEXT"` + poll, per "Agent spawning mode")
+   (If the Agent tool is unavailable, spawn via `claude-spawn-agent` per "Agent spawning mode".)
 
 #### 7e. Read verdict
 

--- a/plugins/looper/skills/subagents/SKILL.md
+++ b/plugins/looper/skills/subagents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagents
-description: Discover and spawn subagents via claude -p when the Agent tool is not available. Use this skill as a fallback to delegate work to specialized agents from subagent contexts or non-interactive sessions where the Agent tool is absent.
+description: Discover and spawn subagents via claude -p. The canonical spawn pattern is `Bash(command="claude-spawn-agent <agent> <prompt>", run_in_background=true)` which returns an automatic completion notification on subprocess exit.
 tools: Bash, Read, Glob
 ---
 
@@ -70,49 +70,55 @@ underlying script self-locates its `CLAUDE_PLUGIN_ROOT` from its own path
 in the caller's environment. Callers never need to know the plugin's install
 layout or export any env vars.
 
-### Sync mode (default)
+### Sync mode (default) — canonical pattern
 
-Blocks until the subagent completes. Prints the path to the result file.
-**Important:** Must be run via `run_in_background: true` in the Bash tool
-(Claude Code's Bash tool suppresses stdout from nested Claude processes in
-foreground mode).
+This is the primary pattern for spawning a single subagent and waiting for
+its result. Invoke `claude-spawn-agent` via the Bash tool with
+`run_in_background: true`. The Bash tool returns immediately with a task
+handle; when the subprocess exits, the parent receives an automatic
+completion notification. At that point, read the result-file path that
+`claude-spawn-agent` printed on stdout.
 
 ```bash
-# Run in background, then read result
-claude-spawn-agent "looper:checker" "Review the doer's work" # prints /tmp/subagent-response-<ts>-<pid>.txt
+# In the Bash tool with run_in_background: true
+claude-spawn-agent "looper:checker" "Review the doer's work"
+# stdout: /tmp/subagent-response-<ts>.txt
+# (completion notification arrives when the subagent exits)
 ```
 
+After the completion notification arrives, read the file:
+
 ```bash
-# Full pattern: launch in background Bash, read result file after
-RESULT=$(claude-spawn-agent "Explore" "What language is this repo?")
-cat "$RESULT"
+cat /tmp/subagent-response-<ts>.txt
 ```
 
-### Async mode
+Do NOT capture the `claude-spawn-agent` call with a foreground
+`RESULT=$(...)` — Claude Code's Bash tool suppresses stdout from nested
+`claude` processes in foreground mode, so you'll get an empty string.
 
-Returns the result file path immediately, runs the subagent in background.
-Ideal for parallel spawning — fire multiple agents, do other work, read later.
+### Async mode — for parallel fan-out
 
-```bash
-# Fire and get path back instantly
-RESULT=$(claude-spawn-agent --async "Explore" "Find all API endpoints")
-# ... do other work ...
-# Poll until file is non-empty
-cat "$RESULT"
-```
-
-### Run multiple subagents in parallel (async)
+Use `--async` when you want to fire multiple subagents concurrently and
+wait for all of them in a single shell block. `--async` prints the
+result-file path immediately and runs the subagent in the background, so
+you can launch N in a row, then `wait` for them to finish together.
 
 ```bash
+# Fire two subagents in parallel, collect both results
 R1=$(claude-spawn-agent --async "looper:planner" "Plan how to add rate limiting")
 R2=$(claude-spawn-agent --async "Explore" "Find all API endpoint definitions")
 
-# Wait for both to finish (poll until files are non-empty)
-while [ ! -s "$R1" ] || [ ! -s "$R2" ]; do sleep 2; done
+# Block on both background subprocesses
+wait
 
-echo "=== Plan ===" && cat "$R1"
+echo "=== Plan ==="    && cat "$R1"
 echo "=== Explore ===" && cat "$R2"
 ```
+
+For single-spawn, prefer the sync pattern above — it's simpler and the
+Bash tool delivers an automatic completion notification. Reserve `--async`
+for the genuine fan-out case where you want N concurrent subagents and
+only one downstream `wait`.
 
 ### Extra flags
 

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -39,6 +39,7 @@ run_suite "test-build-agent-context.sh"
 run_suite "test-resolve-plan-pointers.sh"
 run_suite "test-delta-mode-prompts.sh"
 run_suite "test-issue-tooling.sh"
+run_suite "test-agent-spawn-migration.sh"
 
 echo "=============================="
 echo "Corner-case suite: $PASS suites passed, $FAIL suites failed"

--- a/tests/test-agent-spawn-migration.sh
+++ b/tests/test-agent-spawn-migration.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# test-agent-spawn-migration.sh — Guard-rails for issue #89
+# Ensures the migration away from async+poll subagent spawning does not
+# regress. Covers acceptance criteria AC1-AC7.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+LOOPER_SKILL="$REPO_ROOT/plugins/looper/skills/looper/SKILL.md"
+SUBAGENTS_SKILL="$REPO_ROOT/plugins/looper/skills/subagents/SKILL.md"
+SPAWN_AGENT="$REPO_ROOT/plugins/looper/skills/subagents/scripts/spawn-agent"
+PLANNER="$REPO_ROOT/plugins/looper/agents/planner.md"
+DOER="$REPO_ROOT/plugins/looper/agents/doer.md"
+CHECKER="$REPO_ROOT/plugins/looper/agents/checker.md"
+README="$REPO_ROOT/README.md"
+
+PASS=0
+FAIL=0
+
+assert_file_contains() {
+    local description="$1" file="$2" pattern="$3"
+    if grep -q -- "$pattern" "$file" 2>/dev/null; then
+        echo "PASS: $description"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (pattern '$pattern' not found in $file)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_file_not_contains() {
+    local description="$1" file="$2" pattern="$3"
+    if grep -q -- "$pattern" "$file" 2>/dev/null; then
+        echo "FAIL: $description (pattern '$pattern' found in $file but should not be)"; FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $description"; PASS=$((PASS + 1))
+    fi
+}
+
+# AC1 — SKILL.md shrink: misdiagnosed watchdog phrase removed; section ≤20 lines.
+assert_file_not_contains "SKILL.md: old watchdog phrase removed" \
+    "$LOOPER_SKILL" "600s of no tool-call activity"
+assert_file_not_contains "SKILL.md: poll-loop fallback prose removed" \
+    "$LOOPER_SKILL" "Then poll in a loop"
+assert_file_not_contains "SKILL.md: step-7d fallback annotation removed" \
+    "$LOOPER_SKILL" "+ poll, per"
+# Section length ≤ 20 lines
+section_lines=$(awk '/^## Agent spawning mode/{flag=1;next} /^## /{if(flag){flag=0;exit}} flag{print}' "$LOOPER_SKILL" | wc -l)
+if [ "$section_lines" -le 20 ]; then
+    echo "PASS: SKILL.md: Agent spawning mode section is ≤20 lines ($section_lines)"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: SKILL.md: Agent spawning mode section is $section_lines lines (expected ≤20)"
+    FAIL=$((FAIL + 1))
+fi
+
+# AC2 — Primary pattern: run_in_background + completion notification documented.
+assert_file_contains "SKILL.md: mentions run_in_background" \
+    "$LOOPER_SKILL" "run_in_background"
+assert_file_contains "SKILL.md: mentions completion notification" \
+    "$LOOPER_SKILL" "completion notification"
+assert_file_contains "subagents/SKILL.md: mentions run_in_background" \
+    "$SUBAGENTS_SKILL" "run_in_background"
+assert_file_contains "subagents/SKILL.md: mentions completion notification" \
+    "$SUBAGENTS_SKILL" "completion notification"
+
+# AC3 — --async reframed as parallel fan-out, spawn-agent unchanged.
+assert_file_contains "subagents/SKILL.md: frames --async as parallel fan-out" \
+    "$SUBAGENTS_SKILL" "parallel fan-out"
+assert_file_not_contains "subagents/SKILL.md: old poll-loop removed from parallel example" \
+    "$SUBAGENTS_SKILL" 'while \[ ! -s '
+assert_file_contains "spawn-agent: --async mode preserved" \
+    "$SPAWN_AGENT" 'MODE="async"'
+
+# AC4 — Per-agent preambles migrated and lose dual-path fallback language.
+for f in "$PLANNER" "$DOER" "$CHECKER"; do
+    assert_file_contains "$(basename "$f"): preamble mentions run_in_background" \
+        "$f" "run_in_background"
+    assert_file_not_contains "$(basename "$f"): no 'Agent tool is NOT' dual-path branching" \
+        "$f" "Agent tool is NOT"
+    assert_file_not_contains "$(basename "$f"): no 'async + poll' fallback language" \
+        "$f" "async.*poll"
+done
+
+# AC5 — README documents env var with 2-hour recommendation.
+assert_file_contains "README: documents CLAUDE_STREAM_IDLE_TIMEOUT_MS" \
+    "$README" "CLAUDE_STREAM_IDLE_TIMEOUT_MS"
+assert_file_contains "README: recommends 7200000" \
+    "$README" "7200000"
+assert_file_contains "README: explains stream-stall rationale" \
+    "$README" "stalled model streams"
+
+# AC7 — No reintroduction of absolute CLAUDE_PLUGIN_ROOT paths in migrated docs.
+for f in "$LOOPER_SKILL" "$PLANNER" "$DOER" "$CHECKER"; do
+    assert_file_not_contains "$(basename "$f"): no CLAUDE_PLUGIN_ROOT absolute path" \
+        "$f" 'CLAUDE_PLUGIN_ROOT/skills/subagents/scripts/spawn-agent'
+done
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #89

## Problem / Task

Looper's subagent spawning previously documented a large "async + poll" pattern to work around a misdiagnosed stream watchdog (the old docs claimed the watchdog fires after ~600s of no tool-call activity). Research and a live test confirmed the watchdog actually fires on stalled model streams, and the built-in `Bash(run_in_background=true)` primitive already delivers an automatic completion notification on subprocess exit — so the elaborate polling scaffold was unnecessary.

**Current behavior:** ~49 lines of agent-spawning mode prose in `SKILL.md`, repeated `--async` + poll examples in every agent prompt, and a `while [ ! -s … ]; do sleep 2; done` idiom in `subagents/SKILL.md`.
**Expected behavior:** One canonical pattern — `Bash(command="claude-spawn-agent <agent> <prompt>", run_in_background=true)` → wait for completion notification → read result file. `--async` is kept only for parallel fan-out.

## Existing Architecture

Agents spawn nested subagents via an `--async` spawn + repeated `test -s` polling loop. The parent agent manually keeps the stream alive with a series of short Bash calls, driven by an incorrect description of the watchdog as "tool-call activity" based.

```mermaid
flowchart TD
    Parent([Parent agent])
    Spawn[claude-spawn-agent --async]
    File[/tmp/result-file/]
    Poll{{test -s + sleep 30<br/>repeat until non-empty}}
    Read[cat result file]
    Child((Subagent process))

    Parent --> Spawn
    Spawn --> File
    Spawn -.-> Child
    Child -.-> File
    Parent ==> Poll
    Poll ==> Poll
    Poll --> Read
    Read --> File

    style Poll fill:#f66,stroke:#333
    style Spawn fill:#ff6,stroke:#333
```

## Proposed Architecture

Parent fires a sync `claude-spawn-agent` call via `Bash(run_in_background=true)`. The harness emits an automatic completion notification when the subprocess exits; parent then reads the result file. `--async` remains but is re-framed as the parallel-fan-out primitive.

```mermaid
flowchart TD
    Parent([Parent agent])
    Bg[Bash run_in_background=true<br/>claude-spawn-agent agent prompt]
    Child((Subagent process))
    Notif((Completion notification))
    Read[Read result file]

    Parent --> Bg
    Bg -.-> Child
    Child --> Notif
    Notif --> Parent
    Parent --> Read

    style Bg fill:#6f6,stroke:#333
    style Notif fill:#69f,stroke:#333
```

## Key Changes

- **`plugins/looper/skills/looper/SKILL.md`** — "Agent spawning mode" section shrunk from ~49 → 18 lines. Removed the incorrect "600s of no tool-call activity" watchdog description and the "+ poll, per Agent spawning mode" annotations at step 7d.
- **`plugins/looper/skills/subagents/SKILL.md`** — Reframed sync-mode as canonical with the `run_in_background` + completion-notification idiom. Replaced the `while [ ! -s … ]; do sleep 2; done` polling example with a `& … wait` fan-out idiom. Frontmatter description updated.
- **`plugins/looper/agents/{planner,doer,checker}.md`** — Preambles migrated to reference the `run_in_background` pattern instead of the async+poll fallback.
- **`README.md`** — Added `CLAUDE_STREAM_IDLE_TIMEOUT_MS=7200000` (2 h) to the Configuration table as a belt-and-suspenders recommendation; documents the "stalled model streams" rationale.
- **`tests/test-agent-spawn-migration.sh`** — New guard-rail test with 27 positive/negative assertions that lock in the migration (e.g., `run_in_background` present, stale `600s of no tool-call`, `+ poll, per`, and `while [ ! -s ` phrases absent). Wired into `tests/run-corner-case-tests.sh`.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Guard-rail migration test | ✅ | 27/27 assertions pass |
| Corner-case suite | ✅ | 13 suites pass, 0 fail |
| Cargo unit tests | ✅ | 100/100 pass |
| Cargo clippy (-D warnings) | ✅ | clean |
| Cargo check | ✅ | clean |
| shellcheck (new test) | ✅ | clean |

This work was produced by a looper PDC loop (`chore(89): plan`, `test(89): red`, `refactor(89): green`, `test(89): check — PASS`) on branch `loop/89`.

---