### PR TITLE
fix(looper): require run_in_background=true for parallel subagent fan-out

### DIFF
--- a/plugins/looper/agents/checker.md
+++ b/plugins/looper/agents/checker.md
@@ -24,8 +24,14 @@ stdout (foreground) or delivered inline in the completion notification
 `Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
 the Bash tool returns immediately; an automatic completion notification
 fires on subprocess exit and its output contains the subagent's response
-text inline. For parallel fan-out, redirect each subagent's stdout to a
-temp file and `&`/`wait` — no polling, the response arrives directly.
+text inline. For parallel fan-out, run the `&`/`wait` shell block via
+`Bash(run_in_background=true)` — each subagent's stdout goes to a temp
+file inside the block, end with `cat` to collect responses, and a single
+completion notification with the full output fires when the whole block
+exits. **Do NOT call the `&`/`wait` block in the foreground** — the Bash
+tool caps foreground commands at 10 min (default 2 min) while reviewer
+subagents routinely take 5–10+ min, so foreground `wait` is SIGKILLed
+before it returns.
 
 **Never improvise PDC work inline.** If `claude-spawn-agent` is not on
 `PATH` (verified by the parent skill's step-0 gate), ABORT and surface
@@ -151,6 +157,10 @@ trail and is strictly worse than not running at all.
    the plan summary, doer summary, changed files list, and acceptance criteria
    from step 2.
 
+   **This Bash call MUST use `run_in_background=true`** — the reviewers
+   individually take 3–8 min and `wait` will be SIGKILLed by the foreground
+   Bash timeout (max 10 min) before all five finish. A single completion
+   notification with the `cat` output fires when the whole block exits.
    ```bash
    TMPDIR="/tmp/looper-${TASK_NAME}"
    mkdir -p "$TMPDIR"

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -188,11 +188,13 @@ If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
    After subagents complete, review for consistency between groups.
 
    Invoke the block via `Bash(run_in_background=true)` — implementation
-   subagents routinely exceed the foreground Bash 10-min cap.
+   subagents routinely exceed the foreground Bash 10-min cap. End with
+   `cat` so the completion notification carries each subagent's response.
    ```bash
    claude-spawn-agent "general-purpose" "<prompt for area 1>" > /tmp/impl1.txt &
    claude-spawn-agent "general-purpose" "<prompt for area 2>" > /tmp/impl2.txt &
    wait
+   cat /tmp/impl1.txt /tmp/impl2.txt
    ```
 
 8. **Run checks (two rounds):**

--- a/plugins/looper/agents/doer.md
+++ b/plugins/looper/agents/doer.md
@@ -42,8 +42,14 @@ trail and is strictly worse than not running at all.
    `Bash(command="claude-spawn-agent X Y", run_in_background=true)` — the
    Bash tool returns immediately; the completion notification fires on
    subprocess exit and its output contains the response text inline. For
-   parallel fan-out, redirect each subagent's stdout to a temp file and
-   `&`/`wait` — no polling, the response arrives directly.
+   parallel fan-out, run the `&`/`wait` shell block via
+   `Bash(run_in_background=true)` — each subagent's stdout goes to a temp
+   file inside the block, end with `cat` to collect responses, and a single
+   completion notification with the full output fires when the whole block
+   exits. **Do NOT call the `&`/`wait` block in the foreground** — the Bash
+   tool caps foreground commands at 10 min (default 2 min) while subagents
+   routinely take 5–10+ min, so foreground `wait` is SIGKILLed before it
+   returns.
 
    **Delta-mode pointer resolution.** On iter > 1 the Planner may emit
    sections or list items as `(unchanged from iteration N-1 — see <hash>)`.
@@ -82,6 +88,8 @@ trail and is strictly worse than not running at all.
    Skip this step if the plan only touches 1-2 small files (direct Read is
    faster than subagent overhead).
 
+   Invoke the block via `Bash(run_in_background=true)` — the completion
+   notification carries the `cat` output.
    ```bash
    claude-spawn-agent "Explore" "<prompt for source files>" > /tmp/explore-src.txt &
    claude-spawn-agent "Explore" "<prompt for test files>" > /tmp/explore-tests.txt &
@@ -179,6 +187,8 @@ If it exists, skip Phase 1 entirely and proceed to Phase 2 (GREEN).
    - Instructions to write/edit only source files in their group
    After subagents complete, review for consistency between groups.
 
+   Invoke the block via `Bash(run_in_background=true)` — implementation
+   subagents routinely exceed the foreground Bash 10-min cap.
    ```bash
    claude-spawn-agent "general-purpose" "<prompt for area 1>" > /tmp/impl1.txt &
    claude-spawn-agent "general-purpose" "<prompt for area 2>" > /tmp/impl2.txt &

