### PR TITLE
feat(looper): push loop branch up-front and after every iteration

### DIFF
--- a/plugins/looper/skills/create-github-pr/SKILL.md
+++ b/plugins/looper/skills/create-github-pr/SKILL.md
@@ -259,10 +259,16 @@ Commit message `<type>` should be one of: `feat`, `fix`, `refactor`, `test`, `do
 ### 3b. Push
 
 ```bash
-git push -u origin $CURRENT_BRANCH
+# Use --force-with-lease because looper pushes the branch up-front (in
+# setup-worktree) and after every iteration; a final sync-with-remote rebase
+# would otherwise make a plain push non-fast-forward. --force-with-lease still
+# refuses to clobber unexpected remote work.
+git push --force-with-lease -u origin $CURRENT_BRANCH
 ```
 
-If the push is rejected (e.g., diverged history), inform the user and ask how to proceed. Do NOT force push.
+If the push is rejected because the remote was updated by someone else (lease
+check failed), inform the user and ask how to proceed. Do NOT use plain
+`--force`.
 
 ---
 

--- a/plugins/looper/skills/looper/SKILL.md
+++ b/plugins/looper/skills/looper/SKILL.md
@@ -266,6 +266,22 @@ VERDICT=$(git log --grep="Loop-Verdict:" -1 --format="%B" \
 - **PASS:** Break out of the loop, proceed to step 7.
 - **FAIL** (or no verdict): Report and continue to next iteration.
 
+#### 6e2. Push iteration progress to remote
+
+After every iteration (PASS or FAIL), push the loop branch so the latest
+plan/do/check commits are visible from other machines. Use `--force-with-lease`
+because a later `sync-with-remote` may rebase the branch — fast-forward-only
+pushes would then be rejected.
+
+```bash
+if git remote get-url origin >/dev/null 2>&1; then
+    git push --force-with-lease origin HEAD 2>&1 || \
+        echo "[looper] Warning: failed to push iteration $ITERATION to origin (continuing)" >&2
+fi
+```
+
+This is best-effort: a push failure does not abort the loop.
+
 ### 6f. Sync with remote before PR
 
 After the loop completes with PASS, sync one more time to ensure the PR will have

--- a/plugins/looper/skills/looper/scripts/setup-worktree
+++ b/plugins/looper/skills/looper/scripts/setup-worktree
@@ -100,5 +100,19 @@ if [ -n "$(git -C "$WORKTREE_DIR" status --porcelain 2>/dev/null)" ]; then
     echo "[setup-worktree] Warning: worktree has uncommitted changes" >&2
 fi
 
+# Push the loop branch to origin so it's visible from other machines and serves
+# as the upstream for incremental progress pushes during the loop. Only attempt
+# when an origin remote is configured; a push failure (auth, network, etc.) is
+# logged as a warning — the loop can still proceed locally.
+if git -C "$WORKTREE_DIR" remote get-url origin >/dev/null 2>&1; then
+    PUSH_OUTPUT=$(git -C "$WORKTREE_DIR" push -u origin "$BRANCH" 2>&1) && PUSH_OK=true || PUSH_OK=false
+    if [ "$PUSH_OK" = "true" ]; then
+        echo "[setup-worktree] Pushed branch $BRANCH to origin (visible from other machines)" >&2
+    else
+        echo "[setup-worktree] Warning: failed to push $BRANCH to origin — continuing locally:" >&2
+        echo "$PUSH_OUTPUT" >&2
+    fi
+fi
+
 # Output the path for the caller to cd into
 echo "$WORKTREE_DIR"

--- a/plugins/looper/tests/test-setup-worktree-remote-base.sh
+++ b/plugins/looper/tests/test-setup-worktree-remote-base.sh
@@ -96,10 +96,29 @@ if [ -d "$WORKTREE_DIR" ]; then
     # Unpushed file must not exist in worktree
     check "UNPUSHED.md does not exist in worktree" \
         "$([ ! -f "$WORKTREE_DIR/UNPUSHED.md" ] && echo true || echo false)"
+
+    # New behavior: the loop branch must be pushed to origin so it's visible
+    # from other machines. Querying the bare origin directly avoids any local
+    # cache of remote refs.
+    ORIGIN_HAS_BRANCH=$(git --git-dir="$ORIGIN_DIR" show-ref --quiet "refs/heads/loop/test-task" && echo true || echo false)
+    check "loop/test-task branch was pushed to origin" "$ORIGIN_HAS_BRANCH"
+
+    if [ "$ORIGIN_HAS_BRANCH" = "true" ]; then
+        ORIGIN_BRANCH_SHA=$(git --git-dir="$ORIGIN_DIR" rev-parse "refs/heads/loop/test-task")
+        check "origin loop/test-task points at pushed default-branch SHA" \
+            "$([ "$ORIGIN_BRANCH_SHA" = "$PUSHED_SHA" ] && echo true || echo false)"
+    fi
+
+    # Upstream tracking should be configured so subsequent pushes don't need -u.
+    UPSTREAM=$(git -C "$WORKTREE_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+    check "worktree branch tracks origin/loop/test-task" \
+        "$([ "$UPSTREAM" = "origin/loop/test-task" ] && echo true || echo false)"
 else
     check "worktree HEAD equals pushed (remote) SHA" "false"
     check "worktree HEAD does not equal local (unpushed) HEAD SHA" "false"
     check "UNPUSHED.md does not exist in worktree" "false"
+    check "loop/test-task branch was pushed to origin" "false"
+    check "worktree branch tracks origin/loop/test-task" "false"
 fi
 
 # --- C) Sync scenario: works when local and remote are in sync ---


### PR DESCRIPTION
## Summary

- `setup-worktree` now pushes the freshly created `loop/<task>` branch to `origin` with `-u`, so it's visible from other machines immediately after the worktree is created.
- New step **6e2** in `looper/SKILL.md` pushes `HEAD` to origin with `--force-with-lease` after every iteration (PASS or FAIL), keeping remote progress continuously up to date.
- `create-github-pr` switches its final push to `--force-with-lease`, since the branch is already on remote and the pre-PR `sync-with-remote` rebase would otherwise make a plain push non-fast-forward.
- All remote operations degrade gracefully: missing `origin` is skipped, push failures warn but don't abort the loop.

## Motivation

Loop branches were only pushed at PR-creation time, which meant the user couldn't observe a long-running loop from another machine. Now the branch exists on the remote from iteration 0 and tracks the iteration commits.

## Test plan

- [x] `plugins/looper/tests/test-setup-worktree-remote-base.sh` — extended with 4 new assertions covering: branch lands on `origin`, SHA matches the pushed default-branch SHA, upstream tracking is configured, and failure paths. **14/14 pass.**
- [x] Full looper test suite still green except for one pre-existing failure in `test-integration-ci.sh` unrelated to this change (verified by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)