### PR TITLE
refactor(looper): rely on Claude Desktop for worktree creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "looper-watch"
-version = "0.48.2"
+version = "0.49.0"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Looper supports two execution modes. Pick one per invocation.
 
 | Mode | Command | Isolation | Use when |
 |------|---------|-----------|----------|
-| **Worktree** (default) | `/looper:loop "<task>"` | Git worktree at `.worktrees/<name>/`. Host env, host network, host creds. | Single-developer, single-task, trusted environment. |
+| **Worktree** (default) | `/looper:loop "<task>"` | Runs inside the current git worktree (Claude Desktop creates the worktree before invocation; for non-Desktop flows, `looper-ee` and `initiate-worktree` create one under `.worktrees/<name>/`). Host env, host network, host creds. | Single-developer, single-task, trusted environment. |
 | **Sandboxed** (opt-in) | `/looper:looper-sandboxed "<task>"` | `docker` backend (default): `docker run` + bind-mount + `/var/run/docker.sock` for nested Docker. `sbx` backend (opt-in): microVM + host-side secret proxy. | Concurrent loops, defense-in-depth, or preparing for remote fleet execution. |
 
 Both modes run the same PDC loop — only the execution environment differs.

--- a/crates/looper-watch/src/worker.rs
+++ b/crates/looper-watch/src/worker.rs
@@ -362,9 +362,9 @@ async fn run_claude(
         .output()
         .await;
 
-    // Guard against core.bare=true on the repo after worktree cleanup.
-    // Worktree removal (in create-github-pr) can leave core.bare=true,
-    // which blocks git pull on the main branch.
+    // Guard against core.bare=true on the repo after a session ends.
+    // External worktree management (Claude Desktop / looper-ee) can leave
+    // core.bare=true behind, which blocks git pull on the main branch.
     fix_bare_if_needed(repo, app).await;
 
     let outcome = Outcome::Completed {

--- a/plugins/looper/skills/create-github-pr/SKILL.md
+++ b/plugins/looper/skills/create-github-pr/SKILL.md
@@ -465,20 +465,7 @@ fi
 
 If the squash merge fails (e.g., merge conflicts, branch protection rules), report the error to the user and do NOT retry. The user may need to resolve conflicts or adjust branch protection settings.
 
-### 6b. Clean up worktree
-
-If the `$WORKTREE_DIR` variable is set (indicating this PR was created from a looper worktree), remove the worktree after a successful merge or after the PR is left open:
-
-```bash
-SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)}/skills/looper/scripts"
-"$SCRIPTS_DIR/cleanup-worktree" --dir "$WORKTREE_DIR"
-```
-
-The `cleanup-worktree` script handles returning to the main repo, removing the worktree, and guarding against `core.bare=true` in a single atomic operation.
-
-If worktree removal fails, warn but do not abort.
-
-### 6c. Report final status
+### 6b. Report final status
 
 **If squash-merged (no DB migrations):**
 ```
@@ -522,7 +509,6 @@ Merge manually: gh pr merge <number> --squash --delete-branch
 | Squash merge fails (conflicts) | Report error, print manual merge command `gh pr merge <number> --squash --delete-branch`, do NOT retry |
 | Squash merge fails (branch protection) | Report error, suggest user review branch protection settings |
 | DB migrations detected | Do NOT merge — leave PR open for manual review, report PR URL |
-| Worktree cleanup fails | Warn but do not abort — merge already succeeded |
 
 ---
 

--- a/plugins/looper/skills/looper-issue/SKILL.md
+++ b/plugins/looper/skills/looper-issue/SKILL.md
@@ -134,7 +134,7 @@ Invoke the `looper` skill with the selected issue reference:
 
 This hands off entirely to the existing looper skill, which will:
 - Sanitize the task name from the argument
-- Create or resume an isolated worktree
+- Resolve the current worktree (Claude Desktop creates the worktree before invocation)
 - Run the Plan-Do-Check loop
 
 ---

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -79,28 +79,52 @@ Sanitize `$ARGUMENTS` into a kebab-case task name: lowercase, replace spaces/und
 with hyphens, remove non-alphanumeric characters (except hyphens), truncate to 50 characters,
 strip leading/trailing hyphens.
 
-### 4. Create worktree
+### 4. Resolve worktree paths
 
-Resolve `SCRIPTS_DIR` and `REPO_ROOT` before entering the worktree:
+Claude Desktop creates an isolated worktree before invoking this skill, so the
+current working directory is already a worktree on a feature branch. Resolve
+the paths the rest of the skill depends on:
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
+WORKTREE_DIR=$(git rev-parse --show-toplevel)
+REPO_ROOT="$WORKTREE_DIR"
 SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-${REPO_ROOT}}/skills/looper/scripts"
 ```
 
-Create an isolated worktree (handles gitignore, create-or-resume, and dirty-state warnings):
+**CRITICAL:** All work MUST happen inside the worktree. NEVER commit directly to
+the default branch. Refuse to run if we are on a detached HEAD, on the default
+branch, or cannot determine the default branch:
 
 ```bash
-WORKTREE_DIR=$($SCRIPTS_DIR/setup-worktree --task "$TASK_NAME")
-cd "$WORKTREE_DIR"
-```
+CURRENT_BRANCH=$(git branch --show-current)
+if [ -z "$CURRENT_BRANCH" ]; then
+    echo "ERROR: Detached HEAD — refusing to run." >&2
+    exit 1
+fi
 
-**Gate:** If `setup-worktree` exits non-zero or `WORKTREE_DIR` is empty, abort immediately.
-**CRITICAL:** All work MUST happen inside the worktree. NEVER commit directly to the default branch.
-Verify you are on a `loop/` branch:
-
-```bash
-git branch --show-current | grep -q '^loop/' || { echo "ERROR: not on a loop/ branch"; exit 1; }
+# Resolve default branch: prefer origin/HEAD symref, fall back to gh, then to main/master.
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+    | sed 's|refs/remotes/origin/||' || true)
+if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+fi
+if [ -z "$DEFAULT_BRANCH" ]; then
+    for candidate in main master; do
+        if git rev-parse --verify "$candidate" >/dev/null 2>&1 \
+           || git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+            DEFAULT_BRANCH="$candidate"; break
+        fi
+    done
+fi
+if [ -z "$DEFAULT_BRANCH" ]; then
+    echo "ERROR: Could not determine default branch — refusing to run (cannot guarantee branch isolation)." >&2
+    exit 1
+fi
+if [ "$CURRENT_BRANCH" = "$DEFAULT_BRANCH" ] \
+   || [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+    echo "ERROR: Refusing to run on default/protected branch '$CURRENT_BRANCH'." >&2
+    exit 1
+fi
 ```
 
 ### 4b. Sync worktree with remote
@@ -298,8 +322,7 @@ eval "$SYNC_OUTPUT"   # sets DEFAULT_BRANCH, STATUS
   the default branch. The PR skill will wait for CI, then squash-merge if
   no DB migrations are detected. If DB migration files are present in the
   changeset, the PR is left open for manual review (no auto-merge).
-  The worktree is cleaned up automatically after merge or PR creation.
-  If CI fails or merge fails, the worktree is preserved for manual inspection.
+  Worktree lifecycle is managed by Claude Desktop, not by this skill.
 
   **CRITICAL — never merge locally:** Do NOT run `git merge`, `git checkout
   <default-branch>`, or any command that merges the loop branch into the
@@ -307,6 +330,5 @@ eval "$SYNC_OUTPUT"   # sets DEFAULT_BRANCH, STATUS
 
 - **FAIL (max iterations):** Report that max iterations were reached. Show
   the last checker verdict: `git log --grep="Loop-Verdict: FAIL" -1 --format="%B"`
-  The worktree at `$WORKTREE_DIR` is **preserved** for debugging.
 - **Resumable:** Running `/looper` again with the same task resumes automatically
   via step 5.

--- a/plugins/looper/skills/looper/scripts/git-commit-loop
+++ b/plugins/looper/skills/looper/scripts/git-commit-loop
@@ -67,15 +67,34 @@ if [ -n "$VERDICT" ]; then
     COMMIT_MSG+=$'\n'"Loop-Verdict: ${VERDICT}"
 fi
 
-# Branch guard: refuse to commit on protected branches
+# Branch guard: refuse to commit on protected branches or detached HEAD
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
-# Detect the repo's default branch from the remote HEAD symref, fall back to main/master
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "")
+if [ -z "$CURRENT_BRANCH" ]; then
+    echo "ERROR: Detached HEAD — refusing to commit." >&2
+    echo "Looper must run inside a worktree on a feature branch." >&2
+    exit 1
+fi
+# Detect the repo's default branch: origin/HEAD symref → gh fallback → main/master probe.
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
+if [ -z "$DEFAULT_BRANCH" ] && command -v gh >/dev/null 2>&1; then
+    DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+fi
+if [ -z "$DEFAULT_BRANCH" ]; then
+    for candidate in main master; do
+        if git rev-parse --verify "$candidate" >/dev/null 2>&1 \
+           || git rev-parse --verify "origin/$candidate" >/dev/null 2>&1; then
+            DEFAULT_BRANCH="$candidate"; break
+        fi
+    done
+fi
+if [ -z "$DEFAULT_BRANCH" ]; then
+    echo "ERROR: Could not determine default branch — refusing to commit (cannot guarantee branch isolation)." >&2
+    exit 1
+fi
 if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" || \
-      ( -n "$DEFAULT_BRANCH" && "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ) ]]; then
+      "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ]]; then
     echo "ERROR: Refusing to commit on protected branch '$CURRENT_BRANCH'." >&2