--- a/plugins/looper/agents/planner.md
+++ b/plugins/looper/agents/planner.md
@@ -25,8 +25,14 @@ stdout (foreground) or delivered inline in the completion notification
 `Bash(command="claude-spawn-agent X Y", run_in_background=true)` —
 the Bash tool returns immediately; an automatic completion notification
 fires on subprocess exit and its output contains the subagent's response
-text inline. For parallel fan-out, redirect each subagent's stdout to a
-temp file and `&`/`wait` — no polling, the response arrives directly.
+text inline. For parallel fan-out, run the `&`/`wait` shell block via
+`Bash(run_in_background=true)` — each subagent's stdout goes to a temp
+file inside the block, end with `cat` to collect responses, and a single
+completion notification with the full output fires when the whole block
+exits. **Do NOT call the `&`/`wait` block in the foreground** — the Bash
+tool caps foreground commands at 10 min (default 2 min) while reviewer
+subagents routinely take 5–10+ min, so foreground `wait` is SIGKILLed
+before it returns.
 
 **Never improvise PDC work inline.** If `claude-spawn-agent` is not on
 `PATH` (verified by the parent skill's step-0 gate), ABORT and surface
@@ -231,7 +237,11 @@ trail and is strictly worse than not running at all.
    the draft plan text and the task context. They are read-only reporters — they
    do NOT modify anything.
 
-   Run all three in parallel:
+   Run all three in parallel. **This Bash call MUST use `run_in_background=true`**
+   — the reviewers individually take 3–8 min and `wait` will be SIGKILLed by
+   the foreground Bash timeout (max 10 min) before they all finish. A single
+   completion notification with the `cat` output fires when the whole block
+   exits.
    ```bash
    TMPDIR="/tmp/looper-${TASK_NAME}"
    mkdir -p "$TMPDIR"

--- a/plugins/looper/skills/subagents/SKILL.md
+++ b/plugins/looper/skills/subagents/SKILL.md
@@ -101,7 +101,13 @@ echo "$RESPONSE"
 ### Parallel fan-out
 
 For parallel fan-out, redirect each subagent's stdout to a temp file, run
-them in the background, then `wait`:
+them in the background, then `wait` — and invoke the whole block through
+`Bash(run_in_background=true)`. The Bash tool returns immediately and a
+single completion notification fires with the `cat` output when the block
+exits. **Do NOT call the block in the foreground** — the Bash tool caps
+foreground commands at 10 min (default 2 min) while parallel subagents
+often need 5–10+ min, so foreground `wait` is SIGKILLed before all of
+them finish.
 
 ```bash
 claude-spawn-agent "looper:planner" "Plan rate limiting" > /tmp/p1.txt &

--- a/plugins/looper/skills/subagents/scripts/spawn-agent
+++ b/plugins/looper/skills/subagents/scripts/spawn-agent
@@ -37,8 +37,9 @@ case "$AGENT" in
 esac
 
 OUTFILE="$(mktemp -t subagent-result-XXXXXX.json)"
-# Ensure the temp JSON is always cleaned up, even on error.
-trap 'rm -f "$OUTFILE"' EXIT
+ERRFILE="$(mktemp -t subagent-err-XXXXXX.log)"
+# Ensure both temp files are cleaned up, even on error.
+trap 'rm -f "$OUTFILE" "$ERRFILE"' EXIT
 
 rc=0
 env -u CLAUDECODE -u CLAUDE_CODE claude -p \
@@ -47,15 +48,21 @@ env -u CLAUDECODE -u CLAUDE_CODE claude -p \
   --dangerously-skip-permissions \
   "$PROMPT" \
   "$@" \
-  >"$OUTFILE" 2>/dev/null || rc=$?
+  >"$OUTFILE" 2>"$ERRFILE" || rc=$?
 
 if [ -s "$OUTFILE" ]; then
   # Print .result directly to stdout. If .result is missing/empty, emit the
   # raw JSON so the caller has something to inspect.
   jq -r '.result // empty' "$OUTFILE" 2>/dev/null || cat "$OUTFILE"
 else
-  # claude exited without writing JSON — surface that instead of empty output.
+  # claude exited without writing JSON — surface exit code and stderr so the
+  # caller can diagnose the failure instead of seeing empty output.
   echo "claude-spawn-agent error: claude exited with code $rc (no output)" >&2
+  if [ -s "$ERRFILE" ]; then
+    echo "--- claude stderr ---" >&2
+    cat "$ERRFILE" >&2
+    echo "--- end stderr ---" >&2
+  fi
 fi
 
 exit $rc

--- a/tests/test-agent-definitions.sh
+++ b/tests/test-agent-definitions.sh
@@ -274,30 +274,40 @@ fi
 # Foreground `wait` for parallel claude-spawn-agent calls is SIGKILLed by the
 # Bash tool's 10-min timeout (default 2 min). Reviewer subagents routinely
 # take 5–10+ min, so the parallel-fanout pattern MUST be invoked with
-# run_in_background=true. Regression test for that guidance.
-echo "=== Test 16: parallel fan-out docs mention run_in_background=true ==="
+# run_in_background=true.
+#
+# Lexical regression: the docs must (a) include a fan-out-specific call-out
+# requiring run_in_background=true (NOT just the single-spawn preamble
+# example, which mentions it for a different reason), and (b) NOT preserve
+# the old "no polling, the response arrives directly" framing that described
+# the broken foreground pattern.
+echo "=== Test 16: parallel fan-out docs require run_in_background=true at the block ==="
 SUBAGENTS_SKILL_MD="$REPO_ROOT/plugins/looper/skills/subagents/SKILL.md"
 for doc in "$PLANNER_MD" "$CHECKER_MD" "$DOER_MD" "$SUBAGENTS_SKILL_MD"; do
     basename_doc="$(basename "$doc")"
-    assert_file_contains "$basename_doc parallel-fanout docs reference run_in_background=true" \
-        "$doc" "run_in_background=true"
+    # Fan-out call-out must explicitly reference Bash(run_in_background=true).
+    assert_file_contains "$basename_doc fan-out call-out references Bash(run_in_background=true)" \
+        "$doc" 'Bash(run_in_background=true)'
+    # The old "no polling, the response arrives directly" framing must be gone.
+    assert_file_not_contains "$basename_doc no longer claims 'no polling, the response arrives directly'" \
+        "$doc" "no polling, the response arrives directly"
 done
 
 # --- Test 17: spawn-agent captures stderr instead of suppressing it ---
 # Suppressing claude's stderr with `2>/dev/null` hides why a child session
 # failed, making parallel fan-out failures impossible to diagnose. spawn-agent
 # must capture claude's stderr to a file and surface it when JSON output is
-# missing.
+# missing. Behavioral coverage lives in test-spawn-agent-canonical.sh Case 10;
+# this is the lexical/structural pin.
 echo "=== Test 17: spawn-agent captures stderr for diagnostics ==="
 SPAWN_AGENT="$REPO_ROOT/plugins/looper/skills/subagents/scripts/spawn-agent"
-if [ -f "$SPAWN_AGENT" ]; then
-    assert_file_contains "spawn-agent captures claude stderr to ERRFILE" \
-        "$SPAWN_AGENT" 'ERRFILE'
-    assert_file_contains "spawn-agent redirects claude stderr to ERRFILE" \
-        "$SPAWN_AGENT" '2>"\$ERRFILE"'
-    assert_file_contains "spawn-agent surfaces stderr on missing JSON output" \
-        "$SPAWN_AGENT" 'claude stderr'
-fi
+assert_file_exists "spawn-agent script exists" "$SPAWN_AGENT"
+assert_file_contains "spawn-agent captures claude stderr to ERRFILE" \
+    "$SPAWN_AGENT" 'ERRFILE'
+assert_file_contains "spawn-agent redirects claude stderr to ERRFILE" \
+    "$SPAWN_AGENT" '2>"\$ERRFILE"'
+assert_file_contains "spawn-agent surfaces stderr on missing JSON output" \
+    "$SPAWN_AGENT" 'claude stderr'
 
 # --- Summary ---
 echo ""

--- a/tests/test-agent-definitions.sh
+++ b/tests/test-agent-definitions.sh
@@ -205,10 +205,14 @@ assert_file_contains "planner.md uses TASK_NAME-namespaced tmpdir" \
 
 # --- Test 10: Line count reduction ---
 echo "=== Test 10: checker.md and planner.md are significantly shorter ==="
-assert_line_count_lt "checker.md is under 350 lines (was 482)" "$CHECKER_MD" 350
+# Bumped from 350 → 365 to accommodate the parallel-fanout run_in_background
+# warning added after foreground `wait` was found to be SIGKILLed by the Bash
+# 10-min timeout when reviewer subagents run 5–10+ min.
+assert_line_count_lt "checker.md is under 365 lines (was 482)" "$CHECKER_MD" 365
 # Use <= here: GitHub's squash-merge may add a trailing newline, bumping wc -l
-# by 1 post-merge (see #97). Keep the 360 ceiling but allow the boundary value.
-assert_line_count_le "planner.md is at or under 360 lines (was 311, +52 for on-demand gh rules + issue context sub-sections)" "$PLANNER_MD" 360
+# by 1 post-merge (see #97). Bumped 360 → 400 to accommodate the parallel-fanout
+# run_in_background warning (see above).
+assert_line_count_le "planner.md is at or under 400 lines (was 311, +89 for on-demand gh rules + issue context sub-sections + run_in_background warning)" "$PLANNER_MD" 400
 
 # --- Test 11: simplifier.md agent exists with valid frontmatter ---
 echo "=== Test 11: simplifier.md exists with valid frontmatter ==="
@@ -264,6 +268,35 @@ if [ -f "$DOER_MD" ]; then
         "$DOER_MD" 'last-error-\${ITERATION}'
     assert_file_not_contains "doer.md no longer uses 'after 2 fix attempts' language" \
         "$DOER_MD" "after 2 fix attempts"
+fi
+
+# --- Test 16: parallel fan-out instructions require run_in_background=true ---
+# Foreground `wait` for parallel claude-spawn-agent calls is SIGKILLed by the
+# Bash tool's 10-min timeout (default 2 min). Reviewer subagents routinely
+# take 5–10+ min, so the parallel-fanout pattern MUST be invoked with
+# run_in_background=true. Regression test for that guidance.
+echo "=== Test 16: parallel fan-out docs mention run_in_background=true ==="
+SUBAGENTS_SKILL_MD="$REPO_ROOT/plugins/looper/skills/subagents/SKILL.md"
+for doc in "$PLANNER_MD" "$CHECKER_MD" "$DOER_MD" "$SUBAGENTS_SKILL_MD"; do
+    basename_doc="$(basename "$doc")"
+    assert_file_contains "$basename_doc parallel-fanout docs reference run_in_background=true" \
+        "$doc" "run_in_background=true"
+done
+
+# --- Test 17: spawn-agent captures stderr instead of suppressing it ---
+# Suppressing claude's stderr with `2>/dev/null` hides why a child session
+# failed, making parallel fan-out failures impossible to diagnose. spawn-agent
+# must capture claude's stderr to a file and surface it when JSON output is
+# missing.
+echo "=== Test 17: spawn-agent captures stderr for diagnostics ==="
+SPAWN_AGENT="$REPO_ROOT/plugins/looper/skills/subagents/scripts/spawn-agent"
+if [ -f "$SPAWN_AGENT" ]; then
+    assert_file_contains "spawn-agent captures claude stderr to ERRFILE" \
+        "$SPAWN_AGENT" 'ERRFILE'
+    assert_file_contains "spawn-agent redirects claude stderr to ERRFILE" \
+        "$SPAWN_AGENT" '2>"\$ERRFILE"'
+    assert_file_contains "spawn-agent surfaces stderr on missing JSON output" \
+        "$SPAWN_AGENT" 'claude stderr'
 fi
 
 # --- Summary ---

--- a/tests/test-spawn-agent-canonical.sh
+++ b/tests/test-spawn-agent-canonical.sh
@@ -197,6 +197,61 @@ chmod +x "$SHIMDIR/claude"
 extra_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "do stuff" --max-turns 3 2>/dev/null || true)
 assert_contains "extra flags: --max-turns appears in forwarded argv" "$extra_stdout" "--max-turns"
 
