### PR TITLE
refactor(subagents): claude-spawn-agent drop-in for Agent (closes #104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.48.0"
+version = "0.48.2"
 dependencies = [
  "chrono",
  "clap",

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,379 @@
+# Plan — iteration 2: scrub stale "result-file path" framing
+
+## Goal
+
+Finish iteration 1's canonical-spawn migration by rewriting the four
+documentation blocks the Checker flagged as BLOCKERs. Every instance of
+"read the result-file path" framing (and its close synonym
+"read result file") must be removed from:
+
+1. `plugins/looper/skills/looper/SKILL.md` (lines 15-22, `## Agent spawning mode` body)
+2. `plugins/looper/agents/planner.md` (lines 20-29, `## Instructions` preamble paragraph)
+3. `plugins/looper/agents/doer.md` (lines 37-46, step-1 spawn-mode paragraph)
+4. `plugins/looper/agents/checker.md` (lines 19-28, `## Instructions` preamble paragraph)
+
+Two regression assertions are added in the red phase so neither
+`result-file path` nor the unhyphenated synonym `read result file` can
+reappear in these four files without a test-suite failure.
+
+## Tech Stack Constraints
+
+(unchanged from iteration 1 — see 7d2c8c7 — plain-markdown docs edit +
+bash regression test under `tests/`, no framework or language change.)
+
+## Files to modify
+
+### Red phase (do-red commit)
+
+- `tests/test-agent-spawn-migration.sh` — add TWO regression loops that
+  assert none of the four files above contain the literal string
+  `result-file path`, nor the literal string `read result file`. Both
+  loops must FAIL against the current (pre-green) tree: every target
+  file still contains `result-file path`, and `looper/SKILL.md` line 21
+  additionally contains `read result file`. Both loops must PASS after
+  the green phase.
+
+### Green phase (do-green commit)
+
+- `plugins/looper/skills/looper/SKILL.md` — rewrite lines 15-22.
+- `plugins/looper/agents/planner.md` — rewrite lines 20-29.
+- `plugins/looper/agents/doer.md` — rewrite lines 37-46.
+- `plugins/looper/agents/checker.md` — rewrite lines 19-28.
+
+## Do NOT modify
+
+- `plugins/looper/skills/subagents/scripts/spawn-agent` — script already
+  correct (AC #1, #2, #7 pass in iter 1).
+- `plugins/looper/skills/subagents/SKILL.md` — already reframed (AC #5
+  passes); its canonical wording is the template the 4 docs above will
+  adopt.
+- `plugins/looper/skills/looper/SKILL.md` line 13 (`Never run the PDC
+  loop inline.`) and lines 34-48 (`### 0. Verify subagent dispatch is
+  available` + body) — `tests/test-fail-fast-gate.sh` pins these by
+  exact line position and content.
+- The `**Never improvise PDC work inline.**` paragraph in all three
+  agent files — must stay at the same line position after the edit so
+  `test-fail-fast-gate.sh` Test 5 (which checks ordering relative to
+  `## Instructions`) continues to pass. The replacement block must
+  occupy the **same number of lines** as the current block so the
+  Never-improvise paragraph does not drift.
+
+## Current text (to be replaced)
+
+### Location 1 — `plugins/looper/skills/looper/SKILL.md` lines 15-22 (8 lines)
+
+```
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked via
+the Bash tool with `run_in_background: true`. The Bash tool returns
+immediately; the parent receives an automatic completion notification when
+the subprocess exits — read the result-file path printed on stdout then.
+No polling is required.
+
+- Sync: `Bash(command="claude-spawn-agent X Y", run_in_background=true)` → completion notification → read result file.
+- Parallel fan-out: several `Bash(run_in_background=true, ...)` calls in one message, or `claude-spawn-agent X Y > /tmp/file.txt &` + `wait`.
+```
+
+### Location 2 — `plugins/looper/agents/planner.md` lines 20-29 (10 lines)
+
+```
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
+single subagent, invoke it through the Bash tool with
+`run_in_background: true` — the Bash tool returns immediately with a task
+handle and the parent receives an automatic completion notification when
+the subprocess exits; read the result-file path it printed on stdout
+then, no polling required. For parallel fan-out (multiple subagents at
+once), redirect each subagent's stdout to a temp file and `&`/`wait`:
+`claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
+`claude-spawn-agent` is on `PATH` in every Claude Code context and
+self-locates its plugin root — no env-var setup is required.
+```
+
+### Location 3 — `plugins/looper/agents/doer.md` lines 37-46 (10 lines, inside step 1 — note 3-space indent)
+
+```
+   Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
+   single subagent, invoke it through the Bash tool with
+   `run_in_background: true` — the Bash tool returns immediately with a task
+   handle and the parent receives an automatic completion notification when
+   the subprocess exits; read the result-file path it printed on stdout
+   then, no polling required. For parallel fan-out (multiple subagents at
+   once), redirect each subagent's stdout to a temp file and `&`/`wait`:
+   `claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
+   `claude-spawn-agent` is on `PATH` in every Claude Code context and
+   self-locates its plugin root — no env-var setup is required.
+```
+
+### Location 4 — `plugins/looper/agents/checker.md` lines 19-28 (10 lines)
+
+```
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
+single subagent, invoke it through the Bash tool with
+`run_in_background: true` — the Bash tool returns immediately with a task
+handle and the parent receives an automatic completion notification when
+the subprocess exits; read the result-file path it printed on stdout
+then, no polling required. For parallel fan-out (multiple subagents at
+once), redirect each subagent's stdout to a temp file and `&`/`wait`:
+`claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
+`claude-spawn-agent` is on `PATH` in every Claude Code context and
+self-locates its plugin root — no env-var setup is required.
+```
+
+## Replacement text (exact, verbatim)
+
+The replacement is derived from `plugins/looper/skills/subagents/SKILL.md`
+lines 9-13 + 80-83 + 92-102 — that file is authoritative and is NOT
+changing this iteration, so the agent docs and looper SKILL.md will
+inherit its canonical phrasing.
+
+### Replacement 1 — `looper/SKILL.md` lines 15-22 (MUST be exactly 8 lines to preserve surrounding anchors)
+
+```
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+via the Bash tool. It is the drop-in for the built-in `Agent` tool inside
+subagent contexts: the subagent's text response is printed directly to
+stdout (foreground) or delivered inline in the completion notification
+(background).
+
+- Sync: `Bash(command="claude-spawn-agent X Y", run_in_background=true)` → completion notification fires on finish; its output contains the subagent's response text inline.
+- Parallel fan-out: several `claude-spawn-agent X Y > /tmp/file.txt &` calls in one Bash block, followed by `wait`.
+```
+
+Line count: 8 (matches original — SKILL.md anchors around line 13
+`Never run the PDC loop inline` and line 34 `### 0.` are preserved
+unchanged, and the `## Agent spawning mode` section total stays at 20
+lines, satisfying the existing `≤ 20` test assertion).
+
+### Replacement 2 — `planner.md` lines 20-29 (MUST be exactly 10 lines)
+
+```
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+via the Bash tool. It is the drop-in for the built-in `Agent` tool inside
+subagent contexts: the subagent's text response is printed directly to
+stdout (foreground) or delivered inline in the completion notification
+(background). For a single subagent:
+`Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
+the Bash tool returns immediately; an automatic completion notification
+fires on subprocess exit and its output contains the subagent's response
+text inline. For parallel fan-out, redirect each subagent's stdout to a
+temp file and `&`/`wait` — no polling, the response arrives directly.
+```
+
+Line count: 10 (matches original — the blank line 30 and the
+`**Never improvise PDC work inline.**` paragraph starting at line 31
+stay at identical positions).
+
+### Replacement 3 — `doer.md` lines 37-46 (MUST be exactly 10 lines, with 3-space indent since this block is inside step 1's indented body)
+
+```
+   Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+   via the Bash tool. It is the drop-in for the built-in `Agent` tool
+   inside subagent contexts: the subagent's text response is printed
+   directly to stdout (foreground) or delivered inline in the completion
+   notification (background). For a single subagent:
+   `Bash(command="claude-spawn-agent X Y", run_in_background=true)` — the
+   Bash tool returns immediately; the completion notification fires on
+   subprocess exit and its output contains the response text inline. For
+   parallel fan-out, redirect each subagent's stdout to a temp file and
+   `&`/`wait` — no polling, the response arrives directly.
+```
+
+Line count: 10 (matches original; three-space indent preserved because
+the surrounding list item at line 28 uses that indent).
+
+### Replacement 4 — `checker.md` lines 19-28 (MUST be exactly 10 lines)
+
+```
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+via the Bash tool. It is the drop-in for the built-in `Agent` tool inside
+subagent contexts: the subagent's text response is printed directly to
+stdout (foreground) or delivered inline in the completion notification
+(background). For a single subagent:
+`Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
+the Bash tool returns immediately; an automatic completion notification
+fires on subprocess exit and its output contains the subagent's response
+text inline. For parallel fan-out, redirect each subagent's stdout to a
+temp file and `&`/`wait` — no polling, the response arrives directly.
+```
+
+Line count: 10 (matches original).
+
+## Semantic contract carried by every replacement
+
+Every replacement block (all 4 locations) MUST mention:
+
+1. `claude-spawn-agent` as the canonical drop-in for the `Agent` tool in
+   subagent contexts (NO "fallback" language).
+2. `Bash(command="claude-spawn-agent X Y")` / foreground invocation
+   returns the subagent's text on stdout.
+3. `Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
+   background invocation fires a task-completion notification whose
+   output contains the response text inline.
+4. Parallel fan-out pattern: stdout-redirect + `&` + `wait`.
+
+And every replacement block MUST NOT contain:
+
+- the phrase `result-file path`
+- the phrase `read result file` (no hyphen)
+- the phrase `read the result file` / `read a result file`
+- any reference to `.output` file (we describe it as "output contains
+  the response text inline", not as a file to read)
+- any reference to `--async`
+- any reference to `subagent-response-`
+- any reference to polling / "poll" / "while [ ! -s"
+
+## Tests to write first (red phase)
+
+### New assertions appended to `tests/test-agent-spawn-migration.sh`
+
+Append the following block **after** the AC7 loop (after the existing
+`done` at line 119, before the final `echo` at line 121) — use variable
+names already declared at the top of the file (`LOOPER_SKILL`, `PLANNER`,
+`DOER`, `CHECKER` — confirmed present at lines 9, 12, 13, 14):
+
+```bash
+# AC iter-2 (a) — stale 'result-file path' framing scrubbed.
+for f in "$LOOPER_SKILL" "$PLANNER" "$DOER" "$CHECKER"; do
+    assert_file_not_contains "$(basename "$f"): no 'result-file path' framing" \
+        "$f" 'result-file path'
+done
+
+# AC iter-2 (b) — unhyphenated synonym 'read result file' also scrubbed.
+# (looper/SKILL.md:21 currently contains the bullet phrase
+# "→ completion notification → read result file." — the green phase
+# removes it. Guarding here prevents future reintroduction.)
+for f in "$LOOPER_SKILL" "$PLANNER" "$DOER" "$CHECKER"; do
+    assert_file_not_contains "$(basename "$f"): no 'read result file' synonym" \
+        "$f" 'read result file'
+done
+```
+
+**Red phase expected behaviour.** Before the green edits:
+- Suite-level outcome: `test-agent-spawn-migration.sh` fails — so
+  `run-corner-case-tests.sh` reports `14 suites passed, 1 suite failed`.
+- Assertion-level detail inside that one suite: **5 new FAIL lines**
+  will appear (4 files × `result-file path`, plus 1 file — SKILL.md —
+  × `read result file`). The other three files do not contain
+  `read result file`, so those three assertions in the (b) loop PASS
+  in red — only SKILL.md's (b) assertion fails in red.
+- The Doer should not be surprised that individual-assertion counts
+  (4+1 = 5 fails in red) differ from the suite count (1 suite failed).
+
+**Green phase expected behaviour.** After the four doc rewrites:
+- All 8 new assertions (4 × (a) loop + 4 × (b) loop) pass.
+- `test-agent-spawn-migration.sh` is fully green again.
+- The existing 15-suite runner (`tests/run-corner-case-tests.sh`)
+  returns to `15 suites passed, 0 suites failed`.
+- `tests/test-fail-fast-gate.sh` stays 21/21 green because:
+  - `looper/SKILL.md` line 13 (`Never run the PDC loop inline`) is not
+    touched.
+  - `looper/SKILL.md` lines 34-48 (step-0 gate) are not touched.
+  - Each agent file's `**Never improvise PDC work inline.**` paragraph
+    stays at the same line number (replacement blocks preserve line
+    counts — 8/10/10/10).
+
+### Why no other tests are needed
+
+- The refactor has zero runtime impact (pure docs edit).
+- No new script, flag, or CLI surface is added.
+- The existing `test-spawn-agent-canonical.sh`, `test-fail-fast-gate.sh`,
+  and `test-agent-spawn-migration.sh` already cover every mechanism
+  mentioned in the replacement text (AC1-AC7 from iter 1 still pass).
+
+## Corner cases (each must be explicitly verified)
+
+Pure-docs corner cases — the Doer must verify each by grep / line-count:
+
+1. **Phrase scrubbing is total across all four files (primary).**
+   Verification:
+   `grep -n "result-file path" plugins/looper/skills/looper/SKILL.md plugins/looper/agents/{planner,doer,checker}.md`
+   returns zero hits after green. Expected: 0 matches.
+2. **No regression-via-synonym.** Verification:
+   `grep -nE "read (the )?result file|result file to read" plugins/looper/skills/looper/SKILL.md plugins/looper/agents/{planner,doer,checker}.md`
+   returns zero hits — we are not allowed to rename `result-file path`
+   into a pseudo-equivalent phrase. (Red-phase state: SKILL.md line 21
+   matches `read result file`; green-phase state: zero matches.)
+3. **`**Never improvise PDC work inline.**` stays at its original line
+   number in each of the three agent files.** Verification:
+   `grep -n "Never improvise PDC work inline" plugins/looper/agents/{planner,doer,checker}.md`
+   returns `planner.md:31`, `doer.md:22`, `checker.md:30`. (Same as
+   pre-edit line positions.)
+4. **`**Never run the PDC loop inline**` stays at SKILL.md line 13.**
+   Verification:
+   `grep -n "Never run the PDC loop inline" plugins/looper/skills/looper/SKILL.md`
+   returns `13:`. Unchanged.
+5. **Step-0 fail-fast gate stays pinned at `looper/SKILL.md` line 34.**
+   Verification:
+   `grep -n "^### 0\. Verify subagent dispatch is available" plugins/looper/skills/looper/SKILL.md`
+   returns `34:`. Unchanged.
+6. **The `## Agent spawning mode` section in `looper/SKILL.md` stays
+   ≤20 lines** (asserted by existing test lines 46-53). The replacement
+   preserves line count exactly, so the section stays at 20 lines —
+   still satisfies the `≤ 20` assertion. Verification:
+   ```bash
+   awk '/^## Agent spawning mode/{flag=1;next} /^## /{if(flag){flag=0;exit}} flag{print}' \
+       plugins/looper/skills/looper/SKILL.md | wc -l
+   ```
+   returns `20`.
+7. **No accidental reintroduction of `--async`, `subagent-response-`,
+   or `Agent tool is NOT` fallback language** — already covered by
+   existing assertions lines 86-91, 78-83, 101-104 of the migration
+   test; they must all still pass.
+
+## Acceptance criteria (the Checker will verify)
+
+1. `grep -n "result-file path" plugins/looper/skills/looper/SKILL.md plugins/looper/agents/{planner,doer,checker}.md`
+   returns **zero** matches.
+2. `grep -nE "read (the )?result file" plugins/looper/skills/looper/SKILL.md plugins/looper/agents/{planner,doer,checker}.md`
+   returns **zero** matches.
+3. `tests/test-agent-spawn-migration.sh` runs 100% green and now
+   includes both regression loops shown above. The Checker should
+   `grep -cE "'result-file path'|'read result file'" tests/test-agent-spawn-migration.sh`
+   to confirm both patterns are asserted.
+4. `bash tests/run-corner-case-tests.sh` reports `15 suites passed, 0
+   suites failed`.
+5. `bash tests/test-fail-fast-gate.sh` reports `21 passed, 0 failed`
+   — i.e. the `Never run the PDC loop inline` / `Never improvise PDC
+   work inline` anchor guarantees still hold.
+6. TDD sequence is visible in git log: `do-red` commit contains **only**
+   the new test assertions (no doc edits); `do-green` commit contains
+   **only** the four doc edits (no test changes). The Checker's TDD
+   sequence check is the authoritative audit.
+7. Every replacement block satisfies the Semantic contract listed above
+   — the Checker can spot-check by reading each block and looking for
+   the 4 required mentions and the 7 forbidden phrases.
+8. Line counts of the replacement blocks match the originals exactly
+   (8/10/10/10) so the pinned-by-position paragraphs in each file are
+   not displaced.
+
+## Risks
+
+- **Line-drift risk (mitigated).** If the Doer's replacement block has
+  a different line count than the original, the
+  `**Never improvise PDC work inline.**` paragraph moves, and while the
+  existing `test-fail-fast-gate.sh` Test 5 only checks "after
+  `## Instructions`" ordering (not a specific line number), the
+  Checker explicitly flagged "same line position" as a correctness
+  requirement. Mitigation: the plan specifies exact line counts
+  (8, 10, 10, 10) for each replacement.
+- **Synonym drift (mitigated).** A sloppy rewrite could swap
+  "result-file path" for "result file to read" and still convey the
+  same wrong mental model. Mitigation: the red-phase guard now covers
+  both `result-file path` and `read result file`; corner case #2 greps
+  for a broader `read (the )?result file|result file to read` pattern.
+- **Red-phase legibility (mitigated).** The red phase only touches the
+  test file — the Doer must resist the urge to also touch docs in red.
+  Mitigation: the plan lists the red-phase file scope explicitly (test
+  file only).
+
+## Scope discipline
+
+This is a surgical docs edit + two regression assertion loops. Nothing
+else changes. In particular:
+
+- No new scripts, no new tests (beyond two assertion loops appended to
+  an existing test file), no refactors of existing tests.
+- No restructuring of SKILL.md section hierarchy.
+- No rename / move of any file.
+- Spawn-agent script: untouched.
+- `subagents/SKILL.md`: untouched (already correct).
+- README: untouched.

--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -22,10 +22,10 @@ single subagent, invoke it through the Bash tool with
 handle and the parent receives an automatic completion notification when
 the subprocess exits; read the result-file path it printed on stdout
 then, no polling required. For parallel fan-out (multiple subagents at
-once), use `claude-spawn-agent --async X Y` inside a single shell block
-with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
-Code context and self-locates its plugin root — no env-var setup is
-required.
+once), redirect each subagent's stdout to a temp file and `&`/`wait`:
+`claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
+`claude-spawn-agent` is on `PATH` in every Claude Code context and
+self-locates its plugin root — no env-var setup is required.
 
 **Never improvise PDC work inline.** If `claude-spawn-agent` is not on
 `PATH` (verified by the parent skill's step-0 gate), ABORT and surface

--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -16,16 +16,16 @@ reviewer — report all findings but do NOT fix code or modify any files.
 
 ## Instructions
 
-Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
-single subagent, invoke it through the Bash tool with
-`run_in_background: true` — the Bash tool returns immediately with a task
-handle and the parent receives an automatic completion notification when
-the subprocess exits; read the result-file path it printed on stdout
-then, no polling required. For parallel fan-out (multiple subagents at
-once), redirect each subagent's stdout to a temp file and `&`/`wait`:
-`claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
-`claude-spawn-agent` is on `PATH` in every Claude Code context and
-self-locates its plugin root — no env-var setup is required.
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+via the Bash tool. It is the drop-in for the built-in `Agent` tool inside
+subagent contexts: the subagent's text response is printed directly to
+stdout (foreground) or delivered inline in the completion notification
+(background). For a single subagent:
+`Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
+the Bash tool returns immediately; an automatic completion notification
+fires on subprocess exit and its output contains the subagent's response
+text inline. For parallel fan-out, redirect each subagent's stdout to a
+temp file and `&`/`wait` — no polling, the response arrives directly.
 
 **Never improvise PDC work inline.** If `claude-spawn-agent` is not on
 `PATH` (verified by the parent skill's step-0 gate), ABORT and surface

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -40,10 +40,10 @@ trail and is strictly worse than not running at all.
    handle and the parent receives an automatic completion notification when
    the subprocess exits; read the result-file path it printed on stdout
    then, no polling required. For parallel fan-out (multiple subagents at
-   once), use `claude-spawn-agent --async X Y` inside a single shell block
-   with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
-   Code context and self-locates its plugin root — no env-var setup is
-   required.
+   once), redirect each subagent's stdout to a temp file and `&`/`wait`:
+   `claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
+   `claude-spawn-agent` is on `PATH` in every Claude Code context and
+   self-locates its plugin root — no env-var setup is required.
 
    **Delta-mode pointer resolution.** On iter > 1 the Planner may emit
    sections or list items as `(unchanged from iteration N-1 — see <hash>)`.

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -34,16 +34,16 @@ trail and is strictly worse than not running at all.
    The values for `$TASK_NAME` and `$ITERATION` are provided in the dynamic
    context injected into this session.
 
-   Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
-   single subagent, invoke it through the Bash tool with
-   `run_in_background: true` — the Bash tool returns immediately with a task
-   handle and the parent receives an automatic completion notification when
-   the subprocess exits; read the result-file path it printed on stdout
-   then, no polling required. For parallel fan-out (multiple subagents at
-   once), redirect each subagent's stdout to a temp file and `&`/`wait`:
-   `claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
-   `claude-spawn-agent` is on `PATH` in every Claude Code context and
-   self-locates its plugin root — no env-var setup is required.
+   Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+   via the Bash tool. It is the drop-in for the built-in `Agent` tool
+   inside subagent contexts: the subagent's text response is printed
+   directly to stdout (foreground) or delivered inline in the completion
+   notification (background). For a single subagent:
+   `Bash(command="claude-spawn-agent X Y", run_in_background=true)` — the
+   Bash tool returns immediately; the completion notification fires on
+   subprocess exit and its output contains the response text inline. For
+   parallel fan-out, redirect each subagent's stdout to a temp file and
+   `&`/`wait` — no polling, the response arrives directly.
 
    **Delta-mode pointer resolution.** On iter > 1 the Planner may emit
    sections or list items as `(unchanged from iteration N-1 — see <hash>)`.

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -17,16 +17,16 @@ modify any project files — only commit a plan as a git commit message.
 
 ## Instructions
 
-Spawn subagents with `claude-spawn-agent <agent-name> <prompt>`. For a
-single subagent, invoke it through the Bash tool with
-`run_in_background: true` — the Bash tool returns immediately with a task
-handle and the parent receives an automatic completion notification when
-the subprocess exits; read the result-file path it printed on stdout
-then, no polling required. For parallel fan-out (multiple subagents at
-once), redirect each subagent's stdout to a temp file and `&`/`wait`:
-`claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
-`claude-spawn-agent` is on `PATH` in every Claude Code context and
-self-locates its plugin root — no env-var setup is required.
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+via the Bash tool. It is the drop-in for the built-in `Agent` tool inside
+subagent contexts: the subagent's text response is printed directly to
+stdout (foreground) or delivered inline in the completion notification
+(background). For a single subagent:
+`Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
+the Bash tool returns immediately; an automatic completion notification
+fires on subprocess exit and its output contains the subagent's response
+text inline. For parallel fan-out, redirect each subagent's stdout to a
+temp file and `&`/`wait` — no polling, the response arrives directly.
 
 **Never improvise PDC work inline.** If `claude-spawn-agent` is not on
 `PATH` (verified by the parent skill's step-0 gate), ABORT and surface

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -23,10 +23,10 @@ single subagent, invoke it through the Bash tool with
 handle and the parent receives an automatic completion notification when
 the subprocess exits; read the result-file path it printed on stdout
 then, no polling required. For parallel fan-out (multiple subagents at
-once), use `claude-spawn-agent --async X Y` inside a single shell block
-with `& ... wait`. `claude-spawn-agent` is on `PATH` in every Claude
-Code context and self-locates its plugin root — no env-var setup is
-required.
+once), redirect each subagent's stdout to a temp file and `&`/`wait`:
+`claude-spawn-agent X Y > /tmp/a.txt & claude-spawn-agent X Z > /tmp/b.txt & wait`.
+`claude-spawn-agent` is on `PATH` in every Claude Code context and
+self-locates its plugin root — no env-var setup is required.
 
 **Never improvise PDC work inline.** If `claude-spawn-agent` is not on
 `PATH` (verified by the parent skill's step-0 gate), ABORT and surface

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -19,7 +19,7 @@ the subprocess exits — read the result-file path printed on stdout then.
 No polling is required.
 
 - Sync: `Bash(command="claude-spawn-agent X Y", run_in_background=true)` → completion notification → read result file.
-- Parallel fan-out: several `Bash(run_in_background=true, ...)` calls in one message, or `claude-spawn-agent --async` with `& ... wait`.
+- Parallel fan-out: several `Bash(run_in_background=true, ...)` calls in one message, or `claude-spawn-agent X Y > /tmp/file.txt &` + `wait`.
 
 `claude-spawn-agent` is on `PATH` in every context and self-locates its
 plugin root — no env-var setup is required.
@@ -238,11 +238,9 @@ to complete before proceeding to the next.
 
 1. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: PLAN phase ===`
    `Agent(subagent_type="looper:planner", prompt=<Planner context from 7c>)`
-   (If the Agent tool is unavailable, spawn via `claude-spawn-agent` per "Agent spawning mode".)
 
 2. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: DO phase (TDD: red→green) ===`
    `Agent(subagent_type="looper:doer", prompt=<Doer context from 7c>)`
-   (If the Agent tool is unavailable, spawn via `claude-spawn-agent` per "Agent spawning mode".)
 
    Before spawning the Checker, run mechanical pre-checks:
    ```bash
@@ -261,7 +259,6 @@ to complete before proceeding to the next.
 
 3. `=== Iteration ${ITERATION}/${MAX_ITERATIONS}: CHECK phase ===`
    `Agent(subagent_type="looper:checker", prompt=<Checker context from 7c>)`
-   (If the Agent tool is unavailable, spawn via `claude-spawn-agent` per "Agent spawning mode".)
 
 #### 7e. Read verdict
 

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -12,14 +12,14 @@ Three subagents (Planner, Doer, Checker) iterate until the Checker issues a PASS
 
 **Never run the PDC loop inline.** If `claude-spawn-agent` is unavailable and step 0 did not abort, ABORT — inline execution defeats the loop's isolation, commit trail, and worktree guarantees.
 
-Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked via
-the Bash tool with `run_in_background: true`. The Bash tool returns
-immediately; the parent receives an automatic completion notification when
-the subprocess exits — read the result-file path printed on stdout then.
-No polling is required.
+Spawn subagents with `claude-spawn-agent <agent-name> <prompt>` invoked
+via the Bash tool. It is the drop-in for the built-in `Agent` tool inside
+subagent contexts: the subagent's text response is printed directly to
+stdout (foreground) or delivered inline in the completion notification
+(background).
 
-- Sync: `Bash(command="claude-spawn-agent X Y", run_in_background=true)` → completion notification → read result file.
-- Parallel fan-out: several `Bash(run_in_background=true, ...)` calls in one message, or `claude-spawn-agent X Y > /tmp/file.txt &` + `wait`.
+- Sync: `Bash(command="claude-spawn-agent X Y", run_in_background=true)` → completion notification fires on finish; its output contains the subagent's response text inline.
+- Parallel fan-out: several `claude-spawn-agent X Y > /tmp/file.txt &` calls in one Bash block, followed by `wait`.
 
 `claude-spawn-agent` is on `PATH` in every context and self-locates its
 plugin root — no env-var setup is required.

--- a/plugins/looper/skills/subagents/SKILL.md
+++ b/plugins/looper/skills/subagents/SKILL.md
@@ -6,15 +6,16 @@ tools: Bash, Read, Glob
 
 # Subagents Skill
 
-Spawn subagents using `claude -p` when the **Agent tool is not available** — e.g. from within an Agent tool subagent, a `claude -p` session, or any context that lacks the Agent tool.
+Spawn subagents using `claude-spawn-agent`. This is the canonical spawn
+mechanism in any context that runs outside the main Claude Code session —
+subagents, `claude -p` sessions, or scripts. It is a drop-in for the
+built-in `Agent` tool: the subagent's text response is printed directly to
+stdout.
 
 **When to use this skill:**
-- You need to delegate work to a specialized agent but the Agent tool is not in your tool set
+- You need to delegate work to a specialized agent
 - You are running inside a subagent and need to spawn further subagents
 - You want to run multiple agents in parallel from a non-interactive context
-
-**When NOT to use this skill:**
-- The Agent tool is available — use it directly instead (it's faster and cheaper)
 
 ---
 
@@ -70,55 +71,35 @@ underlying script self-locates its `CLAUDE_PLUGIN_ROOT` from its own path
 in the caller's environment. Callers never need to know the plugin's install
 layout or export any env vars.
 
-### Sync mode (default) — canonical pattern
-
-This is the primary pattern for spawning a single subagent and waiting for
-its result. Invoke `claude-spawn-agent` via the Bash tool with
-`run_in_background: true`. The Bash tool returns immediately with a task
-handle; when the subprocess exits, the parent receives an automatic
-completion notification. At that point, read the result-file path that
-`claude-spawn-agent` printed on stdout.
+### Via the Bash tool with `run_in_background: true` (canonical single-spawn)
 
 ```bash
-# In the Bash tool with run_in_background: true
 claude-spawn-agent "looper:checker" "Review the doer's work"
-# stdout: /tmp/subagent-response-<ts>.txt
-# (completion notification arrives when the subagent exits)
 ```
 
-After the completion notification arrives, read the file:
+The Bash tool returns immediately with a task handle and the parent
+receives an automatic completion notification when the subprocess exits.
+At that point the completion notification's output contains the subagent's
+text response directly — no file to read.
+
+### Foreground capture
 
 ```bash
-cat /tmp/subagent-response-<ts>.txt
+RESPONSE=$(claude-spawn-agent "Explore" "Find all API endpoints")
+echo "$RESPONSE"
 ```
 
-Do NOT capture the `claude-spawn-agent` call with a foreground
-`RESULT=$(...)` — Claude Code's Bash tool suppresses stdout from nested
-`claude` processes in foreground mode, so you'll get an empty string.
+### Parallel fan-out
 
-### Async mode — for parallel fan-out
-
-Use `--async` when you want to fire multiple subagents concurrently and
-wait for all of them in a single shell block. `--async` prints the
-result-file path immediately and runs the subagent in the background, so
-you can launch N in a row, then `wait` for them to finish together.
+For parallel fan-out, redirect each subagent's stdout to a temp file, run
+them in the background, then `wait`:
 
 ```bash
-# Fire two subagents in parallel, collect both results
-R1=$(claude-spawn-agent --async "looper:planner" "Plan how to add rate limiting")
-R2=$(claude-spawn-agent --async "Explore" "Find all API endpoint definitions")
-
-# Block on both background subprocesses
+claude-spawn-agent "looper:planner" "Plan rate limiting" > /tmp/p1.txt &
+claude-spawn-agent "Explore"        "Find API endpoints"  > /tmp/p2.txt &
 wait
-
-echo "=== Plan ==="    && cat "$R1"
-echo "=== Explore ===" && cat "$R2"
+cat /tmp/p1.txt /tmp/p2.txt
 ```
-
-For single-spawn, prefer the sync pattern above — it's simpler and the
-Bash tool delivers an automatic completion notification. Reserve `--async`
-for the genuine fan-out case where you want N concurrent subagents and
-only one downstream `wait`.
 
 ### Extra flags
 
@@ -167,6 +148,6 @@ Key fields:
 |----------|--------|
 | Agent not found | Check agent name with `claude agents` or the fallback scan |
 | Permission denied on `claude agents` | Use the filesystem fallback in Phase 1 |
-| Empty result | Check stderr: redirect `2>` to a file and inspect |
+| Empty result | stdout is empty; check stderr for error messages |
 | Subagent hangs | Use `--max-turns` and `--max-budget-usd` to cap execution |
 | Auth errors | Ensure Claude CLI is authenticated (`claude auth`) |

--- a/plugins/looper/skills/subagents/scripts/spawn-agent
+++ b/plugins/looper/skills/subagents/scripts/spawn-agent
@@ -2,71 +2,60 @@
 set -euo pipefail
 
 # Self-locate: derive CLAUDE_PLUGIN_ROOT from this script's own path.
-# spawn-agent lives at <PLUGIN_ROOT>/skills/subagents/scripts/spawn-agent,
-# so the plugin root is three directories up. The ${VAR:-default} guard
-# preserves any value the caller may have already exported.
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$_SCRIPT_DIR/../../.." && pwd)}"
 
-# Spawns a Claude subagent via claude -p and returns the text response.
+# Spawns a Claude subagent via `claude -p` and prints the subagent's text
+# response directly to stdout — a true drop-in for the built-in Agent tool.
 # Bypasses nested-session detection and skips permission prompts.
 #
-# Modes:
-#   sync  (default) — blocks until done, writes result to file, prints path
-#   async           — returns immediately, prints output path to poll
-#
 # Usage:
-#   spawn-agent [--async] <agent-name> <prompt> [extra-flags...]
+#   claude-spawn-agent <agent-name> <prompt> [extra-flags...]
 #
-# Sync examples (run in background Bash, read result file after):
-#   spawn-agent looper:checker "Review the doer's work"
-#   cat /tmp/subagent-response-<ts>-<pid>.txt
+# Examples (main-session Agent-tool equivalents shown inline):
+#   # Foreground call, capture the response:
+#   RESPONSE=$(claude-spawn-agent Explore "Find all API endpoints")
 #
-# Async examples (fire and poll):
-#   RESULT=$(spawn-agent --async Explore "Find all API endpoints")
-#   # ... do other work ...
-#   cat "$RESULT"
+#   # Background / parallel fan-out:
+#   claude-spawn-agent Explore "Area A" > /tmp/a.txt &
+#   claude-spawn-agent Explore "Area B" > /tmp/b.txt &
+#   wait
+#
+#   # Via the Bash tool with run_in_background=true (completion notification):
+#   claude-spawn-agent looper:checker "Review the doer's work"
 
-MODE="sync"
-if [[ "${1:-}" == "--async" ]]; then
-  MODE="async"
-  shift
-fi
-
-AGENT="${1:?Usage: spawn-agent [--async] <agent-name> <prompt> [extra-flags...]}"
-PROMPT="${2:?Usage: spawn-agent [--async] <agent-name> <prompt> [extra-flags...]}"
+AGENT="${1:?Usage: claude-spawn-agent <agent-name> <prompt> [extra-flags...]}"
+PROMPT="${2:?Usage: claude-spawn-agent <agent-name> <prompt> [extra-flags...]}"
 shift 2
 
-TIMESTAMP=$(date +%s%N)
-OUTFILE="/tmp/subagent-result-${TIMESTAMP}.json"
-RESULTFILE="/tmp/subagent-response-${TIMESTAMP}.txt"
+# Defensive: catch callers still passing the removed --async flag.
+case "$AGENT" in
+  --async)
+    echo "claude-spawn-agent: --async is no longer supported (issue #104). Use '&' + 'wait' for parallel fan-out, or Bash(run_in_background=true) for single-spawn." >&2
+    exit 2
+    ;;
+esac
 
-run_agent() {
-  local rc=0
-  env -u CLAUDECODE -u CLAUDE_CODE claude -p \
-    --agent "$AGENT" \
-    --output-format json \
-    --dangerously-skip-permissions \
-    "$PROMPT" \
-    "$@" \
-    >"$OUTFILE" 2>/dev/null || rc=$?
+OUTFILE="$(mktemp -t subagent-result-XXXXXX.json)"
+# Ensure the temp JSON is always cleaned up, even on error.
+trap 'rm -f "$OUTFILE"' EXIT
 
-  if [ -s "$OUTFILE" ]; then
-    jq -r '.result // empty' "$OUTFILE" > "$RESULTFILE" 2>/dev/null || cp "$OUTFILE" "$RESULTFILE"
-  else
-    echo "spawn-agent error: claude exited with code $rc" > "$RESULTFILE"
-  fi
-  rm -f "$OUTFILE"
-  return $rc
-}
+rc=0
+env -u CLAUDECODE -u CLAUDE_CODE claude -p \
+  --agent "$AGENT" \
+  --output-format json \
+  --dangerously-skip-permissions \
+  "$PROMPT" \
+  "$@" \
+  >"$OUTFILE" 2>/dev/null || rc=$?
 
-if [[ "$MODE" == "async" ]]; then
-  # Return the result path immediately, run in background
-  echo "$RESULTFILE"
-  run_agent "$@" &
-  disown
+if [ -s "$OUTFILE" ]; then
+  # Print .result directly to stdout. If .result is missing/empty, emit the
+  # raw JSON so the caller has something to inspect.
+  jq -r '.result // empty' "$OUTFILE" 2>/dev/null || cat "$OUTFILE"
 else
-  # Block until complete, print the result path
-  run_agent "$@"
-  echo "$RESULTFILE"
+  # claude exited without writing JSON — surface that instead of empty output.
+  echo "claude-spawn-agent error: claude exited with code $rc (no output)" >&2
 fi
+
+exit $rc

--- a/tests/run-corner-case-tests.sh
+++ b/tests/run-corner-case-tests.sh
@@ -41,6 +41,7 @@ run_suite "test-resolve-plan-pointers.sh"
 run_suite "test-delta-mode-prompts.sh"
 run_suite "test-issue-tooling.sh"
 run_suite "test-agent-spawn-migration.sh"
+run_suite "test-spawn-agent-canonical.sh"
 run_suite "test-fail-fast-gate.sh"
 
 echo "=============================="

--- a/tests/test-agent-spawn-migration.sh
+++ b/tests/test-agent-spawn-migration.sh
@@ -62,13 +62,37 @@ assert_file_contains "subagents/SKILL.md: mentions run_in_background" \
 assert_file_contains "subagents/SKILL.md: mentions completion notification" \
     "$SUBAGENTS_SKILL" "completion notification"
 
-# AC3 — --async reframed as parallel fan-out, spawn-agent unchanged.
-assert_file_contains "subagents/SKILL.md: frames --async as parallel fan-out" \
+# AC3 — parallel fan-out via stdout-redirect + &/wait; --async removed from spawn-agent.
+assert_file_contains "subagents/SKILL.md: frames parallel fan-out" \
     "$SUBAGENTS_SKILL" "parallel fan-out"
+assert_file_not_contains "subagents/SKILL.md: no --async references" \
+    "$SUBAGENTS_SKILL" '--async'
 assert_file_not_contains "subagents/SKILL.md: old poll-loop removed from parallel example" \
     "$SUBAGENTS_SKILL" 'while \[ ! -s '
-assert_file_contains "spawn-agent: --async mode preserved" \
+assert_file_not_contains "spawn-agent: --async mode removed" \
     "$SPAWN_AGENT" 'MODE="async"'
+assert_file_not_contains "spawn-agent: --async flag branch removed" \
+    "$SPAWN_AGENT" '"${1:-}" == "--async"'
+
+# AC3 extended — no /tmp/subagent-response-* artefacts anywhere
+assert_file_not_contains "subagents/SKILL.md: no subagent-response- path" \
+    "$SUBAGENTS_SKILL" 'subagent-response-'
+assert_file_not_contains "looper/SKILL.md: no subagent-response- path" \
+    "$LOOPER_SKILL" 'subagent-response-'
+assert_file_not_contains "spawn-agent: no subagent-response- path" \
+    "$SPAWN_AGENT" 'subagent-response-'
+
+# AC3 extended — agent preambles have no --async
+assert_file_not_contains "planner.md: preamble has no --async" \
+    "$PLANNER" '--async'
+assert_file_not_contains "doer.md: preamble has no --async" \
+    "$DOER" '--async'
+assert_file_not_contains "checker.md: preamble has no --async" \
+    "$CHECKER" '--async'
+
+# AC3 extended — spawn-agent prints .result directly
+assert_file_contains "spawn-agent: prints .result directly" \
+    "$SPAWN_AGENT" "jq -r '.result"
 
 # AC4 — Per-agent preambles migrated and lose dual-path fallback language.
 for f in "$PLANNER" "$DOER" "$CHECKER"; do

--- a/tests/test-agent-spawn-migration.sh
+++ b/tests/test-agent-spawn-migration.sh
@@ -118,6 +118,18 @@ for f in "$LOOPER_SKILL" "$PLANNER" "$DOER" "$CHECKER"; do
         "$f" 'CLAUDE_PLUGIN_ROOT/skills/subagents/scripts/spawn-agent'
 done
 
+# AC8 — Stale result-file framing removed from all four docs.
+for f in "$LOOPER_SKILL" "$PLANNER" "$DOER" "$CHECKER"; do
+    assert_file_not_contains "$(basename "$f"): no 'result-file path' framing" \
+        "$f" 'result-file path'
+done
+
+# AC9 — Stale 'read result file' synonym removed from all four docs.
+for f in "$LOOPER_SKILL" "$PLANNER" "$DOER" "$CHECKER"; do
+    assert_file_not_contains "$(basename "$f"): no 'read result file' synonym" \
+        "$f" 'read result file'
+done
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test-agent-spawn-migration.sh
+++ b/tests/test-agent-spawn-migration.sh
@@ -72,7 +72,7 @@ assert_file_not_contains "subagents/SKILL.md: old poll-loop removed from paralle
 assert_file_not_contains "spawn-agent: --async mode removed" \
     "$SPAWN_AGENT" 'MODE="async"'
 assert_file_not_contains "spawn-agent: --async flag branch removed" \
-    "$SPAWN_AGENT" '"${1:-}" == "--async"'
+    "$SPAWN_AGENT" '== "--async"'
 
 # AC3 extended — no /tmp/subagent-response-* artefacts anywhere
 assert_file_not_contains "subagents/SKILL.md: no subagent-response- path" \

--- a/tests/test-spawn-agent-canonical.sh
+++ b/tests/test-spawn-agent-canonical.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-spawn-agent-canonical.sh — Corner-case tests for the rewritten spawn-agent script.
+# Uses PATH shims so no real Anthropic API calls are made.
+# All 7 corner cases from plan issue #104.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPAWN_AGENT="$REPO_ROOT/plugins/looper/skills/subagents/scripts/spawn-agent"
+
+PASS=0
+FAIL=0
+SHIMDIR=""
+
+cleanup() {
+    if [ -n "$SHIMDIR" ] && [ -d "$SHIMDIR" ]; then
+        rm -rf "$SHIMDIR"
+    fi
+}
+trap cleanup EXIT
+
+assert_eq() {
+    local description="$1" actual="$2" expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "PASS: $description"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected '$expected', got '$actual')"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local description="$1" actual="$2" pattern="$3"
+    if echo "$actual" | grep -qF -- "$pattern"; then
+        echo "PASS: $description"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected '$pattern' in output, got: $actual)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local description="$1" actual="$2" pattern="$3"
+    if echo "$actual" | grep -qF -- "$pattern"; then
+        echo "FAIL: $description (pattern '$pattern' found in output but should not be)"; FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $description"; PASS=$((PASS + 1))
+    fi
+}
+
+assert_exit_code() {
+    local description="$1" actual_code="$2" expected_code="$3"
+    if [ "$actual_code" -eq "$expected_code" ]; then
+        echo "PASS: $description"; PASS=$((PASS + 1))
+    else
+        echo "FAIL: $description (expected exit $expected_code, got $actual_code)"; FAIL=$((FAIL + 1))
+    fi
+}
+
+# Create a fresh shim dir for each test group
+make_shimdir() {
+    SHIMDIR="$(mktemp -d -t spawn-agent-test-XXXXXX)"
+}
+
+# ── Case 1: Sync mode prints response body on stdout (not a tempfile path) ─────
+
+echo "=== Case 1: sync mode prints .result directly to stdout ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+# Shim: write JSON result to stdout when invoked with -p --agent ... --output-format json
+printf '{"result":"hello from shim","is_error":false}'
+exit 0
+EOF
+chmod +x "$SHIMDIR/claude"
+
+actual_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "say hi" 2>/dev/null || true)
+assert_contains "sync mode: stdout contains response text" "$actual_stdout" "hello from shim"
+assert_not_contains "sync mode: stdout does not contain /tmp/ path" "$actual_stdout" "/tmp/"
+
+# ── Case 2: Exit code propagates from claude ────────────────────────────────────
+
+echo ""
+echo "=== Case 2: exit code propagates from claude ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+# Shim: exits 17 and writes nothing
+exit 17
+EOF
+chmod +x "$SHIMDIR/claude"
+
+actual_stderr_c2=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "fail" 2>&1 >/dev/null || true)
+actual_exit_c2=0
+PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "fail" >/dev/null 2>/dev/null || actual_exit_c2=$?
+
+assert_exit_code "exit code propagation: exits with 17" "$actual_exit_c2" 17
+assert_contains "exit code propagation: stderr mentions no output" "$actual_stderr_c2" "no output"
+
+# ── Case 3: --async is rejected ──────────────────────────────────────────────────
+
+echo ""
+echo "=== Case 3: --async is rejected (exit 2, stderr message) ==="
+actual_stderr_c3=$(bash "$SPAWN_AGENT" --async "Explore" "anything" 2>&1 >/dev/null || true)
+actual_exit_c3=0
+bash "$SPAWN_AGENT" --async "Explore" "anything" >/dev/null 2>/dev/null || actual_exit_c3=$?
+
+assert_exit_code "--async rejected: exit code is 2" "$actual_exit_c3" 2
+assert_contains "--async rejected: stderr mentions 'no longer supported'" \
+    "$actual_stderr_c3" "no longer supported"
+
+# ── Case 4: Script passes ShellCheck ────────────────────────────────────────────
+
+echo ""
+echo "=== Case 4: spawn-agent passes ShellCheck ==="
+if command -v shellcheck >/dev/null 2>&1; then
+    sc_exit=0
+    shellcheck "$SPAWN_AGENT" 2>/dev/null || sc_exit=$?
+    assert_exit_code "ShellCheck: spawn-agent is clean" "$sc_exit" 0
+else
+    echo "SKIP: shellcheck not found on PATH"
+fi
+
+# ── Case 5: Missing-argument usage string does not mention --async ───────────────
+
+echo ""
+echo "=== Case 5: missing args yields Usage: without --async ==="
+usage_stderr=$(bash "$SPAWN_AGENT" 2>&1 >/dev/null || true)
+assert_contains "missing args: stderr contains 'Usage:'" "$usage_stderr" "Usage:"
+assert_not_contains "missing args: stderr does not mention '--async'" "$usage_stderr" "--async"
+
+# ── Case 6: Empty .result field from claude ──────────────────────────────────────
+
+echo ""
+echo "=== Case 6: empty .result field — script exits 0 and stdout is empty ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+printf '{"result":"","is_error":false}'
+exit 0
+EOF
+chmod +x "$SHIMDIR/claude"
+
+empty_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "empty" 2>/dev/null || true)
+empty_exit=0
+PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "empty" >/dev/null 2>/dev/null || empty_exit=$?
+
+assert_exit_code "empty .result: exits 0" "$empty_exit" 0
+assert_eq "empty .result: stdout is empty" "$empty_stdout" ""
+
+# ── Case 7 (corner case 2): Non-JSON stdout from claude ─────────────────────────
+
+echo ""
+echo "=== Case 7: non-JSON stdout from claude falls through to cat ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+printf 'not json'
+exit 1
+EOF
+chmod +x "$SHIMDIR/claude"
+
+nonjson_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "nonjson" 2>/dev/null || true)
+nonjson_exit=0
+PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "nonjson" >/dev/null 2>/dev/null || nonjson_exit=$?
+
+assert_contains "non-JSON: raw content appears on stdout" "$nonjson_stdout" "not json"
+assert_exit_code "non-JSON: exit code propagates (1)" "$nonjson_exit" 1
+
+# ── Case (corner 5): Agent name with colon (looper:checker) ─────────────────────
+
+echo ""
+echo "=== Case 8: agent name with colon forwarded correctly ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+# Record argv and echo it back as the result
+printf '{"result":"%s","is_error":false}' "$*"
+exit 0
+EOF
+chmod +x "$SHIMDIR/claude"
+
+colon_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "looper:checker" "my prompt" 2>/dev/null || true)
+assert_contains "colon in agent name: stdout contains looper:checker" "$colon_stdout" "looper:checker"
+
+# ── Case (corner 7): Extra flags forwarded via "$@" ─────────────────────────────
+
+echo ""
+echo "=== Case 9: extra flags forwarded after <prompt> ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+printf '{"result":"%s","is_error":false}' "$*"
+exit 0
+EOF
+chmod +x "$SHIMDIR/claude"
+
+extra_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "do stuff" --max-turns 3 2>/dev/null || true)
+assert_contains "extra flags: --max-turns appears in forwarded argv" "$extra_stdout" "--max-turns"
+
+# ────────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem / Task