-    echo "Looper must run inside a worktree on a loop/* branch." >&2
-    echo "Use setup-worktree to create an isolated worktree first." >&2
+    echo "Looper must run inside a worktree on a feature branch." >&2
     exit 1
 fi
 

--- a/plugins/looper/tests/test-worktree-enforcement.sh
+++ b/plugins/looper/tests/test-worktree-enforcement.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# test-worktree-enforcement.sh — Verify that looper skill enforces
-# worktree isolation and prevents committing directly to main/default branch.
-# Addresses issue #42: Looper committed directly to main without worktree.
+# test-worktree-enforcement.sh — Verify that the looper skill enforces
+# branch isolation and prevents committing directly to the default branch.
+# Worktree creation itself is now handled externally by Claude Desktop, so the
+# /looper skill only verifies that the current working directory is a worktree
+# on a non-default branch before doing any work.
 
 SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../skills" && pwd)"
 LOOPER_SKILL="$SKILLS_DIR/looper/SKILL.md"
+GIT_COMMIT_LOOP="$SKILLS_DIR/looper/scripts/git-commit-loop"
 
 PASS=0
 FAIL=0
@@ -16,7 +19,7 @@ check() {
     local file="$2"
     local pattern="$3"
 
-    if grep -q "$pattern" "$file"; then
+    if grep -qE "$pattern" "$file"; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
     else
@@ -26,42 +29,72 @@ check() {
     fi
 }
 
-# looper/SKILL.md must require creating a worktree before any work
-check "looper SKILL.md requires worktree creation" \
-    "$LOOPER_SKILL" \
-    "setup-worktree"
+check_absent() {
+    local label="$1"
+    local file="$2"
+    local pattern="$3"
 
-# looper/SKILL.md must have a gate that aborts if worktree creation fails
-check "looper SKILL.md has worktree creation gate" \
+    if grep -qE "$pattern" "$file"; then
+        echo "FAIL: $label"
+        echo "  Pattern '$pattern' should NOT be in $file"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# looper/SKILL.md must resolve WORKTREE_DIR from the current repo (Claude Desktop
+# is responsible for cd-ing into the worktree before invoking the skill).
+check "looper SKILL.md resolves WORKTREE_DIR via git rev-parse" \
     "$LOOPER_SKILL" \
-    "WORKTREE_DIR.*empty.*abort\|abort.*WORKTREE_DIR.*empty\|setup-worktree.*exits non-zero"
+    'WORKTREE_DIR=\$\(git rev-parse --show-toplevel\)'
 
 # looper/SKILL.md must state CRITICAL: never commit directly to default branch
-check "looper SKILL.md forbids committing directly to default branch" \
+# (The phrase may wrap across lines, so match the leading half only.)
+check "looper SKILL.md forbids committing directly to the default branch" \
     "$LOOPER_SKILL" \
-    "NEVER commit directly to the default branch"
+    "NEVER commit directly to"
 
-# looper/SKILL.md must verify loop/ branch before proceeding
-check "looper SKILL.md verifies loop/ branch" \
+# looper/SKILL.md must reject detached HEAD before any work
+check "looper SKILL.md rejects detached HEAD" \
     "$LOOPER_SKILL" \
-    "loop/"
+    "Detached HEAD"
+
+# looper/SKILL.md must reject the default branch (dynamic detection + main/master fallback)
+check "looper SKILL.md rejects running on default/protected branch" \
+    "$LOOPER_SKILL" \
+    "Refusing to run on default/protected branch"
+
+# looper/SKILL.md must NOT call setup-worktree (Claude Desktop handles worktree creation)
+check_absent "looper SKILL.md does not call setup-worktree" \
+    "$LOOPER_SKILL" \
+    'setup-worktree --task'
 
 # looper/SKILL.md must forbid local merges
 check "looper SKILL.md forbids local merges" \
     "$LOOPER_SKILL" \
-    "never merge locally\|CRITICAL.*never merge\|never merge.*CRITICAL"
+    "never merge locally|CRITICAL.*never merge|never merge.*CRITICAL"
 
 # looper/SKILL.md must direct to create-github-pr for merging
 check "looper SKILL.md uses create-github-pr for merging" \
     "$LOOPER_SKILL" \
     "create-github-pr"
 
-SETUP_WORKTREE_SCRIPT="$SKILLS_DIR/looper/scripts/setup-worktree"
+# git-commit-loop must guard against committing on detached HEAD
+check "git-commit-loop guards detached HEAD" \
+    "$GIT_COMMIT_LOOP" \
+    "Detached HEAD"
 
-# setup-worktree must contain a bare-repo guard
-check "setup-worktree script contains bare-repo guard" \
-    "$SETUP_WORKTREE_SCRIPT" \
-    "ensure_not_bare\|core\.bare"
+# git-commit-loop must guard against committing on the default branch
+check "git-commit-loop guards default branch" \
+    "$GIT_COMMIT_LOOP" \
+    "Refusing to commit on protected branch"
+
+# git-commit-loop must refuse if the default branch cannot be determined
+check "git-commit-loop refuses when default branch undetermined" \
+    "$GIT_COMMIT_LOOP" \
+    "Could not determine default branch"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

The `/looper` skill no longer creates its own git worktree. Claude Desktop creates an isolated worktree before invoking the skill, so step 4 now just resolves `WORKTREE_DIR` from the current repo and verifies we are on a non-default branch.

## Changes

### `plugins/looper/skills/looper/SKILL.md`
- Drop `setup-worktree` invocation and `cd` from step 4. Resolve `WORKTREE_DIR` via `git rev-parse --show-toplevel` (correct from any subdirectory, not just `pwd`).
- Replace the `loop/*` branch check with a default-branch guard that:
  - Refuses on detached HEAD.
  - Detects default branch via `origin/HEAD` symref → `gh repo view` fallback → `main`/`master` probe.
  - Refuses if the default cannot be determined (fail-closed).
- Drop worktree-cleanup wording from step 7.

### `plugins/looper/skills/create-github-pr/SKILL.md`
- Remove Phase 6b (`cleanup-worktree` call). Worktree lifecycle is external now.
- Renumber Phase 6c → 6b. Remove the worktree-cleanup row from the error-handling table.

### `plugins/looper/skills/looper/scripts/git-commit-loop`
- Mirror the SKILL.md guard for defense in depth: detached HEAD, full default-branch detection ladder, refuse-if-undetermined.
- Drop the stale "Use setup-worktree…" hint from the protected-branch error.

### `plugins/looper/skills/looper-issue/SKILL.md`
- Wording fix: `/looper` no longer "creates or resumes" a worktree.

### `plugins/looper/tests/test-worktree-enforcement.sh`
- Rewritten to assert the new contract (no `setup-worktree`, default-branch guard, detached-HEAD guard) and verify the matching guards in `git-commit-loop`.

### `crates/looper-watch/src/worker.rs`
- Stale comment fix: `fix_bare_if_needed` is no longer triggered by `create-github-pr` cleanup; the bare-repo risk now comes from external worktree management (Claude Desktop / `looper-ee`). Logic unchanged.

### `README.md`
- Worktree path text updated to reflect that Claude Desktop owns worktree creation.

### `Cargo.lock`
- Sync with the 0.49.0 version bump (separate commit).

## Out of scope

- `looper-ee` still creates its own worktree because it clones external repos. Note: with Phase 6b removed, the external-repo worktree it creates is no longer cleaned up by `create-github-pr` — to be addressed separately if needed.
- `setup-worktree` and `cleanup-worktree` scripts are kept on disk; `looper-ee` and `initiate-worktree` still use them.

## Test plan

- [x] `bash plugins/looper/tests/test-worktree-enforcement.sh` — 10/10 PASS
- [x] `bash plugins/looper/tests/test-setup-worktree-remote-base.sh` — 11/11 PASS (script unchanged)
- [x] `cargo check -p looper-watch` — clean
- [ ] Verify `/looper` runs end-to-end inside a Claude Desktop worktree
- [ ] Verify `/looper` aborts cleanly when invoked on `main`/`alpha`/detached HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)