+# ── Case 10: stderr from a failing child is captured and surfaced ───────────────
+#
+# Previously `claude -p` stderr was redirected to /dev/null, so silent child
+# failures inside a parallel fan-out (auth error, agent typo, rate limit) had
+# no diagnostic trail. spawn-agent must now capture child stderr and print it
+# on the wrapper's stderr when no JSON output came back.
+
+echo ""
+echo "=== Case 10: child stderr surfaces when claude exits without JSON ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+# Shim: writes a diagnostic to stderr, no stdout, exits non-zero
+echo "API key invalid" >&2
+exit 1
+EOF
+chmod +x "$SHIMDIR/claude"
+
+stderr_c10=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "fail" 2>&1 >/dev/null || true)
+
+assert_contains "stderr capture: child diagnostic appears on wrapper stderr" \
+    "$stderr_c10" "API key invalid"
+assert_contains "stderr capture: includes '--- claude stderr ---' header" \
+    "$stderr_c10" "--- claude stderr ---"
+assert_contains "stderr capture: includes 'end stderr' footer" \
+    "$stderr_c10" "end stderr"
+assert_contains "stderr capture: includes 'no output' marker" \
+    "$stderr_c10" "no output"
+
+# ── Case 11: child stderr on successful run is NOT surfaced (no false alarms) ──
+#
+# claude may write progress/warning noise to stderr while still producing valid
+# JSON on stdout. spawn-agent must only surface child stderr when OUTFILE is
+# empty — successful runs stay quiet.
+
+echo ""
+echo "=== Case 11: child stderr is silent when claude exits with valid JSON ==="
+make_shimdir
+cat > "$SHIMDIR/claude" << 'EOF'
+#!/usr/bin/env bash
+echo "noisy progress line on stderr" >&2
+printf '{"result":"hello","is_error":false}'
+exit 0
+EOF
+chmod +x "$SHIMDIR/claude"
+
+c11_stderr=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "ok" 2>&1 >/dev/null || true)
+c11_stdout=$(PATH="$SHIMDIR:$PATH" bash "$SPAWN_AGENT" "Explore" "ok" 2>/dev/null || true)
+
+assert_contains "successful run: stdout has the .result text" "$c11_stdout" "hello"
+assert_not_contains "successful run: stderr does NOT contain child's noise" \
+    "$c11_stderr" "noisy progress line on stderr"
+assert_not_contains "successful run: stderr does NOT contain stderr-capture header" \
+    "$c11_stderr" "--- claude stderr ---"
+
 # ────────────────────────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Problem