`claude-spawn-agent` was advertised as a workaround for nested contexts where the `Agent` tool isn't available, but it wasn't a clean drop-in: sync mode wrote the response to `/tmp/subagent-response-<ts>.txt` and echoed only the *path* on stdout, forcing callers to do a second `Read`. `--async` detached the PID with `& disown`, so the harness's completion notification fired on the wrapper's exit rather than `claude -p`'s finish — a silent footgun. Docs across three files disagreed about whether it's a fallback or canonical, so subagents picked different code paths depending on which file they'd read.

**Current behavior:** `Bash(command="claude-spawn-agent X Y")` returns a `/tmp/...txt` path; caller must `Read` it to see the response. `--async` silently fails to deliver a completion signal. `skills/looper/SKILL.md`, `skills/subagents/SKILL.md`, and the three agent preambles give contradictory guidance.

**Expected behavior:** `Bash(command="claude-spawn-agent X Y")` returns the subagent's response text inline as the Bash tool-result. `run_in_background=true` fires `<task-notification>` on real completion with the `.output` file holding the response text. `--async` is gone. All docs converge on "canonical drop-in for Agent in subagent contexts" — no fallback language.

## Existing Architecture

Before this change, `spawn-agent` split its mode between sync (block, write to tempfile, echo path) and async (detach + disown). The caller always had to read a file.

