### PR TITLE
fix(looper): fail-fast gate for unavailable subagent dispatch (#85)

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -27,6 +27,12 @@ with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
 Code context and self-locates its plugin root — no env-var setup is
 required.
 
+**Never improvise PDC work inline.** If `claude-spawn-agent` is not on
+`PATH` (verified by the parent skill's step-0 gate), ABORT and surface
+the error — do NOT attempt to do planner/doer/checker work yourself in
+this session. Inline execution defeats the loop's isolation and commit
+trail and is strictly worse than not running at all.
+
 1. **Verify Doer committed work and run TDD sequence checks** — The Doer must
    produce two or three commits per iteration: `do-red` (tests), `do-green`
    (implementation), and optionally `do-integration` (integration tests for

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -16,6 +16,15 @@ write failing tests first, then write just enough code to make them pass.
 
 ## Instructions
 
+Spawn subagents via the `claude-spawn-agent` command (on `PATH` in every
+context, self-locates its plugin root — no env setup required).
+
+**Never improvise PDC work inline.** If `claude-spawn-agent` is not on
+`PATH` (verified by the parent skill's step-0 gate), ABORT and surface
+the error — do NOT attempt to do planner/doer/checker work yourself in
+this session. Inline execution defeats the loop's isolation and commit
+trail and is strictly worse than not running at all.
+
 1. **Read the plan** — Get the Planner's plan from the latest commit:
    ```bash
    git log --grep="Loop-Phase: plan" --grep="Loop-Iteration: $ITERATION" \

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -28,6 +28,12 @@ with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
 Code context and self-locates its plugin root — no env-var setup is
 required.
 
+**Never improvise PDC work inline.** If `claude-spawn-agent` is not on
+`PATH` (verified by the parent skill's step-0 gate), ABORT and surface
+the error — do NOT attempt to do planner/doer/checker work yourself in
+this session. Inline execution defeats the loop's isolation and commit
+trail and is strictly worse than not running at all.
+
 1. **Read prior context** — Check the dynamic context injected into this session.
    If this is not iteration 1, study the loop context carefully. Understand what
    was attempted, what worked, what failed, and what the Checker's feedback was.

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -10,6 +10,15 @@ Three subagents (Planner, Doer, Checker) iterate until the Checker issues a PASS
 
 ## Agent spawning mode
 
+### Never run the PDC loop inline
+
+**Never attempt to run the PDC loop inline.** If `claude-spawn-agent` is not
+available and step 0 did not abort (edge case: race condition, PATH change
+mid-session, ambiguous environment), ABORT rather than running
+planner/doer/checker work yourself in the same session. Inline execution
+defeats the loop's isolation, commit-trail, and worktree guarantees — it is
+strictly worse than not running at all.
+
 Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked via
 the Bash tool with `run_in_background: true`. The Bash tool returns
 immediately; the parent receives an automatic completion notification when
@@ -28,6 +37,26 @@ of tool-call activity in the parent. A productive subagent does not trip it
 regardless of runtime. Looper recommends `7200000` ms (2 h) — see README.
 
 ## Steps
+
+### 0. Verify subagent dispatch is available
+
+Before ANY side effect (no worktree creation, no issue fetching, no commits),
+verify that `claude-spawn-agent` is reachable on `PATH`. This command is
+provided by the looper plugin's `bin/` directory, which Claude Code puts on
+`PATH` in every context (including subagents). If it is not reachable, the
+loop cannot spawn planner / doer / checker subagents and must abort — see
+"Never run the PDC loop inline" above.
+
+```bash
+command -v claude-spawn-agent >/dev/null 2>&1 || {
+    echo "ERROR: claude-spawn-agent not found on PATH — the looper plugin's bin/ directory is either not installed or not registered with Claude Code. Cannot run /looper." >&2
+    exit 1
+}
+```
+
+**Gate:** If this check fails, abort immediately. Do NOT attempt to locate
+the script manually, do NOT fall through to step 1, and do NOT run any
+planner/doer/checker work inline in this session (see rule above).
 
 ### 1. Validate environment
 

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -10,14 +10,7 @@ Three subagents (Planner, Doer, Checker) iterate until the Checker issues a PASS
 
 ## Agent spawning mode
 
-### Never run the PDC loop inline
-
-**Never attempt to run the PDC loop inline.** If `claude-spawn-agent` is not
-available and step 0 did not abort (edge case: race condition, PATH change
-mid-session, ambiguous environment), ABORT rather than running
-planner/doer/checker work yourself in the same session. Inline execution
-defeats the loop's isolation, commit-trail, and worktree guarantees — it is
-strictly worse than not running at all.
+**Never run the PDC loop inline.** If `claude-spawn-agent` is unavailable and step 0 did not abort, ABORT — inline execution defeats the loop's isolation, commit trail, and worktree guarantees.
 
 Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked via
 the Bash tool with `run_in_background: true`. The Bash tool returns

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 #           test-git-commit-loop-validation.sh, test-git-loop-context.sh,
 #           test-sync-with-remote.sh, test-check-blocked.sh,
 #           test-check-scope.sh,
-#           test-fetch-issue-context.sh, test-build-agent-context.sh
+#           test-fetch-issue-context.sh, test-build-agent-context.sh,
+#           test-fail-fast-gate.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -40,6 +41,7 @@ run_suite "test-resolve-plan-pointers.sh"
 run_suite "test-delta-mode-prompts.sh"
 run_suite "test-issue-tooling.sh"
 run_suite "test-agent-spawn-migration.sh"
+run_suite "test-fail-fast-gate.sh"
 
 echo "=============================="
 echo "Corner-case suite: $PASS suites passed, $FAIL suites failed"

--- a/tests/test-fail-fast-gate.sh
+++ b/tests/test-fail-fast-gate.sh
@@ -198,12 +198,11 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# The rule must appear AFTER "## Agent spawning mode" and BEFORE "If the \`Agent\` tool is in your toolset"
+# The rule must appear AFTER "## Agent spawning mode" and BEFORE the "## Steps" section
+# (i.e. prominently at the top of the spawning-mode section, not buried below the steps).
 AGENT_SPAWN_LINE=$(grep -n '^## Agent spawning mode' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
 NEVER_INLINE_LINE=$(grep -n 'Never run the PDC loop inline' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
-# shellcheck disable=SC2016  # backticks here are literal grep text, not command substitutions
-AGENT_TOOL_PATTERN='If the `Agent` tool is in your toolset'
-AGENT_TOOL_LINE=$(grep -n "$AGENT_TOOL_PATTERN" "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+STEPS_LINE=$(grep -n '^## Steps' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
 
 if [ -z "$AGENT_SPAWN_LINE" ]; then
     echo "FAIL: Could not find '## Agent spawning mode' heading in SKILL.md"
@@ -211,8 +210,8 @@ if [ -z "$AGENT_SPAWN_LINE" ]; then
 elif [ -z "$NEVER_INLINE_LINE" ]; then
     echo "FAIL: Could not find 'Never run the PDC loop inline' in SKILL.md"
     FAIL=$((FAIL + 1))
-elif [ -z "$AGENT_TOOL_LINE" ]; then
-    echo "FAIL: Could not find 'If the Agent tool is in your toolset' in SKILL.md"
+elif [ -z "$STEPS_LINE" ]; then
+    echo "FAIL: Could not find '## Steps' heading in SKILL.md"
     FAIL=$((FAIL + 1))
 else
     if [ "$NEVER_INLINE_LINE" -gt "$AGENT_SPAWN_LINE" ]; then
@@ -222,11 +221,11 @@ else
         echo "FAIL: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is NOT after '## Agent spawning mode' (line $AGENT_SPAWN_LINE)"
         FAIL=$((FAIL + 1))
     fi
-    if [ "$NEVER_INLINE_LINE" -lt "$AGENT_TOOL_LINE" ]; then
-        echo "PASS: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is before 'If the Agent tool...' (line $AGENT_TOOL_LINE)"
+    if [ "$NEVER_INLINE_LINE" -lt "$STEPS_LINE" ]; then
+        echo "PASS: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is before '## Steps' (line $STEPS_LINE)"
         PASS=$((PASS + 1))
     else
-        echo "FAIL: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is NOT before 'If the Agent tool...' (line $AGENT_TOOL_LINE)"
+        echo "FAIL: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is NOT before '## Steps' (line $STEPS_LINE)"
         FAIL=$((FAIL + 1))
     fi
 fi

--- a/tests/test-fail-fast-gate.sh
+++ b/tests/test-fail-fast-gate.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-fail-fast-gate.sh — Regression tests for the step-0 fail-fast gate in SKILL.md
+# Verifies that looper aborts cleanly when claude-spawn-agent is absent from PATH,
+# the hard-negative "never inline" rule is present, and the note propagates to agents.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_MD="$REPO_ROOT/plugins/looper/skills/looper/SKILL.md"
+PLANNER_MD="$REPO_ROOT/plugins/looper/agents/planner.md"
+DOER_MD="$REPO_ROOT/plugins/looper/agents/doer.md"
+CHECKER_MD="$REPO_ROOT/plugins/looper/agents/checker.md"
+
+PASS=0
+FAIL=0
+
+assert_exit_zero() {
+    local description="$1"
+    local exit_code="$2"
+    if [ "$exit_code" -eq 0 ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit 0, got $exit_code)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_eq() {
+    local description="$1"
+    local actual="$2"
+    local expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_eq() {
+    local description="$1"
+    local actual="$2"
+    local unexpected="$3"
+    if [ "$actual" != "$unexpected" ]; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (value should not be '$unexpected', but it was)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local description="$1"
+    local output="$2"
+    local expected="$3"
+    if echo "$output" | grep -q "$expected"; then
+        echo "PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected output to contain '$expected')"
+        echo "  Actual output: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Extract the step-0 gate snippet from SKILL.md — exercises the live source of truth.
+# Finds the first fenced bash block containing 'command -v claude-spawn-agent'.
+GATE_SNIPPET=$(awk '
+    /^```bash$/ { in_block=1; buf=""; next }
+    /^```$/ && in_block {
+        if (buf ~ /command -v claude-spawn-agent/) { printf "%s", buf; exit }
+        in_block=0; next
+    }
+    in_block { buf = buf $0 "\n" }
+' "$SKILL_MD")
+
+# --- Test 1: SKILL.md contains a step-0 gate snippet ---
+echo "=== Test 1: SKILL.md contains a step-0 gate snippet ==="
+
+# 1a. The gate command is present
+if grep -q 'command -v claude-spawn-agent' "$SKILL_MD"; then
+    echo "PASS: SKILL.md contains 'command -v claude-spawn-agent'"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: SKILL.md does not contain 'command -v claude-spawn-agent'"
+    FAIL=$((FAIL + 1))
+fi
+
+# 1b. A ### 0. heading exists whose text mentions subagent dispatch or claude-spawn-agent
+if grep -qE '^### 0\.' "$SKILL_MD"; then
+    echo "PASS: SKILL.md has a '### 0.' heading"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: SKILL.md does not have a '### 0.' heading"
+    FAIL=$((FAIL + 1))
+fi
+
+HEADING_0_TEXT=$(grep -E '^### 0\.' "$SKILL_MD" || true)
+if echo "$HEADING_0_TEXT" | grep -qiE 'subagent dispatch|claude-spawn-agent'; then
+    echo "PASS: '### 0.' heading mentions 'subagent dispatch' or 'claude-spawn-agent'"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: '### 0.' heading does not mention 'subagent dispatch' or 'claude-spawn-agent'"
+    echo "  Heading text: $HEADING_0_TEXT"
+    FAIL=$((FAIL + 1))
+fi
+
+# 1c. The ### 0. heading's line number is less than all other ### headings
+HEADING_0_LINE=$(grep -n '^### 0\.' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+if [ -z "$HEADING_0_LINE" ]; then
+    echo "FAIL: Could not find '### 0.' heading in SKILL.md"
+    FAIL=$((FAIL + 1))
+else
+    # Get all other ### headings (excluding ### 0.)
+    OTHER_HEADINGS=$(grep -n '^### ' "$SKILL_MD" | grep -v '^'"$HEADING_0_LINE"':' || true)
+    ALL_BEFORE=true
+    while IFS= read -r line; do
+        if [ -z "$line" ]; then continue; fi
+        OTHER_LINE=$(echo "$line" | cut -d: -f1)
+        if [ -n "$OTHER_LINE" ] && [ "$OTHER_LINE" -le "$HEADING_0_LINE" ]; then
+            ALL_BEFORE=false
+            echo "FAIL: Found '### ' heading at line $OTHER_LINE which is not after '### 0.' at line $HEADING_0_LINE"
+            echo "  Heading: $line"
+            break
+        fi
+    done <<< "$OTHER_HEADINGS"
+    if [ "$ALL_BEFORE" = "true" ]; then
+        echo "PASS: '### 0.' heading (line $HEADING_0_LINE) appears before all other '### ' headings"
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+# --- Test 2: Step-0 gate aborts with specific message when claude-spawn-agent is absent ---
+echo ""
+echo "=== Test 2: Gate aborts with specific message when claude-spawn-agent is absent ==="
+
+if [ -z "$GATE_SNIPPET" ]; then
+    echo "FAIL: could not extract step-0 gate snippet from SKILL.md — all test 2/3 subtests skipped"
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: step-0 gate snippet extracted from SKILL.md"
+    PASS=$((PASS + 1))
+
+    TMP_EMPTY_PATH=$(mktemp -d)
+    set +e
+    OUTPUT=$(PATH="$TMP_EMPTY_PATH" bash -c "$GATE_SNIPPET" 2>&1)
+    EXIT=$?
+    set -e
+    rmdir "$TMP_EMPTY_PATH"
+
+    assert_not_eq "gate exits non-zero when claude-spawn-agent is absent" "$EXIT" "0"
+    assert_output_contains "gate output contains 'ERROR:'" "$OUTPUT" "ERROR:"
+    assert_output_contains "gate output contains 'claude-spawn-agent not found'" "$OUTPUT" "claude-spawn-agent not found"
+    assert_output_contains "gate output contains 'Cannot run /looper'" "$OUTPUT" "Cannot run /looper"
+fi
+
+# --- Test 3: Step-0 gate passes silently when claude-spawn-agent IS on PATH ---
+echo ""
+echo "=== Test 3: Gate passes silently when claude-spawn-agent IS on PATH ==="
+
+if [ -z "$GATE_SNIPPET" ]; then
+    echo "SKIP: gate snippet not available — skipping test 3"
+else
+    TMP_SHIM_DIR=$(mktemp -d)
+    cat > "$TMP_SHIM_DIR/claude-spawn-agent" << 'SHIM'
+#!/usr/bin/env bash
+exit 0
+SHIM
+    chmod +x "$TMP_SHIM_DIR/claude-spawn-agent"
+
+    set +e
+    OUTPUT=$(PATH="$TMP_SHIM_DIR:$PATH" bash -c "$GATE_SNIPPET" 2>&1)
+    EXIT=$?
+    set -e
+    rm -rf "$TMP_SHIM_DIR"
+
+    assert_exit_zero "gate exits 0 when claude-spawn-agent is on PATH" "$EXIT"
+    assert_eq "gate produces no output when claude-spawn-agent is present" "$OUTPUT" ""
+fi
+
+# --- Test 4: Hard-negative rule "Never run the PDC loop inline" is present and prominent ---
+echo ""
+echo "=== Test 4: Hard-negative rule is present and prominent in SKILL.md ==="
+
+if grep -q 'Never run the PDC loop inline' "$SKILL_MD"; then
+    echo "PASS: SKILL.md contains 'Never run the PDC loop inline'"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: SKILL.md does not contain 'Never run the PDC loop inline'"
+    FAIL=$((FAIL + 1))
+fi
+
+# The rule must appear AFTER "## Agent spawning mode" and BEFORE "If the \`Agent\` tool is in your toolset"
+AGENT_SPAWN_LINE=$(grep -n '^## Agent spawning mode' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+NEVER_INLINE_LINE=$(grep -n 'Never run the PDC loop inline' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+# shellcheck disable=SC2016  # backticks here are literal grep text, not command substitutions
+AGENT_TOOL_PATTERN='If the `Agent` tool is in your toolset'
+AGENT_TOOL_LINE=$(grep -n "$AGENT_TOOL_PATTERN" "$SKILL_MD" | head -1 | cut -d: -f1 || true)
+
+if [ -z "$AGENT_SPAWN_LINE" ]; then
+    echo "FAIL: Could not find '## Agent spawning mode' heading in SKILL.md"
+    FAIL=$((FAIL + 1))
+elif [ -z "$NEVER_INLINE_LINE" ]; then
+    echo "FAIL: Could not find 'Never run the PDC loop inline' in SKILL.md"
+    FAIL=$((FAIL + 1))
+elif [ -z "$AGENT_TOOL_LINE" ]; then
+    echo "FAIL: Could not find 'If the Agent tool is in your toolset' in SKILL.md"
+    FAIL=$((FAIL + 1))
+else
+    if [ "$NEVER_INLINE_LINE" -gt "$AGENT_SPAWN_LINE" ]; then
+        echo "PASS: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is after '## Agent spawning mode' (line $AGENT_SPAWN_LINE)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is NOT after '## Agent spawning mode' (line $AGENT_SPAWN_LINE)"
+        FAIL=$((FAIL + 1))
+    fi
+    if [ "$NEVER_INLINE_LINE" -lt "$AGENT_TOOL_LINE" ]; then
+        echo "PASS: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is before 'If the Agent tool...' (line $AGENT_TOOL_LINE)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: 'Never run the PDC loop inline' (line $NEVER_INLINE_LINE) is NOT before 'If the Agent tool...' (line $AGENT_TOOL_LINE)"
+        FAIL=$((FAIL + 1))
+    fi
+fi
+
+# --- Test 5: Each agent prompt carries the propagated note ---
+echo ""
+echo "=== Test 5: Each agent prompt carries the propagated 'Never improvise PDC work inline' note ==="
+
+for agent_file in "$PLANNER_MD" "$DOER_MD" "$CHECKER_MD"; do
+    agent_name=$(basename "$agent_file")
+
+    # 5a. The phrase exists
+    if grep -q 'Never improvise PDC work inline' "$agent_file"; then
+        echo "PASS: $agent_name contains 'Never improvise PDC work inline'"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $agent_name does NOT contain 'Never improvise PDC work inline'"
+        FAIL=$((FAIL + 1))
+    fi
+
+    # 5b. The "Never improvise" line appears AFTER the ## Instructions heading
+    INSTRUCTIONS_LINE=$(grep -n '^## Instructions' "$agent_file" | head -1 | cut -d: -f1 || true)
+    IMPROVISE_LINE=$(grep -n 'Never improvise PDC work inline' "$agent_file" | head -1 | cut -d: -f1 || true)
+
+    if [ -z "$INSTRUCTIONS_LINE" ]; then
+        echo "FAIL: $agent_name does not have a '## Instructions' heading"
+        FAIL=$((FAIL + 1))
+    elif [ -z "$IMPROVISE_LINE" ]; then
+        echo "SKIP: $agent_name 'Never improvise' line not found (already failed above)"
+    else
+        if [ "$IMPROVISE_LINE" -gt "$INSTRUCTIONS_LINE" ]; then
+            echo "PASS: $agent_name 'Never improvise' (line $IMPROVISE_LINE) is after '## Instructions' (line $INSTRUCTIONS_LINE)"
+            PASS=$((PASS + 1))
+        else
+            echo "FAIL: $agent_name 'Never improvise' (line $IMPROVISE_LINE) is NOT after '## Instructions' (line $INSTRUCTIONS_LINE)"
+            FAIL=$((FAIL + 1))
+        fi
+    fi
+done
+
+# --- Test 6: Gate snippet is side-effect-free on failure ---
+echo ""
+echo "=== Test 6: Gate snippet contains no side-effect code ==="
+
+if [ -z "$GATE_SNIPPET" ]; then
+    echo "FAIL: gate snippet not available — cannot check for side effects"
+    FAIL=$((FAIL + 1))
+else
+    FORBIDDEN_TOKENS=("setup-worktree" "fetch-issue-context" "git worktree" "gh issue" "git commit")
+    ALL_CLEAN=true
+    for token in "${FORBIDDEN_TOKENS[@]}"; do
+        if echo "$GATE_SNIPPET" | grep -q "$token"; then
+            echo "FAIL: gate snippet contains forbidden side-effect token: '$token'"
+            FAIL=$((FAIL + 1))
+            ALL_CLEAN=false
+        fi
+    done
+    if [ "$ALL_CLEAN" = "true" ]; then
+        echo "PASS: gate snippet contains no forbidden side-effect tokens"
+        PASS=$((PASS + 1))
+    fi
+fi
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/test-fail-fast-gate.sh
+++ b/tests/test-fail-fast-gate.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+THIS_BASH="${BASH:-/usr/bin/bash}"  # full path to bash (for PATH-isolation tests)
 SKILL_MD="$REPO_ROOT/plugins/looper/skills/looper/SKILL.md"
 PLANNER_MD="$REPO_ROOT/plugins/looper/agents/planner.md"
 DOER_MD="$REPO_ROOT/plugins/looper/agents/doer.md"
@@ -109,27 +110,28 @@ else
     FAIL=$((FAIL + 1))
 fi
 
-# 1c. The ### 0. heading's line number is less than all other ### headings
+# 1c. The ### 0. heading's line number is less than all other numbered step headings (### N.)
+# This confirms it is the first step — non-step subsections (### Never run...) are excluded.
 HEADING_0_LINE=$(grep -n '^### 0\.' "$SKILL_MD" | head -1 | cut -d: -f1 || true)
 if [ -z "$HEADING_0_LINE" ]; then
     echo "FAIL: Could not find '### 0.' heading in SKILL.md"
     FAIL=$((FAIL + 1))
 else
-    # Get all other ### headings (excluding ### 0.)
-    OTHER_HEADINGS=$(grep -n '^### ' "$SKILL_MD" | grep -v '^'"$HEADING_0_LINE"':' || true)
+    # Get all other numbered step headings (### N. ...) excluding ### 0. itself
+    OTHER_STEP_HEADINGS=$(grep -n '^### [0-9]' "$SKILL_MD" | grep -v '^'"$HEADING_0_LINE"':' || true)
     ALL_BEFORE=true
     while IFS= read -r line; do
         if [ -z "$line" ]; then continue; fi
         OTHER_LINE=$(echo "$line" | cut -d: -f1)
         if [ -n "$OTHER_LINE" ] && [ "$OTHER_LINE" -le "$HEADING_0_LINE" ]; then
             ALL_BEFORE=false
-            echo "FAIL: Found '### ' heading at line $OTHER_LINE which is not after '### 0.' at line $HEADING_0_LINE"
+            echo "FAIL: Found numbered step heading at line $OTHER_LINE which is not after '### 0.' at line $HEADING_0_LINE"
             echo "  Heading: $line"
             break
         fi
-    done <<< "$OTHER_HEADINGS"
+    done <<< "$OTHER_STEP_HEADINGS"
     if [ "$ALL_BEFORE" = "true" ]; then
-        echo "PASS: '### 0.' heading (line $HEADING_0_LINE) appears before all other '### ' headings"
+        echo "PASS: '### 0.' heading (line $HEADING_0_LINE) appears before all other numbered step headings"
         PASS=$((PASS + 1))
     else
         FAIL=$((FAIL + 1))
@@ -149,7 +151,7 @@ else
 
     TMP_EMPTY_PATH=$(mktemp -d)
     set +e
-    OUTPUT=$(PATH="$TMP_EMPTY_PATH" bash -c "$GATE_SNIPPET" 2>&1)
+    OUTPUT=$(PATH="$TMP_EMPTY_PATH" "$THIS_BASH" -c "$GATE_SNIPPET" 2>&1)
     EXIT=$?
     set -e
     rmdir "$TMP_EMPTY_PATH"
@@ -175,7 +177,7 @@ SHIM
     chmod +x "$TMP_SHIM_DIR/claude-spawn-agent"
 
     set +e
-    OUTPUT=$(PATH="$TMP_SHIM_DIR:$PATH" bash -c "$GATE_SNIPPET" 2>&1)
+    OUTPUT=$(PATH="$TMP_SHIM_DIR:$PATH" "$THIS_BASH" -c "$GATE_SNIPPET" 2>&1)
     EXIT=$?
     set -e
     rm -rf "$TMP_SHIM_DIR"


### PR DESCRIPTION
## Problem / Task

Closes #85. When `/looper` was invoked from a context where subagent dispatch was structurally broken (e.g., `claude-spawn-agent` not on `PATH`), SKILL.md silently fell through and the invoking agent improvised PDC work inline — producing no `Loop-Phase:` commits, no worktree, and no audit trail. Inline execution defeats the loop's core isolation and commit-trail guarantees.

**Current behavior:** Silent fall-through to inline execution when dispatch is unavailable.
**Expected behavior:** Clean, specific, pre-side-effect abort with an actionable remediation message. A hard-negative rule also tells the invoking agent never to improvise PDC work inline, even in edge cases.

## Existing Architecture

Before this PR, SKILL.md jumped straight to step 1 (git-repo validation) with no dispatch precheck. If `claude-spawn-agent` happened to be missing, the loop would create a worktree, fetch the issue body, and only fail at step 7d when it tried to spawn the planner — by which point side effects had already fired.

```mermaid
graph TD
    User([User: /looper &lt;task&gt;]) --> S1[Step 1: git rev-parse]
    S1 --> S4[Step 4: setup-worktree]
    S4 --> S4c[Step 4c: fetch-issue-context]
    S4c --> S7[Step 7: PDC loop]
    S7 --> Spawn{claude-spawn-agent<br/>on PATH?}
    Spawn -- yes --> Planner[Spawn Planner]
    Spawn -- no --> Inline[Silent fall-through:<br/>improvise inline]
    style Inline fill:#f66,stroke:#333
    style Spawn fill:#ff6,stroke:#333
```

## Proposed Architecture

A new **step 0** gate verifies `command -v claude-spawn-agent` before any side effect. If the binary is missing, the loop aborts with a specific error message pointing at the remediation (plugin bin/ not installed or not registered). A hard-negative rule in the spawning-mode section and propagated notes in planner.md / doer.md / checker.md tell every participant to abort rather than improvise.

```mermaid
graph TD
    User([User: /looper &lt;task&gt;]) --> S0{Step 0:<br/>claude-spawn-agent<br/>on PATH?}
    S0 -- no --> Abort[Abort with<br/>actionable ERROR —<br/>zero side effects]
    S0 -- yes --> S1[Step 1: git rev-parse]
    S1 --> S4[Step 4: setup-worktree]
    S4 --> S4c[Step 4c: fetch-issue-context]
    S4c --> S7[Step 7: PDC loop]
    S7 --> Planner[Spawn Planner via claude-spawn-agent]
    Planner -. never improvise .-> Doer[Spawn Doer]
    Doer -. never improvise .-> Checker[Spawn Checker]
    style S0 fill:#6f6,stroke:#333
    style Abort fill:#69f,stroke:#333
```

## Key Changes

- **SKILL.md step 0 gate** — Added `### 0. Verify subagent dispatch is available` as the first step. `command -v claude-spawn-agent` check with a specific abort message; gate runs before any worktree/issue/commit side effect.
- **Hard-negative rule** — Added a prominent bold leading sentence at the top of `## Agent spawning mode`: "**Never run the PDC loop inline.**" Kept under the section's ≤20-line budget (enforced by #89's test-agent-spawn-migration.sh) by inlining it without a sub-heading.
- **Propagated note** — Added a "Never improvise PDC work inline" paragraph near the top of `## Instructions` in planner.md, doer.md, and checker.md so the discipline carries into every subagent prompt. In doer.md, also relocated the spawn-instruction sentence above the numbered list for structural parity with the other agents.
- **Regression suite** — New `tests/test-fail-fast-gate.sh` with 21 assertions across 6 test groups: step-0 heading position, gate aborts with the exact message when PATH is broken, gate passes silently when PATH is fine, hard-negative rule presence + prominence, propagated note in each agent file, and "no side-effect tokens in the gate snippet" guard. Wired into `tests/run-corner-case-tests.sh`.
- **Rebase integration with #89** — #89 landed during this iteration (async+poll → Bash `run_in_background` refactor) and conflicted in SKILL.md, doer.md, and run-corner-case-tests.sh. Resolved by keeping #89's new concise spawn description + bullet list and this PR's hard-negative rule + fail-fast gate, with the gate's "never inline" text tightened so the `## Agent spawning mode` section stays ≤20 lines.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Corner-case suite | ✅ | 14/14 suites passing (including new test-fail-fast-gate.sh with 21/21 assertions) |
| test-agent-spawn-migration.sh | ✅ | 27/27 — `## Agent spawning mode` stays at exactly 20 lines |
| ShellCheck | ✅ | Clean on new/modified shell scripts |

`test-agent-definitions.sh` reports a soft pre-breached line-count guard on planner.md unrelated to this PR's changes (noted as out-of-scope in the plan — not wired into CI or the corner-case runner).