The Planner step **"Run 3 plan reviewers in parallel"** (and the Checker's 5-way analogue, and the Doer's parallel Explore/implementation blocks) reliably fails. The shared shape is:

```bash
TMPDIR="/tmp/looper-${TASK_NAME}"
mkdir -p "$TMPDIR"
claude-spawn-agent "looper:plan-feasibility"  "<context>" > "$TMPDIR/plan-feasibility.txt"  &
claude-spawn-agent "looper:plan-completeness" "<context>" > "$TMPDIR/plan-completeness.txt" &
claude-spawn-agent "looper:plan-scope"        "<context>" > "$TMPDIR/plan-scope.txt"        &
wait
cat "$TMPDIR"/plan-*.txt
```

This entire block is one foreground `Bash(...)` call. The Bash tool's foreground timeout caps at **10 min (default 2 min)**. Sonnet-backed reviewer subagents that read a ~50 KB plan and grep the codebase routinely take **5–10+ min each**, and `wait` blocks for the slowest one — so the foreground call is SIGKILLed before `wait` returns.

Concrete evidence from a recent loop run (`/tmp/looper-issue-7014-crm-admin-scaffold/`):

| File | Mtime delta after draft-plan.md |
|---|---|
| draft-plan.md | 0 |
| plan-completeness.txt | +3 min |
| plan-scope.txt | +6 min |
| plan-feasibility.txt | +8 min |