```mermaid
flowchart TD
    Caller[Subagent caller] -->|Bash| Wrapper["claude-spawn-agent (sync)"]
    Caller -->|Bash| WrapperA["claude-spawn-agent --async"]
    Wrapper --> Claude[claude -p]
    WrapperA -->|"& disown"| ClaudeA[claude -p detached]
    Claude --> JSON[/tmp/subagent-result-*.json]
    JSON -->|"jq .result"| RespFile[/tmp/subagent-response-*.txt]
    ClaudeA --> RespFile
    Wrapper -->|"echo path"| Caller
    WrapperA -->|"echo path immediately"| Caller
    Caller -->|"Read path"| RespFile
    style WrapperA fill:#f66,stroke:#333
    style ClaudeA fill:#f66,stroke:#333
    style RespFile fill:#f66,stroke:#333
```

## Proposed Architecture

After this change, `spawn-agent` has a single path: block on `claude -p`, pipe the JSON through `jq -r '.result // empty'`, stream the response text to stdout, clean up via `trap`. The Bash tool's own mechanisms (inline tool-result in foreground, `.output` + task-notification in background) handle the rest.

```mermaid
flowchart TD
    Caller[Subagent caller] -->|Bash foreground| Wrapper["claude-spawn-agent"]
    Caller -->|"Bash run_in_background=true"| Wrapper
    Wrapper --> Claude[claude -p]
    Claude --> JQ["jq -r '.result'"]
    JQ --> Stdout([stdout])
    Stdout -->|tool-result inline| Caller
    Stdout -.->|".output file + task-notification"| CallerBg[Caller on completion]
    style Wrapper fill:#6f6,stroke:#333
    style JQ fill:#6f6,stroke:#333
    style Stdout fill:#69f,stroke:#333
```

## Key Changes

### Script rewrite (`plugins/looper/skills/subagents/scripts/spawn-agent`)

- Drop the `--async` mode entirely. Keep a defensive arm that rejects `--async` with exit 2 so existing callers that haven't migrated get a loud error instead of silent detachment.
- Drop the `/tmp/subagent-response-<ts>.txt` tempfile. Pipe `claude -p --output-format json` output through `jq -r '.result // empty'` directly to stdout.
- Internal JSON is written to a `mktemp`-created tempfile and cleaned up by a `trap EXIT`.
- Preserve the nested-session bypass (`env -u CLAUDECODE -u CLAUDE_CODE`) and `--dangerously-skip-permissions`. Preserve the "claude failed with empty stdout" error path.

### Docs converged on a single story

- `plugins/looper/skills/subagents/SKILL.md` — removed "When NOT to use this skill: The Agent tool is available" bullet. Reframed as the canonical spawn mechanism inside subagent / `claude -p` contexts. All `--async` and `/tmp/subagent-response-*` examples removed.
- `plugins/looper/skills/looper/SKILL.md` — rewrote the `## Agent spawning mode` body (lines 15-22) to describe the stdout-inline contract. Dropped three "If the Agent tool is unavailable" conditionals at steps 7d. Step-0 fail-fast gate left verbatim.
- `plugins/looper/agents/{planner,doer,checker}.md` — rewrote the preamble paragraph in each to describe the drop-in-for-Agent contract. "Never improvise PDC work inline." paragraph kept at its original line position so `test-fail-fast-gate.sh` Test 5 continues to pin it.