The detached background subprocesses survive the parent kill and the txt files eventually land — which is why the artifacts look correct on disk while the parent agent has reported failure.

Aggravating factor: `spawn-agent` redirects `claude -p` stderr to `/dev/null`, so when a child does genuinely fail (auth issue, rate limit, agent name typo) the caller sees only `claude exited with code N (no output)` with zero context.

## Fix

- Update `planner.md`, `checker.md`, `doer.md`, and `skills/subagents/SKILL.md` so the parallel `&`/`wait` shell block is invoked through `Bash(run_in_background=true)`. The Bash tool returns immediately, the shell runs to completion with no foreground cap, and a single completion notification with the full `cat` output fires when all subagents exit. Foreground single-spawn pattern is unchanged.
- Capture `claude -p` stderr to a temp file in `spawn-agent` (`2>"$ERRFILE"`) and surface it on missing JSON output, so silent child failures inside a fan-out are diagnosable.
- Add regression tests (Test 16, Test 17) in `test-agent-definitions.sh` pinning the `run_in_background=true` guidance in all four docs and the stderr capture in `spawn-agent`.
- Bump the planner.md / checker.md line-count caps to accommodate the new warning text. Also unblocks a pre-existing failure of the 360-line cap that landed unfixed with delta-mode planning.

## Test plan

- [x] `bash tests/test-agent-definitions.sh` → 118 passed, 0 failed (was 110/1 failed before).
- [x] `bash tests/test-spawn-agent-canonical.sh` → 15 passed, 0 failed (stderr-message regression on Case 2 caught and resolved during the change).
- [x] `bash tests/test-agent-spawn-migration.sh` → 42 passed, 0 failed.
- [x] Full suite (22 test files, 663 assertions) → all green.
- [x] `shellcheck plugins/looper/skills/subagents/scripts/spawn-agent` → clean.
- [ ] End-to-end loop run that exercises the planner's 3-way fan-out — needs to land on a real task once merged (manual verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)