### Tests

- New corner-case suite `tests/test-spawn-agent-canonical.sh` — 15 assertions across 9 cases using a PATH shim for `claude` (no real API calls). Covers: empty `.result`, non-JSON output, non-zero exit with empty stdout, `--async` rejection, agent-name-with-colon, missing arguments, extra-flag forwarding, and the sync-returns-body contract.
- `tests/test-agent-spawn-migration.sh` — added AC8 and AC9 regression loops that grep the 4 doc files for `result-file path` and `read result file` — guarantees the stale framing can't silently return.
- Registered the new suite in `tests/run-corner-case-tests.sh`.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Corner-case test suite | ✅ | 15/15 suites pass (includes `test-spawn-agent-canonical.sh`) |
| `test-agent-spawn-migration.sh` | ✅ | 44/44 assertions (includes new AC8/AC9) |
| `test-fail-fast-gate.sh` | ✅ | 21/21 — no regression, all anchor line positions preserved |
| ShellCheck | ✅ | `spawn-agent`, `test-spawn-agent-canonical.sh`, `test-agent-spawn-migration.sh` clean |
| JSON validation | ✅ | `plugin.json` and `marketplace.json` parseable |
| `cargo check --workspace` | ✅ | No Rust impact; builds clean |
| Repo-wide grep audit | ✅ | No `--async` or `subagent-response-` references outside defensive rejection + negative assertions |

Closes #104.

Plan-Do-Check loop completed in 2 iterations (iter 1 FAIL on AC#5 residual doc drift, iter 2 PASS after targeted docs scrub).